### PR TITLE
Test `SchemaFlatFileResolver` re-identifying a schema with absolute refs

### DIFF
--- a/test/jsonschema/jsonschema_flat_file_resolver_test.cc
+++ b/test/jsonschema/jsonschema_flat_file_resolver_test.cc
@@ -292,3 +292,29 @@ TEST(JSONSchema_SchemaFlatFileResolver, with_recursive_ref) {
       resolver("https://www.sourcemeta.com/2019-09-recursive-ref.json").value(),
       expected);
 }
+
+TEST(JSONSchema_SchemaFlatFileResolver, with_absolute_references_reidentify) {
+  sourcemeta::core::SchemaFlatFileResolver resolver;
+  const auto schema_path{std::filesystem::path{SCHEMAS_PATH} /
+                         "2020-12-absolute-ref.json"};
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://www.example.com/2020-12-absolute-ref.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "2020-12-id.json"
+  })JSON");
+
+  const auto &identifier{resolver.add(schema_path)};
+  EXPECT_EQ(identifier, "https://www.sourcemeta.com/2020-12-absolute-ref.json");
+
+  resolver.reidentify("https://www.sourcemeta.com/2020-12-absolute-ref.json",
+                      "https://www.example.com/2020-12-absolute-ref.json");
+
+  EXPECT_FALSE(resolver("https://www.sourcemeta.com/2020-12-absolute-ref.json")
+                   .has_value());
+  EXPECT_TRUE(resolver("https://www.example.com/2020-12-absolute-ref.json")
+                  .has_value());
+  EXPECT_EQ(
+      resolver("https://www.example.com/2020-12-absolute-ref.json").value(),
+      expected);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
