### PR TITLE
As a fallback, recognise `id` after Draft 4 in "loose" mode

### DIFF
--- a/src/core/jsonschema/jsonschema.cc
+++ b/src/core/jsonschema/jsonschema.cc
@@ -105,6 +105,13 @@ auto sourcemeta::core::identify(
     const auto keyword{id_keyword(maybe_base_dialect.value())};
     if (schema.defines(keyword) && schema.at(keyword).is_string()) {
       return schema.at(keyword).to_string();
+    } else {
+      const auto fallback{id_keyword_guess(schema)};
+      if (fallback.has_value()) {
+        return schema.at(fallback.value()).to_string();
+      } else {
+        return std::nullopt;
+      }
     }
   }
 

--- a/test/jsonschema/jsonschema_identify_test.cc
+++ b/test/jsonschema/jsonschema_identify_test.cc
@@ -252,6 +252,18 @@ TEST(JSONSchema_identify, loose_with_unresolvable_dialect) {
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
 
+TEST(JSONSchema_identify, loose_draft6_id) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "id": "https://example.com/my-schema"
+  })JSON");
+  std::optional<std::string> id{sourcemeta::core::identify(
+      document, sourcemeta::core::schema_official_resolver,
+      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
 TEST(JSONSchema_identify, anonymize_with_unknown_base_dialect) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com/my-schema",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
