### PR TITLE
Allow `SchemaFlatFileResolver` to take a custom reference visitor

### DIFF
--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_resolver.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_resolver.h
@@ -108,7 +108,8 @@ public:
   auto add(const std::filesystem::path &path,
            const std::optional<std::string> &default_dialect = std::nullopt,
            const std::optional<std::string> &default_id = std::nullopt,
-           const Reader &reader = sourcemeta::core::read_json)
+           const Reader &reader = read_json,
+           SchemaVisitorReference &&reference_visitor = nullptr)
       -> const std::string &;
 
   // Change the identifier of a registered schema
@@ -130,6 +131,7 @@ public:
     std::optional<std::string> default_dialect;
     std::string original_identifier;
     Reader reader;
+    SchemaVisitorReference reference_visitor;
   };
 
 private:

--- a/src/core/jsonschema/resolver.cc
+++ b/src/core/jsonschema/resolver.cc
@@ -92,8 +92,8 @@ static auto to_lowercase(const std::string_view input) -> std::string {
 auto SchemaFlatFileResolver::add(
     const std::filesystem::path &path,
     const std::optional<std::string> &default_dialect,
-    const std::optional<std::string> &default_id, const Reader &reader)
-    -> const std::string & {
+    const std::optional<std::string> &default_id, const Reader &reader,
+    SchemaVisitorReference &&reference_visitor) -> const std::string & {
   const auto canonical{std::filesystem::weakly_canonical(path)};
   const auto schema{reader(canonical)};
   assert(sourcemeta::core::is_schema(schema));
@@ -114,7 +114,9 @@ auto SchemaFlatFileResolver::add(
 
   const auto result{this->schemas.emplace(
       effective_identifier,
-      Entry{canonical, default_dialect, effective_identifier, reader})};
+      Entry{canonical, default_dialect, effective_identifier, reader,
+            reference_visitor ? std::move(reference_visitor)
+                              : reference_visitor_relativize})};
   if (!result.second && result.first->second.path != canonical) {
     std::ostringstream error;
     error << "Cannot register the same identifier twice: "
@@ -152,8 +154,7 @@ auto SchemaFlatFileResolver::operator()(std::string_view identifier) const
     // Because we allow re-identification, we can get into issues unless we
     // always try to relativize references
     sourcemeta::core::reference_visit(
-        schema, schema_official_walker, *this,
-        sourcemeta::core::reference_visitor_relativize,
+        schema, schema_official_walker, *this, result->second.reference_visitor,
         result->second.default_dialect, result->second.original_identifier);
     sourcemeta::core::reidentify(schema, result->first, *this,
                                  result->second.default_dialect);


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
