### PR TITLE
Make `PointerTemplate` distinguish between property/item/key wildcards

### DIFF
--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
@@ -5,6 +5,7 @@
 #include <sourcemeta/core/jsonpointer_token.h>
 
 #include <algorithm> // std::copy
+#include <cassert>   // assert
 #include <iterator>  // std::back_inserter
 #include <variant>   // std::variant
 #include <vector>    // std::vector
@@ -14,9 +15,8 @@ namespace sourcemeta::core {
 /// @ingroup jsonpointer
 template <typename PointerT> class GenericPointerTemplate {
 public:
-  struct Wildcard {
-    auto operator==(const Wildcard &) const noexcept -> bool = default;
-  };
+  /// The type of wildcard
+  enum class Wildcard { Property, Item, Key };
 
   using Token = typename PointerT::Token;
   using Container = std::vector<std::variant<Token, Wildcard>>;
@@ -95,9 +95,13 @@ public:
   /// #include <sourcemeta/core/jsonpointer.h>
   ///
   /// sourcemeta::core::PointerTemplate pointer;
-  /// pointer.emplace_back(sourcemeta::core::PointerTemplate::Wildcard{});
+  /// pointer.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Property);
   /// ```
   template <class... Args> auto emplace_back(Args &&...args) -> reference {
+    // It is a logical error to push a token after a key wildcard
+    assert(this->data.empty() ||
+           !std::holds_alternative<Wildcard>(this->data.back()) ||
+           std::get<Wildcard>(this->data.back()) != Wildcard::Key);
     return this->data.emplace_back(args...);
   }
 
@@ -112,6 +116,10 @@ public:
   /// result.push_back(pointer);
   /// ```
   auto push_back(const PointerT &other) -> void {
+    // It is a logical error to push a token after a key wildcard
+    assert(this->data.empty() ||
+           !std::holds_alternative<Wildcard>(this->data.back()) ||
+           std::get<Wildcard>(this->data.back()) != Wildcard::Key);
     this->data.reserve(this->data.size() + other.size());
     std::copy(other.cbegin(), other.cend(), std::back_inserter(this->data));
   }

--- a/src/core/jsonpointer/stringify.h
+++ b/src/core/jsonpointer/stringify.h
@@ -441,8 +441,26 @@ auto stringify(const PointerT &pointer,
   if constexpr (requires { typename PointerT::Wildcard; }) {
     for (const auto &token : pointer) {
       if (std::holds_alternative<typename PointerT::Wildcard>(token)) {
+        // TODO: Do it differently for different types of wildcards
         // Represent wildcards using an impossible JSON Pointer token
         stream.put(internal::token_pointer_slash<CharT>);
+        stream.put(internal::token_pointer_tilde<CharT>);
+
+        switch (std::get<typename PointerT::Wildcard>(token)) {
+          case PointerT::Wildcard::Property:
+            stream.put('P');
+            break;
+          case PointerT::Wildcard::Item:
+            stream.put('I');
+            break;
+          case PointerT::Wildcard::Key:
+            stream.put('K');
+            break;
+          default:
+            assert(false);
+            break;
+        }
+
         stream.put(internal::token_pointer_tilde<CharT>);
       } else {
         stringify_token<CharT, Traits, Allocator, typename PointerT::Token>(

--- a/test/jsonpointer/jsonpointer_template_test.cc
+++ b/test/jsonpointer/jsonpointer_template_test.cc
@@ -19,47 +19,129 @@ TEST(JSONPointer_template, equality_without_wildcard_false) {
   EXPECT_NE(left, right);
 }
 
-TEST(JSONPointer_template, equality_with_wildcard_true) {
+TEST(JSONPointer_template, equality_with_property_wildcard_true) {
   const sourcemeta::core::Pointer prefix{"foo", "bar"};
   const sourcemeta::core::Pointer suffix{"baz"};
 
   sourcemeta::core::PointerTemplate left{prefix};
-  left.emplace_back(sourcemeta::core::PointerTemplate::Wildcard{});
+  left.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Property);
   left.push_back(suffix);
 
   sourcemeta::core::PointerTemplate right{prefix};
-  right.emplace_back(sourcemeta::core::PointerTemplate::Wildcard{});
+  right.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Property);
   right.push_back(suffix);
 
   EXPECT_EQ(left, right);
 }
 
-TEST(JSONPointer_template, equality_with_wildcard_false) {
+TEST(JSONPointer_template, equality_with_property_wildcard_false) {
   const sourcemeta::core::Pointer prefix{"foo", "bar"};
   const sourcemeta::core::Pointer suffix{"baz"};
 
   sourcemeta::core::PointerTemplate left{prefix};
-  left.emplace_back(sourcemeta::core::PointerTemplate::Wildcard{});
+  left.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Property);
   left.push_back(suffix);
 
   sourcemeta::core::PointerTemplate right{prefix};
   right.push_back(suffix);
-  right.emplace_back(sourcemeta::core::PointerTemplate::Wildcard{});
+  right.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Property);
 
   EXPECT_NE(left, right);
 }
 
-TEST(JSONPointer_template, stringify_multiple_wildcards) {
+TEST(JSONPointer_template, equality_with_item_wildcard_true) {
+  const sourcemeta::core::Pointer prefix{"foo", "bar"};
+  const sourcemeta::core::Pointer suffix{"baz"};
+
+  sourcemeta::core::PointerTemplate left{prefix};
+  left.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Item);
+  left.push_back(suffix);
+
+  sourcemeta::core::PointerTemplate right{prefix};
+  right.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Item);
+  right.push_back(suffix);
+
+  EXPECT_EQ(left, right);
+}
+
+TEST(JSONPointer_template, equality_with_item_wildcard_false) {
+  const sourcemeta::core::Pointer prefix{"foo", "bar"};
+  const sourcemeta::core::Pointer suffix{"baz"};
+
+  sourcemeta::core::PointerTemplate left{prefix};
+  left.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Item);
+  left.push_back(suffix);
+
+  sourcemeta::core::PointerTemplate right{prefix};
+  right.push_back(suffix);
+  right.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Item);
+
+  EXPECT_NE(left, right);
+}
+
+TEST(JSONPointer_template, equality_with_key_wildcard_true) {
+  const sourcemeta::core::Pointer prefix{"foo", "bar"};
+
+  sourcemeta::core::PointerTemplate left{prefix};
+  left.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Key);
+
+  sourcemeta::core::PointerTemplate right{prefix};
+  right.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Key);
+
+  EXPECT_EQ(left, right);
+}
+
+TEST(JSONPointer_template, equality_with_key_wildcard_false) {
+  const sourcemeta::core::Pointer prefix_1{"foo"};
+  const sourcemeta::core::Pointer prefix_2{"bar"};
+
+  sourcemeta::core::PointerTemplate left{prefix_1};
+  left.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Key);
+
+  sourcemeta::core::PointerTemplate right{prefix_2};
+  right.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Key);
+
+  EXPECT_NE(left, right);
+}
+
+TEST(JSONPointer_template, stringify_multiple_property_wildcards) {
   const sourcemeta::core::Pointer prefix{"foo", "bar"};
   const sourcemeta::core::Pointer suffix{"baz"};
 
   sourcemeta::core::PointerTemplate pointer{prefix};
-  pointer.emplace_back(sourcemeta::core::PointerTemplate::Wildcard{});
+  pointer.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Property);
   pointer.push_back(suffix);
-  pointer.emplace_back(sourcemeta::core::PointerTemplate::Wildcard{});
+  pointer.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Property);
 
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
 
-  EXPECT_EQ(stream.str(), "/foo/bar/~/baz/~");
+  EXPECT_EQ(stream.str(), "/foo/bar/~P~/baz/~P~");
+}
+
+TEST(JSONPointer_template, stringify_multiple_item_wildcards) {
+  const sourcemeta::core::Pointer prefix{"foo", "bar"};
+  const sourcemeta::core::Pointer suffix{"baz"};
+
+  sourcemeta::core::PointerTemplate pointer{prefix};
+  pointer.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Item);
+  pointer.push_back(suffix);
+  pointer.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Item);
+
+  std::ostringstream stream;
+  sourcemeta::core::stringify(pointer, stream);
+
+  EXPECT_EQ(stream.str(), "/foo/bar/~I~/baz/~I~");
+}
+
+TEST(JSONPointer_template, stringify_key_wildcard) {
+  const sourcemeta::core::Pointer prefix{"foo", "bar"};
+
+  sourcemeta::core::PointerTemplate pointer{prefix};
+  pointer.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Key);
+
+  std::ostringstream stream;
+  sourcemeta::core::stringify(pointer, stream);
+
+  EXPECT_EQ(stream.str(), "/foo/bar/~K~");
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
