### PR TITLE
Rename `instance_location` to `relative_instance_location` in `SchemaIteratorEntry`

### DIFF
--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_types.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_types.h
@@ -196,7 +196,7 @@ struct SchemaIteratorEntry {
   // TODO: Do we really need a full copy of the JSON value if the client
   // can get it through the JSON Pointer if needed?
   JSON value;
-  PointerTemplate instance_location;
+  PointerTemplate relative_instance_location;
   bool orphan;
 };
 

--- a/test/jsonschema/jsonschema_test_utils.h
+++ b/test/jsonschema/jsonschema_test_utils.h
@@ -321,7 +321,7 @@
   EXPECT_EQ(entries.at(index).dialect.value(), expected_dialect);              \
   EXPECT_EQ(entries.at(index).base_dialect.value(), expected_base_dialect);    \
   EXPECT_FALSE(entries.at(index).vocabularies.empty());                        \
-  EXPECT_POINTER_TEMPLATE(entries.at(index).instance_location,                 \
+  EXPECT_POINTER_TEMPLATE(entries.at(index).relative_instance_location,        \
                           expected_instance_location);
 
 #define EXPECT_OFFICIAL_WALKER_ENTRY_2020_12(                                  \


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
