### PR TITLE
Avoid copying subschemas in `SchemaIteratorEntry`

### DIFF
--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_types.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_types.h
@@ -2,7 +2,7 @@
 #define SOURCEMETA_CORE_JSONSCHEMA_TYPES_H_
 
 #include <cstdint>     // std::uint8_t
-#include <functional>  // std::function
+#include <functional>  // std::function, std::reference_wrapper
 #include <map>         // std::map
 #include <optional>    // std::optional
 #include <set>         // std::set
@@ -193,9 +193,7 @@ struct SchemaIteratorEntry {
   std::optional<std::string> dialect;
   std::map<std::string, bool> vocabularies;
   std::optional<std::string> base_dialect;
-  // TODO: Do we really need a full copy of the JSON value if the client
-  // can get it through the JSON Pointer if needed?
-  JSON value;
+  std::reference_wrapper<const JSON> subschema;
   PointerTemplate relative_instance_location;
   bool orphan;
 };

--- a/src/core/jsonschema/walker.cc
+++ b/src/core/jsonschema/walker.cc
@@ -34,8 +34,10 @@ auto walk(const sourcemeta::core::Pointer &pointer,
       resolver, base_dialect.value(), new_dialect)};
 
   if (type == SchemaWalkerType_t::Deep || level > 0) {
-    subschemas.push_back({pointer, new_dialect, vocabularies, base_dialect,
-                          subschema, instance_location, orphan});
+    sourcemeta::core::SchemaIteratorEntry entry{
+        pointer,   new_dialect,       vocabularies, base_dialect,
+        subschema, instance_location, orphan};
+    subschemas.push_back(std::move(entry));
   }
 
   // We can't recurse any further
@@ -265,13 +267,10 @@ sourcemeta::core::SchemaIterator::SchemaIterator(
   // not pass a default, then there is nothing we can do. We know
   // the current schema is a subschema, but cannot walk any further.
   if (!dialect.has_value()) {
-    this->subschemas.push_back({pointer,
-                                std::nullopt,
-                                {},
-                                std::nullopt,
-                                schema,
-                                instance_location,
-                                false});
+    sourcemeta::core::SchemaIteratorEntry entry{
+        pointer, std::nullopt,      {},   std::nullopt,
+        schema,  instance_location, false};
+    this->subschemas.push_back(std::move(entry));
   } else {
     walk(pointer, instance_location, this->subschemas, schema, walker, resolver,
          dialect.value(), SchemaWalkerType_t::Deep, 0, false);
@@ -315,13 +314,10 @@ sourcemeta::core::SchemaKeywordIterator::SchemaKeywordIterator(
   }
 
   for (const auto &entry : schema.as_object()) {
-    this->entries.push_back({{entry.first},
-                             dialect,
-                             vocabularies,
-                             base_dialect,
-                             entry.second,
-                             {},
-                             false});
+    sourcemeta::core::SchemaIteratorEntry subschema_entry{
+        {entry.first}, dialect, vocabularies, base_dialect,
+        entry.second,  {},      false};
+    this->entries.push_back(std::move(subschema_entry));
   }
 
   // Sort keywords based on priority for correct evaluation

--- a/test/jsonschema/jsonschema_keyword_iterator_test.cc
+++ b/test/jsonschema/jsonschema_keyword_iterator_test.cc
@@ -43,57 +43,58 @@ TEST(JSONSchema_keyword_iterator, draft_2020_12) {
 
   EXPECT_EQ(entries.at(0).pointer, sourcemeta::core::Pointer({"$schema"}));
   EXPECT_EQ(
-      entries.at(0).value,
+      entries.at(0).subschema.get(),
       sourcemeta::core::JSON{"https://json-schema.org/draft/2020-12/schema"});
 
   EXPECT_EQ(entries.at(1).pointer, sourcemeta::core::Pointer({"if"}));
-  EXPECT_EQ(entries.at(1).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(1).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(2).pointer, sourcemeta::core::Pointer({"maxContains"}));
-  EXPECT_EQ(entries.at(2).value, sourcemeta::core::JSON{1});
+  EXPECT_EQ(entries.at(2).subschema.get(), sourcemeta::core::JSON{1});
 
   EXPECT_EQ(entries.at(3).pointer, sourcemeta::core::Pointer({"minContains"}));
-  EXPECT_EQ(entries.at(3).value, sourcemeta::core::JSON{0});
+  EXPECT_EQ(entries.at(3).subschema.get(), sourcemeta::core::JSON{0});
 
   EXPECT_EQ(entries.at(4).pointer,
             sourcemeta::core::Pointer({"patternProperties"}));
-  EXPECT_EQ(entries.at(4).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(4).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(5).pointer, sourcemeta::core::Pointer({"prefixItems"}));
-  EXPECT_EQ(entries.at(5).value, sourcemeta::core::parse_json("[]"));
+  EXPECT_EQ(entries.at(5).subschema.get(), sourcemeta::core::parse_json("[]"));
 
   EXPECT_EQ(entries.at(6).pointer, sourcemeta::core::Pointer({"required"}));
-  EXPECT_EQ(entries.at(6).value, sourcemeta::core::parse_json("[ \"foo\" ]"));
+  EXPECT_EQ(entries.at(6).subschema.get(),
+            sourcemeta::core::parse_json("[ \"foo\" ]"));
 
   EXPECT_EQ(entries.at(7).pointer, sourcemeta::core::Pointer({"contains"}));
-  EXPECT_EQ(entries.at(7).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(7).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(8).pointer, sourcemeta::core::Pointer({"else"}));
-  EXPECT_EQ(entries.at(8).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(8).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(9).pointer, sourcemeta::core::Pointer({"items"}));
-  EXPECT_EQ(entries.at(9).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(9).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(10).pointer, sourcemeta::core::Pointer({"properties"}));
-  EXPECT_EQ(entries.at(10).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(10).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(11).pointer, sourcemeta::core::Pointer({"then"}));
-  EXPECT_EQ(entries.at(11).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(11).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(12).pointer,
             sourcemeta::core::Pointer({"additionalProperties"}));
-  EXPECT_EQ(entries.at(12).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(12).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(13).pointer, sourcemeta::core::Pointer({"type"}));
-  EXPECT_EQ(entries.at(13).value, sourcemeta::core::JSON{"string"});
+  EXPECT_EQ(entries.at(13).subschema.get(), sourcemeta::core::JSON{"string"});
 
   EXPECT_EQ(entries.at(14).pointer,
             sourcemeta::core::Pointer({"unevaluatedItems"}));
-  EXPECT_EQ(entries.at(14).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(14).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(15).pointer,
             sourcemeta::core::Pointer({"unevaluatedProperties"}));
-  EXPECT_EQ(entries.at(15).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(15).subschema.get(), sourcemeta::core::JSON{true});
 }
 
 TEST(JSONSchema_keyword_iterator, draft_2019_09) {
@@ -133,58 +134,59 @@ TEST(JSONSchema_keyword_iterator, draft_2019_09) {
 
   EXPECT_EQ(entries.at(0).pointer, sourcemeta::core::Pointer({"$schema"}));
   EXPECT_EQ(
-      entries.at(0).value,
+      entries.at(0).subschema.get(),
       sourcemeta::core::JSON{"https://json-schema.org/draft/2019-09/schema"});
 
   EXPECT_EQ(entries.at(1).pointer, sourcemeta::core::Pointer({"if"}));
-  EXPECT_EQ(entries.at(1).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(1).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(2).pointer, sourcemeta::core::Pointer({"items"}));
-  EXPECT_EQ(entries.at(2).value, sourcemeta::core::parse_json("[]"));
+  EXPECT_EQ(entries.at(2).subschema.get(), sourcemeta::core::parse_json("[]"));
 
   EXPECT_EQ(entries.at(3).pointer, sourcemeta::core::Pointer({"maxContains"}));
-  EXPECT_EQ(entries.at(3).value, sourcemeta::core::JSON{1});
+  EXPECT_EQ(entries.at(3).subschema.get(), sourcemeta::core::JSON{1});
 
   EXPECT_EQ(entries.at(4).pointer, sourcemeta::core::Pointer({"minContains"}));
-  EXPECT_EQ(entries.at(4).value, sourcemeta::core::JSON{0});
+  EXPECT_EQ(entries.at(4).subschema.get(), sourcemeta::core::JSON{0});
 
   EXPECT_EQ(entries.at(5).pointer,
             sourcemeta::core::Pointer({"patternProperties"}));
-  EXPECT_EQ(entries.at(5).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(5).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(6).pointer, sourcemeta::core::Pointer({"required"}));
-  EXPECT_EQ(entries.at(6).value, sourcemeta::core::parse_json("[ \"foo\" ]"));
+  EXPECT_EQ(entries.at(6).subschema.get(),
+            sourcemeta::core::parse_json("[ \"foo\" ]"));
 
   EXPECT_EQ(entries.at(7).pointer,
             sourcemeta::core::Pointer({"additionalItems"}));
-  EXPECT_EQ(entries.at(7).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(7).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(8).pointer, sourcemeta::core::Pointer({"contains"}));
-  EXPECT_EQ(entries.at(8).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(8).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(9).pointer, sourcemeta::core::Pointer({"else"}));
-  EXPECT_EQ(entries.at(9).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(9).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(10).pointer, sourcemeta::core::Pointer({"properties"}));
-  EXPECT_EQ(entries.at(10).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(10).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(11).pointer, sourcemeta::core::Pointer({"then"}));
-  EXPECT_EQ(entries.at(11).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(11).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(12).pointer,
             sourcemeta::core::Pointer({"additionalProperties"}));
-  EXPECT_EQ(entries.at(12).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(12).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(13).pointer, sourcemeta::core::Pointer({"type"}));
-  EXPECT_EQ(entries.at(13).value, sourcemeta::core::JSON{"string"});
+  EXPECT_EQ(entries.at(13).subschema.get(), sourcemeta::core::JSON{"string"});
 
   EXPECT_EQ(entries.at(14).pointer,
             sourcemeta::core::Pointer({"unevaluatedItems"}));
-  EXPECT_EQ(entries.at(14).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(14).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(15).pointer,
             sourcemeta::core::Pointer({"unevaluatedProperties"}));
-  EXPECT_EQ(entries.at(15).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(15).subschema.get(), sourcemeta::core::JSON{true});
 }
 
 TEST(JSONSchema_keyword_iterator, draft7) {
@@ -217,41 +219,42 @@ TEST(JSONSchema_keyword_iterator, draft7) {
   EXPECT_EQ(entries.size(), 11);
 
   EXPECT_EQ(entries.at(0).pointer, sourcemeta::core::Pointer({"$schema"}));
-  EXPECT_EQ(entries.at(0).value,
+  EXPECT_EQ(entries.at(0).subschema.get(),
             sourcemeta::core::JSON{"http://json-schema.org/draft-07/schema#"});
 
   EXPECT_EQ(entries.at(1).pointer, sourcemeta::core::Pointer({"if"}));
-  EXPECT_EQ(entries.at(1).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(1).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(2).pointer, sourcemeta::core::Pointer({"items"}));
-  EXPECT_EQ(entries.at(2).value, sourcemeta::core::parse_json("[]"));
+  EXPECT_EQ(entries.at(2).subschema.get(), sourcemeta::core::parse_json("[]"));
 
   EXPECT_EQ(entries.at(3).pointer,
             sourcemeta::core::Pointer({"patternProperties"}));
-  EXPECT_EQ(entries.at(3).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(3).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(4).pointer, sourcemeta::core::Pointer({"required"}));
-  EXPECT_EQ(entries.at(4).value, sourcemeta::core::parse_json("[ \"foo\" ]"));
+  EXPECT_EQ(entries.at(4).subschema.get(),
+            sourcemeta::core::parse_json("[ \"foo\" ]"));
 
   EXPECT_EQ(entries.at(5).pointer,
             sourcemeta::core::Pointer({"additionalItems"}));
-  EXPECT_EQ(entries.at(5).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(5).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(6).pointer, sourcemeta::core::Pointer({"else"}));
-  EXPECT_EQ(entries.at(6).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(6).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(7).pointer, sourcemeta::core::Pointer({"properties"}));
-  EXPECT_EQ(entries.at(7).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(7).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(8).pointer, sourcemeta::core::Pointer({"then"}));
-  EXPECT_EQ(entries.at(8).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(8).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(9).pointer,
             sourcemeta::core::Pointer({"additionalProperties"}));
-  EXPECT_EQ(entries.at(9).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(9).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(10).pointer, sourcemeta::core::Pointer({"type"}));
-  EXPECT_EQ(entries.at(10).value, sourcemeta::core::JSON{"string"});
+  EXPECT_EQ(entries.at(10).subschema.get(), sourcemeta::core::JSON{"string"});
 }
 
 TEST(JSONSchema_keyword_iterator, draft6) {
@@ -281,32 +284,33 @@ TEST(JSONSchema_keyword_iterator, draft6) {
   EXPECT_EQ(entries.size(), 8);
 
   EXPECT_EQ(entries.at(0).pointer, sourcemeta::core::Pointer({"$schema"}));
-  EXPECT_EQ(entries.at(0).value,
+  EXPECT_EQ(entries.at(0).subschema.get(),
             sourcemeta::core::JSON{"http://json-schema.org/draft-06/schema#"});
 
   EXPECT_EQ(entries.at(1).pointer, sourcemeta::core::Pointer({"items"}));
-  EXPECT_EQ(entries.at(1).value, sourcemeta::core::parse_json("[]"));
+  EXPECT_EQ(entries.at(1).subschema.get(), sourcemeta::core::parse_json("[]"));
 
   EXPECT_EQ(entries.at(2).pointer,
             sourcemeta::core::Pointer({"patternProperties"}));
-  EXPECT_EQ(entries.at(2).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(2).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(3).pointer, sourcemeta::core::Pointer({"required"}));
-  EXPECT_EQ(entries.at(3).value, sourcemeta::core::parse_json("[ \"foo\" ]"));
+  EXPECT_EQ(entries.at(3).subschema.get(),
+            sourcemeta::core::parse_json("[ \"foo\" ]"));
 
   EXPECT_EQ(entries.at(4).pointer,
             sourcemeta::core::Pointer({"additionalItems"}));
-  EXPECT_EQ(entries.at(4).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(4).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(5).pointer, sourcemeta::core::Pointer({"properties"}));
-  EXPECT_EQ(entries.at(5).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(5).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(6).pointer,
             sourcemeta::core::Pointer({"additionalProperties"}));
-  EXPECT_EQ(entries.at(6).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(6).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(7).pointer, sourcemeta::core::Pointer({"type"}));
-  EXPECT_EQ(entries.at(7).value, sourcemeta::core::JSON{"string"});
+  EXPECT_EQ(entries.at(7).subschema.get(), sourcemeta::core::JSON{"string"});
 }
 
 TEST(JSONSchema_keyword_iterator, draft4) {
@@ -336,32 +340,33 @@ TEST(JSONSchema_keyword_iterator, draft4) {
   EXPECT_EQ(entries.size(), 8);
 
   EXPECT_EQ(entries.at(0).pointer, sourcemeta::core::Pointer({"$schema"}));
-  EXPECT_EQ(entries.at(0).value,
+  EXPECT_EQ(entries.at(0).subschema.get(),
             sourcemeta::core::JSON{"http://json-schema.org/draft-04/schema#"});
 
   EXPECT_EQ(entries.at(1).pointer, sourcemeta::core::Pointer({"items"}));
-  EXPECT_EQ(entries.at(1).value, sourcemeta::core::parse_json("[]"));
+  EXPECT_EQ(entries.at(1).subschema.get(), sourcemeta::core::parse_json("[]"));
 
   EXPECT_EQ(entries.at(2).pointer,
             sourcemeta::core::Pointer({"patternProperties"}));
-  EXPECT_EQ(entries.at(2).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(2).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(3).pointer, sourcemeta::core::Pointer({"required"}));
-  EXPECT_EQ(entries.at(3).value, sourcemeta::core::parse_json("[ \"foo\" ]"));
+  EXPECT_EQ(entries.at(3).subschema.get(),
+            sourcemeta::core::parse_json("[ \"foo\" ]"));
 
   EXPECT_EQ(entries.at(4).pointer,
             sourcemeta::core::Pointer({"additionalItems"}));
-  EXPECT_EQ(entries.at(4).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(4).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(5).pointer, sourcemeta::core::Pointer({"properties"}));
-  EXPECT_EQ(entries.at(5).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(5).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(6).pointer,
             sourcemeta::core::Pointer({"additionalProperties"}));
-  EXPECT_EQ(entries.at(6).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(6).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(7).pointer, sourcemeta::core::Pointer({"type"}));
-  EXPECT_EQ(entries.at(7).value, sourcemeta::core::JSON{"string"});
+  EXPECT_EQ(entries.at(7).subschema.get(), sourcemeta::core::JSON{"string"});
 }
 
 TEST(JSONSchema_keyword_iterator, draft3) {
@@ -390,29 +395,29 @@ TEST(JSONSchema_keyword_iterator, draft3) {
   EXPECT_EQ(entries.size(), 7);
 
   EXPECT_EQ(entries.at(0).pointer, sourcemeta::core::Pointer({"$schema"}));
-  EXPECT_EQ(entries.at(0).value,
+  EXPECT_EQ(entries.at(0).subschema.get(),
             sourcemeta::core::JSON{"http://json-schema.org/draft-03/schema#"});
 
   EXPECT_EQ(entries.at(1).pointer, sourcemeta::core::Pointer({"items"}));
-  EXPECT_EQ(entries.at(1).value, sourcemeta::core::parse_json("[]"));
+  EXPECT_EQ(entries.at(1).subschema.get(), sourcemeta::core::parse_json("[]"));
 
   EXPECT_EQ(entries.at(2).pointer,
             sourcemeta::core::Pointer({"patternProperties"}));
-  EXPECT_EQ(entries.at(2).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(2).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(3).pointer, sourcemeta::core::Pointer({"properties"}));
-  EXPECT_EQ(entries.at(3).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(3).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(4).pointer, sourcemeta::core::Pointer({"type"}));
-  EXPECT_EQ(entries.at(4).value, sourcemeta::core::JSON{"string"});
+  EXPECT_EQ(entries.at(4).subschema.get(), sourcemeta::core::JSON{"string"});
 
   EXPECT_EQ(entries.at(5).pointer,
             sourcemeta::core::Pointer({"additionalItems"}));
-  EXPECT_EQ(entries.at(5).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(5).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(6).pointer,
             sourcemeta::core::Pointer({"additionalProperties"}));
-  EXPECT_EQ(entries.at(6).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(6).subschema.get(), sourcemeta::core::JSON{true});
 }
 
 TEST(JSONSchema_keyword_iterator, draft2) {
@@ -439,18 +444,18 @@ TEST(JSONSchema_keyword_iterator, draft2) {
   EXPECT_EQ(entries.size(), 4);
 
   EXPECT_EQ(entries.at(0).pointer, sourcemeta::core::Pointer({"$schema"}));
-  EXPECT_EQ(entries.at(0).value,
+  EXPECT_EQ(entries.at(0).subschema.get(),
             sourcemeta::core::JSON{"http://json-schema.org/draft-02/schema#"});
 
   EXPECT_EQ(entries.at(1).pointer, sourcemeta::core::Pointer({"properties"}));
-  EXPECT_EQ(entries.at(1).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(1).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(2).pointer, sourcemeta::core::Pointer({"type"}));
-  EXPECT_EQ(entries.at(2).value, sourcemeta::core::JSON{"string"});
+  EXPECT_EQ(entries.at(2).subschema.get(), sourcemeta::core::JSON{"string"});
 
   EXPECT_EQ(entries.at(3).pointer,
             sourcemeta::core::Pointer({"additionalProperties"}));
-  EXPECT_EQ(entries.at(3).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(3).subschema.get(), sourcemeta::core::JSON{true});
 }
 
 TEST(JSONSchema_keyword_iterator, draft1) {
@@ -477,18 +482,18 @@ TEST(JSONSchema_keyword_iterator, draft1) {
   EXPECT_EQ(entries.size(), 4);
 
   EXPECT_EQ(entries.at(0).pointer, sourcemeta::core::Pointer({"$schema"}));
-  EXPECT_EQ(entries.at(0).value,
+  EXPECT_EQ(entries.at(0).subschema.get(),
             sourcemeta::core::JSON{"http://json-schema.org/draft-01/schema#"});
 
   EXPECT_EQ(entries.at(1).pointer, sourcemeta::core::Pointer({"properties"}));
-  EXPECT_EQ(entries.at(1).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(1).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(2).pointer, sourcemeta::core::Pointer({"type"}));
-  EXPECT_EQ(entries.at(2).value, sourcemeta::core::JSON{"string"});
+  EXPECT_EQ(entries.at(2).subschema.get(), sourcemeta::core::JSON{"string"});
 
   EXPECT_EQ(entries.at(3).pointer,
             sourcemeta::core::Pointer({"additionalProperties"}));
-  EXPECT_EQ(entries.at(3).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(3).subschema.get(), sourcemeta::core::JSON{true});
 }
 
 TEST(JSONSchema_keyword_iterator, draft0) {
@@ -515,18 +520,18 @@ TEST(JSONSchema_keyword_iterator, draft0) {
   EXPECT_EQ(entries.size(), 4);
 
   EXPECT_EQ(entries.at(0).pointer, sourcemeta::core::Pointer({"$schema"}));
-  EXPECT_EQ(entries.at(0).value,
+  EXPECT_EQ(entries.at(0).subschema.get(),
             sourcemeta::core::JSON{"http://json-schema.org/draft-00/schema#"});
 
   EXPECT_EQ(entries.at(1).pointer, sourcemeta::core::Pointer({"properties"}));
-  EXPECT_EQ(entries.at(1).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(1).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(2).pointer, sourcemeta::core::Pointer({"type"}));
-  EXPECT_EQ(entries.at(2).value, sourcemeta::core::JSON{"string"});
+  EXPECT_EQ(entries.at(2).subschema.get(), sourcemeta::core::JSON{"string"});
 
   EXPECT_EQ(entries.at(3).pointer,
             sourcemeta::core::Pointer({"additionalProperties"}));
-  EXPECT_EQ(entries.at(3).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(3).subschema.get(), sourcemeta::core::JSON{true});
 }
 
 TEST(JSONSchema_keyword_iterator, unknown_keyword) {
@@ -546,7 +551,7 @@ TEST(JSONSchema_keyword_iterator, unknown_keyword) {
 
   EXPECT_EQ(entries.at(0).pointer, sourcemeta::core::Pointer({"$schema"}));
   EXPECT_EQ(
-      entries.at(0).value,
+      entries.at(0).subschema.get(),
       sourcemeta::core::JSON{"https://json-schema.org/draft/2020-12/schema"});
   EXPECT_EQ(entries.at(0).dialect,
             "https://json-schema.org/draft/2020-12/schema");
@@ -555,7 +560,7 @@ TEST(JSONSchema_keyword_iterator, unknown_keyword) {
   EXPECT_EQ(entries.at(0).vocabularies.size(), 7);
 
   EXPECT_EQ(entries.at(1).pointer, sourcemeta::core::Pointer({"foobar"}));
-  EXPECT_EQ(entries.at(1).value, sourcemeta::core::JSON{0});
+  EXPECT_EQ(entries.at(1).subschema.get(), sourcemeta::core::JSON{0});
   EXPECT_EQ(entries.at(1).dialect,
             "https://json-schema.org/draft/2020-12/schema");
   EXPECT_EQ(entries.at(1).base_dialect,
@@ -588,14 +593,14 @@ TEST(JSONSchema_keyword_iterator, with_default_dialect) {
 
   EXPECT_EQ(entries.at(0).pointer,
             sourcemeta::core::Pointer({"patternProperties"}));
-  EXPECT_EQ(entries.at(0).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(0).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(1).pointer, sourcemeta::core::Pointer({"properties"}));
-  EXPECT_EQ(entries.at(1).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(1).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(2).pointer,
             sourcemeta::core::Pointer({"additionalProperties"}));
-  EXPECT_EQ(entries.at(2).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(2).subschema.get(), sourcemeta::core::JSON{true});
 }
 
 TEST(JSONSchema_keyword_iterator, no_default_dialect) {
@@ -621,14 +626,14 @@ TEST(JSONSchema_keyword_iterator, no_default_dialect) {
 
   EXPECT_EQ(entries.at(0).pointer,
             sourcemeta::core::Pointer({"additionalProperties"}));
-  EXPECT_EQ(entries.at(0).value, sourcemeta::core::JSON{true});
+  EXPECT_EQ(entries.at(0).subschema.get(), sourcemeta::core::JSON{true});
 
   EXPECT_EQ(entries.at(1).pointer,
             sourcemeta::core::Pointer({"patternProperties"}));
-  EXPECT_EQ(entries.at(1).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(1).subschema.get(), sourcemeta::core::parse_json("{}"));
 
   EXPECT_EQ(entries.at(2).pointer, sourcemeta::core::Pointer({"properties"}));
-  EXPECT_EQ(entries.at(2).value, sourcemeta::core::parse_json("{}"));
+  EXPECT_EQ(entries.at(2).subschema.get(), sourcemeta::core::parse_json("{}"));
 }
 
 TEST(JSONSchema_keyword_iterator, boolean_true) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
