### PR TITLE
Ensure `SchemaIterator` fully records orphan pointer templates

### DIFF
--- a/test/jsonschema/jsonschema_official_walker_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_official_walker_2019_09_test.cc
@@ -1591,3 +1591,36 @@ TEST(JSONSchema_official_walker_2019_09, instance_locations) {
   EXPECT_OFFICIAL_WALKER_ENTRY_2019_09_ORPHAN(entries, 27, "/definitions/foo",
                                               "");
 }
+
+TEST(JSONSchema_official_walker_2019_09, definitions_subschemas) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+      "foo": {
+        "properties": {
+          "bar": {
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  })JSON");
+
+  std::vector<sourcemeta::core::SchemaIteratorEntry> entries;
+  for (const auto &entry : sourcemeta::core::SchemaIterator(
+           document, sourcemeta::core::schema_official_walker,
+           sourcemeta::core::schema_official_resolver)) {
+    entries.push_back(entry);
+  }
+
+  EXPECT_EQ(entries.size(), 4);
+
+  EXPECT_OFFICIAL_WALKER_ENTRY_2019_09(entries, 0, "", "");
+  EXPECT_OFFICIAL_WALKER_ENTRY_2019_09_ORPHAN(entries, 1, "/$defs/foo", "");
+  EXPECT_OFFICIAL_WALKER_ENTRY_2019_09_ORPHAN(
+      entries, 2, "/$defs/foo/properties/bar", "/bar");
+  EXPECT_OFFICIAL_WALKER_ENTRY_2019_09_ORPHAN(
+      entries, 3, "/$defs/foo/properties/bar/additionalProperties", "/bar/~P~");
+}

--- a/test/jsonschema/jsonschema_official_walker_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_official_walker_2020_12_test.cc
@@ -1724,3 +1724,36 @@ TEST(JSONSchema_official_walker_2020_12, instance_locations_defs_with_ref) {
   EXPECT_OFFICIAL_WALKER_ENTRY_2020_12(entries, 1, "/allOf/0", "");
   EXPECT_OFFICIAL_WALKER_ENTRY_2020_12_ORPHAN(entries, 2, "/$defs/foo", "");
 }
+
+TEST(JSONSchema_official_walker_2020_12, definitions_subschemas) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+      "foo": {
+        "properties": {
+          "bar": {
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  })JSON");
+
+  std::vector<sourcemeta::core::SchemaIteratorEntry> entries;
+  for (const auto &entry : sourcemeta::core::SchemaIterator(
+           document, sourcemeta::core::schema_official_walker,
+           sourcemeta::core::schema_official_resolver)) {
+    entries.push_back(entry);
+  }
+
+  EXPECT_EQ(entries.size(), 4);
+
+  EXPECT_OFFICIAL_WALKER_ENTRY_2020_12(entries, 0, "", "");
+  EXPECT_OFFICIAL_WALKER_ENTRY_2020_12_ORPHAN(entries, 1, "/$defs/foo", "");
+  EXPECT_OFFICIAL_WALKER_ENTRY_2020_12_ORPHAN(
+      entries, 2, "/$defs/foo/properties/bar", "/bar");
+  EXPECT_OFFICIAL_WALKER_ENTRY_2020_12_ORPHAN(
+      entries, 3, "/$defs/foo/properties/bar/additionalProperties", "/bar/~P~");
+}

--- a/test/jsonschema/jsonschema_official_walker_draft4_test.cc
+++ b/test/jsonschema/jsonschema_official_walker_draft4_test.cc
@@ -703,3 +703,38 @@ TEST(JSONSchema_official_walker_draft4, instance_locations) {
   EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT4_ORPHAN(entries, 16, "/definitions/foo",
                                              "");
 }
+
+TEST(JSONSchema_official_walker_draft4, definitions_subschemas) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {
+      "foo": {
+        "properties": {
+          "bar": {
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  })JSON");
+
+  std::vector<sourcemeta::core::SchemaIteratorEntry> entries;
+  for (const auto &entry : sourcemeta::core::SchemaIterator(
+           document, sourcemeta::core::schema_official_walker,
+           sourcemeta::core::schema_official_resolver)) {
+    entries.push_back(entry);
+  }
+
+  EXPECT_EQ(entries.size(), 4);
+
+  EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT4(entries, 0, "", "");
+  EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT4_ORPHAN(entries, 1, "/definitions/foo",
+                                             "");
+  EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT4_ORPHAN(
+      entries, 2, "/definitions/foo/properties/bar", "/bar");
+  EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT4_ORPHAN(
+      entries, 3, "/definitions/foo/properties/bar/additionalProperties",
+      "/bar/~P~");
+}

--- a/test/jsonschema/jsonschema_official_walker_draft6_test.cc
+++ b/test/jsonschema/jsonschema_official_walker_draft6_test.cc
@@ -759,3 +759,38 @@ TEST(JSONSchema_official_walker_draft6, instance_locations) {
   EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT6_ORPHAN(entries, 18, "/definitions/foo",
                                              "");
 }
+
+TEST(JSONSchema_official_walker_draft6, definitions_subschemas) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+      "foo": {
+        "properties": {
+          "bar": {
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  })JSON");
+
+  std::vector<sourcemeta::core::SchemaIteratorEntry> entries;
+  for (const auto &entry : sourcemeta::core::SchemaIterator(
+           document, sourcemeta::core::schema_official_walker,
+           sourcemeta::core::schema_official_resolver)) {
+    entries.push_back(entry);
+  }
+
+  EXPECT_EQ(entries.size(), 4);
+
+  EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT6(entries, 0, "", "");
+  EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT6_ORPHAN(entries, 1, "/definitions/foo",
+                                             "");
+  EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT6_ORPHAN(
+      entries, 2, "/definitions/foo/properties/bar", "/bar");
+  EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT6_ORPHAN(
+      entries, 3, "/definitions/foo/properties/bar/additionalProperties",
+      "/bar/~P~");
+}

--- a/test/jsonschema/jsonschema_official_walker_draft7_test.cc
+++ b/test/jsonschema/jsonschema_official_walker_draft7_test.cc
@@ -947,3 +947,38 @@ TEST(JSONSchema_official_walker_draft7, instance_locations) {
   EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT7_ORPHAN(entries, 21, "/definitions/foo",
                                              "");
 }
+
+TEST(JSONSchema_official_walker_draft7, definitions_subschemas) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "foo": {
+        "properties": {
+          "bar": {
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  })JSON");
+
+  std::vector<sourcemeta::core::SchemaIteratorEntry> entries;
+  for (const auto &entry : sourcemeta::core::SchemaIterator(
+           document, sourcemeta::core::schema_official_walker,
+           sourcemeta::core::schema_official_resolver)) {
+    entries.push_back(entry);
+  }
+
+  EXPECT_EQ(entries.size(), 4);
+
+  EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT7(entries, 0, "", "");
+  EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT7_ORPHAN(entries, 1, "/definitions/foo",
+                                             "");
+  EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT7_ORPHAN(
+      entries, 2, "/definitions/foo/properties/bar", "/bar");
+  EXPECT_OFFICIAL_WALKER_ENTRY_DRAFT7_ORPHAN(
+      entries, 3, "/definitions/foo/properties/bar/additionalProperties",
+      "/bar/~P~");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
