### PR TITLE
Refactor read_json to accept optioal callback and update related tests and functions

### DIFF
--- a/src/core/json/include/sourcemeta/core/json.h
+++ b/src/core/json/include/sourcemeta/core/json.h
@@ -127,7 +127,8 @@ auto parse_json(const std::basic_string<JSON::Char, JSON::CharTraits> &input,
 ///
 /// If parsing fails, sourcemeta::core::JSONParseError will be thrown.
 SOURCEMETA_CORE_JSON_EXPORT
-auto read_json(const std::filesystem::path &path) -> JSON;
+auto read_json(const std::filesystem::path &path,
+               const JSON::ParseCallback &callback = nullptr) -> JSON;
 
 // TODO: Move this function to a system integration component, as it
 // is not JSON specific

--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -50,12 +50,12 @@ auto read_file(const std::filesystem::path &path)
   return stream;
 }
 
-auto read_json(const std::filesystem::path &path) -> JSON {
+auto read_json(const std::filesystem::path &path,
+               const JSON::ParseCallback &callback) -> JSON {
   auto stream{read_file(path)};
   try {
-    return parse_json(stream);
+    return parse_json(stream, callback);
   } catch (const JSONParseError &error) {
-    // For producing better error messages
     throw JSONFileParseError(path, error);
   }
 }

--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -56,6 +56,7 @@ auto read_json(const std::filesystem::path &path,
   try {
     return parse_json(stream, callback);
   } catch (const JSONParseError &error) {
+    // For producing better error messages
     throw JSONFileParseError(path, error);
   }
 }

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_resolver.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_resolver.h
@@ -110,8 +110,9 @@ public:
       const std::optional<std::string> &default_dialect = std::nullopt,
       const std::optional<std::string> &default_id = std::nullopt,
       const Reader &reader =
-          [](const std::filesystem::path &p) { return read_json(p, nullptr); },
-      SchemaVisitorReference reference_visitor = {}) -> const std::string &;
+          [](const std::filesystem::path &path) { return read_json(path); },
+      SchemaVisitorReference &&reference_visitor = nullptr)
+      -> const std::string &;
 
   // Change the identifier of a registered schema
   auto reidentify(const std::string &schema, const std::string &new_identifier)

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_resolver.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_resolver.h
@@ -105,12 +105,13 @@ public:
 
   /// Register a schema to the flat file resolver, returning the detected
   /// identifier for the schema
-  auto add(const std::filesystem::path &path,
-           const std::optional<std::string> &default_dialect = std::nullopt,
-           const std::optional<std::string> &default_id = std::nullopt,
-           const Reader &reader = read_json,
-           SchemaVisitorReference &&reference_visitor = nullptr)
-      -> const std::string &;
+  auto add(
+      const std::filesystem::path &path,
+      const std::optional<std::string> &default_dialect = std::nullopt,
+      const std::optional<std::string> &default_id = std::nullopt,
+      const Reader &reader =
+          [](const std::filesystem::path &p) { return read_json(p, nullptr); },
+      SchemaVisitorReference reference_visitor = {}) -> const std::string &;
 
   // Change the identifier of a registered schema
   auto reidentify(const std::string &schema, const std::string &new_identifier)

--- a/src/core/jsonschema/resolver.cc
+++ b/src/core/jsonschema/resolver.cc
@@ -93,23 +93,21 @@ auto SchemaFlatFileResolver::add(
     const std::filesystem::path &path,
     const std::optional<std::string> &default_dialect,
     const std::optional<std::string> &default_id, const Reader &reader,
-    SchemaVisitorReference reference_visitor) -> const std::string & {
-
+    SchemaVisitorReference &&reference_visitor) -> const std::string & {
   const auto canonical{std::filesystem::weakly_canonical(path)};
   const auto schema{reader(canonical)};
   assert(sourcemeta::core::is_schema(schema));
-
   const auto identifier{sourcemeta::core::identify(
       schema, *this, SchemaIdentificationStrategy::Loose, default_dialect,
       default_id)};
-
   if (!identifier.has_value() && !default_id.has_value()) {
     std::ostringstream error;
     error << "Cannot identify schema: " << canonical.string();
     throw SchemaError(error.str());
   }
 
-  // Normalize identifier (case-insensitive comparison)
+  // Filesystems behave differently with regards to casing. To unify
+  // them, assume they are case-insensitive.
   const auto effective_identifier{to_lowercase(
       default_id.has_value() ? identifier.value_or(default_id.value())
                              : identifier.value())};
@@ -119,7 +117,6 @@ auto SchemaFlatFileResolver::add(
       Entry{canonical, default_dialect, effective_identifier, reader,
             reference_visitor ? std::move(reference_visitor)
                               : reference_visitor_relativize})};
-
   if (!result.second && result.first->second.path != canonical) {
     std::ostringstream error;
     error << "Cannot register the same identifier twice: "

--- a/test/json/json_parse_callback_test.cc
+++ b/test/json/json_parse_callback_test.cc
@@ -258,15 +258,6 @@ TEST(JSON_parse_callback, object_empty_arrays) {
   EXPECT_TRACE(5, Post, Object, 4, 1, sourcemeta::core::parse_json(input));
 }
 
-TEST(JSON_parse_callback, read_json_stub_valid) {
-  const auto input{std::filesystem::path{TEST_DIRECTORY} / "stub_valid.json"};
-  READ_WITH_TRACES(document, input, 4);
-  EXPECT_TRACE(0, Pre, Object, 1, 1, sourcemeta::core::JSON{nullptr});
-  EXPECT_TRACE(1, Pre, Integer, 1, 10, sourcemeta::core::JSON{"foo"});
-  EXPECT_TRACE(2, Post, Integer, 1, 10, sourcemeta::core::JSON{1});
-  EXPECT_TRACE(3, Post, Object, 1, 12, sourcemeta::core::read_json(input));
-}
-
 TEST(JSON_parse_callback, object_empty_objects) {
   const auto input{"{\n  \"foo\": {},\n  \"bar\": {}\n}"};
   PARSE_WITH_TRACES(document, input, 6);
@@ -298,4 +289,13 @@ TEST(JSON_parse_callback, complex_1) {
   EXPECT_TRACE(6, Post, Object, 6, 3,
                sourcemeta::core::parse_json(input).at(0));
   EXPECT_TRACE(7, Post, Array, 7, 1, sourcemeta::core::parse_json(input));
+}
+
+TEST(JSON_parse_callback, read_json_stub_valid) {
+  const auto input{std::filesystem::path{TEST_DIRECTORY} / "stub_valid.json"};
+  READ_WITH_TRACES(document, input, 4);
+  EXPECT_TRACE(0, Pre, Object, 1, 1, sourcemeta::core::JSON{nullptr});
+  EXPECT_TRACE(1, Pre, Integer, 1, 10, sourcemeta::core::JSON{"foo"});
+  EXPECT_TRACE(2, Post, Integer, 1, 10, sourcemeta::core::JSON{1});
+  EXPECT_TRACE(3, Post, Object, 1, 12, sourcemeta::core::read_json(input));
 }

--- a/test/json/json_parse_callback_test.cc
+++ b/test/json/json_parse_callback_test.cc
@@ -20,6 +20,20 @@
       })};                                                                     \
   EXPECT_EQ(traces.size(), expected_size)
 
+#define READ_WITH_TRACES(result, input, expected_size)                         \
+  std::vector<std::tuple<sourcemeta::core::JSON::ParsePhase,                   \
+                         sourcemeta::core::JSON::Type, std::uint64_t,          \
+                         std::uint64_t, sourcemeta::core::JSON>>               \
+      traces;                                                                  \
+  const auto result{sourcemeta::core::read_json(                               \
+      input, [&traces](const sourcemeta::core::JSON::ParsePhase phase,         \
+                       const sourcemeta::core::JSON::Type type,                \
+                       const std::uint64_t line, const std::uint64_t column,   \
+                       const sourcemeta::core::JSON &value) {                  \
+        traces.emplace_back(phase, type, line, column, value);                 \
+      })};                                                                     \
+  EXPECT_EQ(traces.size(), expected_size)
+
 #define EXPECT_TRACE(index, expected_phase, expected_type, expected_line,      \
                      expected_column, expected_value)                          \
   EXPECT_EQ(std::get<0>(traces.at(index)),                                     \
@@ -244,33 +258,13 @@ TEST(JSON_parse_callback, object_empty_arrays) {
   EXPECT_TRACE(5, Post, Object, 4, 1, sourcemeta::core::parse_json(input));
 }
 
-TEST(JSON_read_callback, file_boolean_true) {
-  const auto path = std::filesystem::temp_directory_path() /
-                    "read_json_callback_true_test.json";
-  {
-    std::ofstream file{path};
-    ASSERT_TRUE(file.good());
-    file << "true";
-  }
-  std::vector<std::tuple<sourcemeta::core::JSON::ParsePhase,
-                         sourcemeta::core::JSON::Type, std::uint64_t,
-                         std::uint64_t, sourcemeta::core::JSON>>
-      traces;
-  const auto document = sourcemeta::core::read_json(
-      path,
-      [&](const sourcemeta::core::JSON::ParsePhase phase,
-          const sourcemeta::core::JSON::Type type, const std::uint64_t line,
-          const std::uint64_t column, const sourcemeta::core::JSON &value) {
-        traces.emplace_back(phase, type, line, column, value);
-      });
-  std::filesystem::remove(path);
-  EXPECT_EQ(document, sourcemeta::core::JSON(true));
-  ASSERT_EQ(traces.size(), 2u);
-  EXPECT_EQ(std::get<0>(traces[0]), sourcemeta::core::JSON::ParsePhase::Pre);
-  EXPECT_EQ(std::get<1>(traces[0]), sourcemeta::core::JSON::Type::Boolean);
-  EXPECT_EQ(std::get<0>(traces[1]), sourcemeta::core::JSON::ParsePhase::Post);
-  EXPECT_EQ(std::get<1>(traces[1]), sourcemeta::core::JSON::Type::Boolean);
-  EXPECT_EQ(std::get<4>(traces[1]), sourcemeta::core::JSON(true));
+TEST(JSON_parse_callback, read_json_stub_valid) {
+  const auto input{std::filesystem::path{TEST_DIRECTORY} / "stub_valid.json"};
+  READ_WITH_TRACES(document, input, 4);
+  EXPECT_TRACE(0, Pre, Object, 1, 1, sourcemeta::core::JSON{nullptr});
+  EXPECT_TRACE(1, Pre, Integer, 1, 10, sourcemeta::core::JSON{"foo"});
+  EXPECT_TRACE(2, Post, Integer, 1, 10, sourcemeta::core::JSON{1});
+  EXPECT_TRACE(3, Post, Object, 1, 12, sourcemeta::core::read_json(input));
 }
 
 TEST(JSON_parse_callback, object_empty_objects) {

--- a/test/jsonschema/jsonschema_flat_file_resolver_test.cc
+++ b/test/jsonschema/jsonschema_flat_file_resolver_test.cc
@@ -27,21 +27,24 @@ TEST(JSONSchema_SchemaFlatFileResolver, single_schema) {
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-id.json").has_value());
   EXPECT_EQ(resolver("https://www.sourcemeta.com/2020-12-id.json").value(),
-            sourcemeta::core::read_json(schema_path));
+            sourcemeta::core::read_json(schema_path, nullptr));
 }
 
 TEST(JSONSchema_SchemaFlatFileResolver, single_schema_custom_reader) {
   sourcemeta::core::SchemaFlatFileResolver resolver;
   const auto schema_path{std::filesystem::path{SCHEMAS_PATH} / "2020-12-id"};
+
   const auto &identifier{resolver.add(
       schema_path, std::nullopt, std::nullopt, [](const auto &path) {
-        return sourcemeta::core::read_json(path.string() + ".json");
+        return sourcemeta::core::read_json(path.string() + ".json", nullptr);
       })};
+
   EXPECT_EQ(identifier, "https://www.sourcemeta.com/2020-12-id.json");
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-id.json").has_value());
-  EXPECT_EQ(resolver("https://www.sourcemeta.com/2020-12-id.json").value(),
-            sourcemeta::core::read_json(schema_path.string() + ".json"));
+  EXPECT_EQ(
+      resolver("https://www.sourcemeta.com/2020-12-id.json").value(),
+      sourcemeta::core::read_json(schema_path.string() + ".json", nullptr));
 }
 
 TEST(JSONSchema_SchemaFlatFileResolver, single_schema_with_default_dialect) {
@@ -119,8 +122,9 @@ TEST(JSONSchema_SchemaFlatFileResolver, single_schema_idempotent) {
 
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-id.json").has_value());
+
   EXPECT_EQ(resolver("https://www.sourcemeta.com/2020-12-id.json").value(),
-            sourcemeta::core::read_json(schema_path));
+            sourcemeta::core::read_json(schema_path, nullptr));
 }
 
 TEST(JSONSchema_SchemaFlatFileResolver, duplicate_ids) {
@@ -146,9 +150,11 @@ TEST(JSONSchema_SchemaFlatFileResolver, no_embedded_resource) {
 
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-embedded.json").has_value());
+
   EXPECT_EQ(
       resolver("https://www.sourcemeta.com/2020-12-embedded.json").value(),
-      sourcemeta::core::read_json(schema_path));
+      sourcemeta::core::read_json(schema_path, nullptr));
+
   EXPECT_FALSE(resolver("https://www.sourcemeta.com/string").has_value());
 }
 
@@ -175,14 +181,16 @@ TEST(JSONSchema_SchemaFlatFileResolver, metaschema_out_of_order) {
 
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-meta-1.json").has_value());
+
   EXPECT_EQ(resolver("https://www.sourcemeta.com/2020-12-meta-1.json").value(),
             sourcemeta::core::read_json(metaschema_path));
 
   EXPECT_TRUE(resolver("https://www.sourcemeta.com/2020-12-meta-1-schema.json")
                   .has_value());
+
   EXPECT_EQ(
       resolver("https://www.sourcemeta.com/2020-12-meta-1-schema.json").value(),
-      sourcemeta::core::read_json(schema_path));
+      sourcemeta::core::read_json(schema_path, nullptr));
 }
 
 TEST(JSONSchema_SchemaFlatFileResolver, iterators) {
@@ -212,11 +220,13 @@ TEST(JSONSchema_SchemaFlatFileResolver, reidentify) {
   const auto schema_path{std::filesystem::path{SCHEMAS_PATH} /
                          "2020-12-id.json"};
   const auto &identifier{resolver.add(schema_path)};
+
   EXPECT_EQ(identifier, "https://www.sourcemeta.com/2020-12-id.json");
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-id.json").has_value());
+
   EXPECT_EQ(resolver("https://www.sourcemeta.com/2020-12-id.json").value(),
-            sourcemeta::core::read_json(schema_path));
+            sourcemeta::core::read_json(schema_path, nullptr));
 
   resolver.reidentify("https://www.sourcemeta.com/2020-12-id.json",
                       "https://example.com");
@@ -258,15 +268,19 @@ TEST(JSONSchema_SchemaFlatFileResolver, case_insensitive_lookup) {
   const auto schema_path{std::filesystem::path{SCHEMAS_PATH} /
                          "2020-12-id.json"};
   const auto &identifier{resolver.add(schema_path)};
+
   EXPECT_EQ(identifier, "https://www.sourcemeta.com/2020-12-id.json");
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-Id.json").has_value());
+
   EXPECT_EQ(resolver("https://www.sourcemeta.com/2020-12-Id.json").value(),
-            sourcemeta::core::read_json(schema_path));
+            sourcemeta::core::read_json(schema_path, nullptr));
+
   EXPECT_TRUE(
       resolver("https://WwW.SOURCEmeta.com/2020-12-Id.json").has_value());
+
   EXPECT_EQ(resolver("https://WwW.SOURCEmeta.com/2020-12-Id.json").value(),
-            sourcemeta::core::read_json(schema_path));
+            sourcemeta::core::read_json(schema_path, nullptr));
 }
 
 TEST(JSONSchema_SchemaFlatFileResolver, case_insensitive_insert) {
@@ -314,9 +328,10 @@ TEST(JSONSchema_SchemaFlatFileResolver, with_recursive_ref) {
             "https://www.sourcemeta.com/2019-09-recursive-ref.json");
   EXPECT_TRUE(resolver("https://www.sourcemeta.com/2019-09-recursive-ref.json")
                   .has_value());
+
   EXPECT_EQ(
       resolver("https://www.sourcemeta.com/2019-09-recursive-ref.json").value(),
-      expected);
+      sourcemeta::core::read_json(schema_path, nullptr));
 }
 
 TEST(JSONSchema_SchemaFlatFileResolver, with_absolute_references_reidentify) {
@@ -357,7 +372,10 @@ TEST(JSONSchema_SchemaFlatFileResolver, custom_reference_visitor) {
   })JSON");
 
   const auto &identifier{resolver.add(
-      schema_path, std::nullopt, std::nullopt, sourcemeta::core::read_json,
+      schema_path, std::nullopt, std::nullopt,
+      [](const std::filesystem::path &p) {
+        return sourcemeta::core::read_json(p, nullptr);
+      },
       [](sourcemeta::core::JSON &schema, const sourcemeta::core::URI &,
          const sourcemeta::core::JSON::String &,
          const sourcemeta::core::JSON::String &keyword,

--- a/test/jsonschema/jsonschema_flat_file_resolver_test.cc
+++ b/test/jsonschema/jsonschema_flat_file_resolver_test.cc
@@ -27,24 +27,21 @@ TEST(JSONSchema_SchemaFlatFileResolver, single_schema) {
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-id.json").has_value());
   EXPECT_EQ(resolver("https://www.sourcemeta.com/2020-12-id.json").value(),
-            sourcemeta::core::read_json(schema_path, nullptr));
+            sourcemeta::core::read_json(schema_path));
 }
 
 TEST(JSONSchema_SchemaFlatFileResolver, single_schema_custom_reader) {
   sourcemeta::core::SchemaFlatFileResolver resolver;
   const auto schema_path{std::filesystem::path{SCHEMAS_PATH} / "2020-12-id"};
-
   const auto &identifier{resolver.add(
       schema_path, std::nullopt, std::nullopt, [](const auto &path) {
-        return sourcemeta::core::read_json(path.string() + ".json", nullptr);
+        return sourcemeta::core::read_json(path.string() + ".json");
       })};
-
   EXPECT_EQ(identifier, "https://www.sourcemeta.com/2020-12-id.json");
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-id.json").has_value());
-  EXPECT_EQ(
-      resolver("https://www.sourcemeta.com/2020-12-id.json").value(),
-      sourcemeta::core::read_json(schema_path.string() + ".json", nullptr));
+  EXPECT_EQ(resolver("https://www.sourcemeta.com/2020-12-id.json").value(),
+            sourcemeta::core::read_json(schema_path.string() + ".json"));
 }
 
 TEST(JSONSchema_SchemaFlatFileResolver, single_schema_with_default_dialect) {
@@ -122,9 +119,8 @@ TEST(JSONSchema_SchemaFlatFileResolver, single_schema_idempotent) {
 
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-id.json").has_value());
-
   EXPECT_EQ(resolver("https://www.sourcemeta.com/2020-12-id.json").value(),
-            sourcemeta::core::read_json(schema_path, nullptr));
+            sourcemeta::core::read_json(schema_path));
 }
 
 TEST(JSONSchema_SchemaFlatFileResolver, duplicate_ids) {
@@ -150,11 +146,9 @@ TEST(JSONSchema_SchemaFlatFileResolver, no_embedded_resource) {
 
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-embedded.json").has_value());
-
   EXPECT_EQ(
       resolver("https://www.sourcemeta.com/2020-12-embedded.json").value(),
-      sourcemeta::core::read_json(schema_path, nullptr));
-
+      sourcemeta::core::read_json(schema_path));
   EXPECT_FALSE(resolver("https://www.sourcemeta.com/string").has_value());
 }
 
@@ -181,16 +175,14 @@ TEST(JSONSchema_SchemaFlatFileResolver, metaschema_out_of_order) {
 
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-meta-1.json").has_value());
-
   EXPECT_EQ(resolver("https://www.sourcemeta.com/2020-12-meta-1.json").value(),
             sourcemeta::core::read_json(metaschema_path));
 
   EXPECT_TRUE(resolver("https://www.sourcemeta.com/2020-12-meta-1-schema.json")
                   .has_value());
-
   EXPECT_EQ(
       resolver("https://www.sourcemeta.com/2020-12-meta-1-schema.json").value(),
-      sourcemeta::core::read_json(schema_path, nullptr));
+      sourcemeta::core::read_json(schema_path));
 }
 
 TEST(JSONSchema_SchemaFlatFileResolver, iterators) {
@@ -220,13 +212,11 @@ TEST(JSONSchema_SchemaFlatFileResolver, reidentify) {
   const auto schema_path{std::filesystem::path{SCHEMAS_PATH} /
                          "2020-12-id.json"};
   const auto &identifier{resolver.add(schema_path)};
-
   EXPECT_EQ(identifier, "https://www.sourcemeta.com/2020-12-id.json");
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-id.json").has_value());
-
   EXPECT_EQ(resolver("https://www.sourcemeta.com/2020-12-id.json").value(),
-            sourcemeta::core::read_json(schema_path, nullptr));
+            sourcemeta::core::read_json(schema_path));
 
   resolver.reidentify("https://www.sourcemeta.com/2020-12-id.json",
                       "https://example.com");
@@ -268,19 +258,15 @@ TEST(JSONSchema_SchemaFlatFileResolver, case_insensitive_lookup) {
   const auto schema_path{std::filesystem::path{SCHEMAS_PATH} /
                          "2020-12-id.json"};
   const auto &identifier{resolver.add(schema_path)};
-
   EXPECT_EQ(identifier, "https://www.sourcemeta.com/2020-12-id.json");
   EXPECT_TRUE(
       resolver("https://www.sourcemeta.com/2020-12-Id.json").has_value());
-
   EXPECT_EQ(resolver("https://www.sourcemeta.com/2020-12-Id.json").value(),
-            sourcemeta::core::read_json(schema_path, nullptr));
-
+            sourcemeta::core::read_json(schema_path));
   EXPECT_TRUE(
       resolver("https://WwW.SOURCEmeta.com/2020-12-Id.json").has_value());
-
   EXPECT_EQ(resolver("https://WwW.SOURCEmeta.com/2020-12-Id.json").value(),
-            sourcemeta::core::read_json(schema_path, nullptr));
+            sourcemeta::core::read_json(schema_path));
 }
 
 TEST(JSONSchema_SchemaFlatFileResolver, case_insensitive_insert) {
@@ -328,10 +314,9 @@ TEST(JSONSchema_SchemaFlatFileResolver, with_recursive_ref) {
             "https://www.sourcemeta.com/2019-09-recursive-ref.json");
   EXPECT_TRUE(resolver("https://www.sourcemeta.com/2019-09-recursive-ref.json")
                   .has_value());
-
   EXPECT_EQ(
       resolver("https://www.sourcemeta.com/2019-09-recursive-ref.json").value(),
-      sourcemeta::core::read_json(schema_path, nullptr));
+      expected);
 }
 
 TEST(JSONSchema_SchemaFlatFileResolver, with_absolute_references_reidentify) {
@@ -373,8 +358,8 @@ TEST(JSONSchema_SchemaFlatFileResolver, custom_reference_visitor) {
 
   const auto &identifier{resolver.add(
       schema_path, std::nullopt, std::nullopt,
-      [](const std::filesystem::path &p) {
-        return sourcemeta::core::read_json(p, nullptr);
+      [](const std::filesystem::path &path) {
+        return sourcemeta::core::read_json(path);
       },
       [](sourcemeta::core::JSON &schema, const sourcemeta::core::URI &,
          const sourcemeta::core::JSON::String &,


### PR DESCRIPTION
This PR refactors the `read_json` function to accept an optional `ParseCallback` parameter, enhancing the flexibility of JSON parsing. It also updates related function calls and definitions to align with this change as discussed in [slack](https://json-schema.slack.com/archives/C8C4UBXDF/p1739193378870919?thread_ts=1738590781.293879&cid=C8C4UBXDF)