### PR TITLE
Overload `parse_yaml` to read from `std::basic_istream`

### DIFF
--- a/src/core/yaml/include/sourcemeta/core/yaml.h
+++ b/src/core/yaml/include/sourcemeta/core/yaml.h
@@ -10,6 +10,7 @@
 #include <sourcemeta/core/json.h>
 
 #include <filesystem> // std::filesystem
+#include <istream>    // std::basic_istream
 
 /// @defgroup yaml YAML
 /// @brief A YAML compatibility library based on `libyaml`.
@@ -21,6 +22,25 @@
 /// ```
 
 namespace sourcemeta::core {
+
+/// @ingroup yaml
+///
+/// Create a JSON document from a C++ standard input stream that represents a
+/// YAML document. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/json.h>
+/// #include <cassert>
+/// #include <sstream>
+///
+/// std::istringstream stream{"foo: bar"};
+/// const sourcemeta::core::JSON document =
+///   sourcemeta::core::parse_yaml(stream);
+/// assert(document.is_object());
+/// ```
+SOURCEMETA_CORE_YAML_EXPORT
+auto parse_yaml(std::basic_istream<JSON::Char, JSON::CharTraits> &stream)
+    -> JSON;
 
 /// @ingroup yaml
 ///

--- a/src/core/yaml/yaml.cc
+++ b/src/core/yaml/yaml.cc
@@ -91,6 +91,13 @@ static auto internal_parse_json(yaml_parser_t *parser)
 
 namespace sourcemeta::core {
 
+auto parse_yaml(std::basic_istream<JSON::Char, JSON::CharTraits> &stream)
+    -> JSON {
+  std::basic_ostringstream<JSON::Char, JSON::CharTraits> buffer;
+  buffer << stream.rdbuf();
+  return parse_yaml(buffer.str());
+}
+
 auto parse_yaml(const JSON::String &input) -> JSON {
   yaml_parser_t parser;
   if (!yaml_parser_initialize(&parser)) {

--- a/test/yaml/yaml_parse_test.cc
+++ b/test/yaml/yaml_parse_test.cc
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <sstream>
+
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/yaml.h>
 
@@ -80,4 +82,17 @@ TEST(YAML_parse, file_not_exists) {
   EXPECT_THROW(sourcemeta::core::read_yaml(std::filesystem::path{STUBS_PATH} /
                                            "not_exists.yaml"),
                std::filesystem::filesystem_error);
+}
+
+TEST(YAML_parse, istringstream) {
+  std::istringstream stream{"hello: world\nfoo: 1\nbar: true"};
+  const auto result{sourcemeta::core::parse_yaml(stream)};
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "hello": "world",
+    "foo": 1,
+    "bar": true
+  })JSON");
+
+  EXPECT_EQ(result, expected);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
