### PR TITLE
Fix `read_file` on Bash's process substitution

### DIFF
--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -43,7 +43,12 @@ auto read_file(const std::filesystem::path &path)
         std::make_error_code(std::errc::is_a_directory));
   }
 
-  std::ifstream stream{std::filesystem::canonical(path)};
+  std::ifstream stream{
+      // On Linux, FIFO files (like /dev/fd/XX due to process substitution)
+      // cannot be
+      // made canonical
+      // See https://github.com/sourcemeta/jsonschema/issues/252
+      std::filesystem::is_fifo(path) ? path : std::filesystem::canonical(path)};
   stream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
   assert(!stream.fail());
   assert(stream.is_open());


### PR DESCRIPTION
See: https://github.com/sourcemeta/jsonschema/issues/252
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
