### PR TITLE
Implement a `Regex::matches_if_valid` convenience shorthand

### DIFF
--- a/src/core/regex/include/sourcemeta/core/regex.h
+++ b/src/core/regex/include/sourcemeta/core/regex.h
@@ -204,6 +204,24 @@ auto matches(const Regex<T> &regex, const T &value) -> bool {
 #endif
 }
 
+/// @ingroup regex
+///
+/// Validate a string against a regular expression pattern if the pattern
+/// represents a valid regular expression, compiling it along the way. For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/regex.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::matches_if_valid("^foo", "foo bar"));
+/// ```
+template <typename T>
+auto matches_if_valid(const T &pattern, const T &value) -> bool {
+  const auto regex{to_regex(pattern)};
+  return regex.has_value() && matches(regex.value(), value);
+}
+
 } // namespace sourcemeta::core
 
 #endif

--- a/test/regex/regex_matches_test.cc
+++ b/test/regex/regex_matches_test.cc
@@ -4,6 +4,16 @@
 
 #include <sourcemeta/core/regex.h>
 
+TEST(Regex_matches_if_valid, match_pattern_true) {
+  EXPECT_TRUE(
+      sourcemeta::core::matches_if_valid<std::string>("^foo", "foobar"));
+}
+
+TEST(Regex_matches_if_valid, match_pattern_false) {
+  EXPECT_FALSE(
+      sourcemeta::core::matches_if_valid<std::string>("^bar", "foobar"));
+}
+
 TEST(Regex_matches, match_true_1) {
   const auto regex{sourcemeta::core::to_regex<std::string>("^foo")};
   EXPECT_TRUE(regex.has_value());


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
