### PR TITLE
Add wildcard support for `PointerTemplate::matches`

### DIFF
--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
@@ -216,8 +216,6 @@ public:
   [[nodiscard]] auto
   matches(const GenericPointerTemplate<PointerT> &other) const noexcept
       -> bool {
-    // TODO: Support wildcards
-
     auto iterator_this = this->data.cbegin();
     auto iterator_that = other.data.cbegin();
 
@@ -254,6 +252,13 @@ public:
                   std::get<Regex>(*iterator_this), token.to_property())) {
             return false;
           }
+
+          // Handle wildcards
+        } else if (std::holds_alternative<Wildcard>(*iterator_this) &&
+                   std::holds_alternative<Token>(*iterator_that)) {
+        } else if (std::holds_alternative<Token>(*iterator_this) &&
+                   std::holds_alternative<Wildcard>(*iterator_that)) {
+
         } else {
           return false;
         }

--- a/test/jsonpointer/jsonpointer_template_test.cc
+++ b/test/jsonpointer/jsonpointer_template_test.cc
@@ -501,3 +501,71 @@ TEST(JSONPointer_template, matches_regex_true_conditional) {
   EXPECT_TRUE(left.matches(right));
   EXPECT_TRUE(right.matches(left));
 }
+
+TEST(JSONPointer_template, matches_wildcard_property) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::Pointer::Token{"foo"}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard{}};
+
+  EXPECT_TRUE(left.matches(right));
+  EXPECT_TRUE(right.matches(left));
+}
+
+TEST(JSONPointer_template, matches_wildcard_index) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::Pointer::Token{0}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard{}};
+
+  EXPECT_TRUE(left.matches(right));
+  EXPECT_TRUE(right.matches(left));
+}
+
+TEST(JSONPointer_template, matches_wildcard_multi_token) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::Pointer::Token{"foo"},
+      sourcemeta::core::Pointer::Token{"bar"}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard{}};
+
+  EXPECT_FALSE(left.matches(right));
+  EXPECT_FALSE(right.matches(left));
+}
+
+TEST(JSONPointer_template, matches_wildcard_property_conditional) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::PointerTemplate::Condition{},
+      sourcemeta::core::Pointer::Token{"foo"}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard{}};
+
+  EXPECT_TRUE(left.matches(right));
+  EXPECT_TRUE(right.matches(left));
+}
+
+TEST(JSONPointer_template, matches_wildcard_regex) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::PointerTemplate::Regex{"^f"}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard{}};
+
+  EXPECT_FALSE(left.matches(right));
+  EXPECT_FALSE(right.matches(left));
+}
+
+TEST(JSONPointer_template, matches_wildcard_negation) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::PointerTemplate::Negation{}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard{}};
+
+  EXPECT_FALSE(left.matches(right));
+  EXPECT_FALSE(right.matches(left));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
