### PR TITLE
Improve `PointerTemplate` wildcard matching for tokens and regexes

### DIFF
--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
@@ -216,6 +216,7 @@ public:
   [[nodiscard]] auto
   matches(const GenericPointerTemplate<PointerT> &other) const noexcept
       -> bool {
+    // TODO: Find a way to simplify this long method
     auto iterator_this = this->data.cbegin();
     auto iterator_that = other.data.cbegin();
 
@@ -256,9 +257,32 @@ public:
           // Handle wildcards
         } else if (std::holds_alternative<Wildcard>(*iterator_this) &&
                    std::holds_alternative<Token>(*iterator_that)) {
+          const auto &token{std::get<Token>(*iterator_that)};
+          const auto wildcard{std::get<Wildcard>(*iterator_this)};
+          if (wildcard == Wildcard::Key ||
+              (wildcard == Wildcard::Property && !token.is_property()) ||
+              (wildcard == Wildcard::Item && !token.is_index())) {
+            return false;
+          }
         } else if (std::holds_alternative<Token>(*iterator_this) &&
                    std::holds_alternative<Wildcard>(*iterator_that)) {
-
+          const auto &token{std::get<Token>(*iterator_this)};
+          const auto wildcard{std::get<Wildcard>(*iterator_that)};
+          if (wildcard == Wildcard::Key ||
+              (wildcard == Wildcard::Property && !token.is_property()) ||
+              (wildcard == Wildcard::Item && !token.is_index())) {
+            return false;
+          }
+        } else if (std::holds_alternative<Regex>(*iterator_this) &&
+                   std::holds_alternative<Wildcard>(*iterator_that)) {
+          if (std::get<Wildcard>(*iterator_that) != Wildcard::Property) {
+            return false;
+          }
+        } else if (std::holds_alternative<Wildcard>(*iterator_this) &&
+                   std::holds_alternative<Regex>(*iterator_that)) {
+          if (std::get<Wildcard>(*iterator_this) != Wildcard::Property) {
+            return false;
+          }
         } else {
           return false;
         }

--- a/test/jsonpointer/jsonpointer_template_test.cc
+++ b/test/jsonpointer/jsonpointer_template_test.cc
@@ -502,69 +502,146 @@ TEST(JSONPointer_template, matches_regex_true_conditional) {
   EXPECT_TRUE(right.matches(left));
 }
 
-TEST(JSONPointer_template, matches_wildcard_property) {
+TEST(JSONPointer_template, matches_property_wildcard_property) {
   const sourcemeta::core::PointerTemplate left{
       sourcemeta::core::Pointer::Token{"foo"}};
 
   const sourcemeta::core::PointerTemplate right{
-      sourcemeta::core::PointerTemplate::Wildcard{}};
+      sourcemeta::core::PointerTemplate::Wildcard::Property};
 
   EXPECT_TRUE(left.matches(right));
   EXPECT_TRUE(right.matches(left));
 }
 
-TEST(JSONPointer_template, matches_wildcard_index) {
+TEST(JSONPointer_template, matches_item_wildcard_property) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::Pointer::Token{"foo"}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard::Item};
+
+  EXPECT_FALSE(left.matches(right));
+  EXPECT_FALSE(right.matches(left));
+}
+
+TEST(JSONPointer_template, matches_key_wildcard_property) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::Pointer::Token{"foo"}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard::Key};
+
+  EXPECT_FALSE(left.matches(right));
+  EXPECT_FALSE(right.matches(left));
+}
+
+TEST(JSONPointer_template, matches_item_wildcard_index) {
   const sourcemeta::core::PointerTemplate left{
       sourcemeta::core::Pointer::Token{0}};
 
   const sourcemeta::core::PointerTemplate right{
-      sourcemeta::core::PointerTemplate::Wildcard{}};
+      sourcemeta::core::PointerTemplate::Wildcard::Item};
 
   EXPECT_TRUE(left.matches(right));
   EXPECT_TRUE(right.matches(left));
 }
 
-TEST(JSONPointer_template, matches_wildcard_multi_token) {
+TEST(JSONPointer_template, matches_property_wildcard_index) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::Pointer::Token{0}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard::Property};
+
+  EXPECT_FALSE(left.matches(right));
+  EXPECT_FALSE(right.matches(left));
+}
+
+TEST(JSONPointer_template, matches_key_wildcard_index) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::Pointer::Token{0}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard::Key};
+
+  EXPECT_FALSE(left.matches(right));
+  EXPECT_FALSE(right.matches(left));
+}
+
+TEST(JSONPointer_template, matches_property_wildcard_multi_token) {
   const sourcemeta::core::PointerTemplate left{
       sourcemeta::core::Pointer::Token{"foo"},
       sourcemeta::core::Pointer::Token{"bar"}};
 
   const sourcemeta::core::PointerTemplate right{
-      sourcemeta::core::PointerTemplate::Wildcard{}};
+      sourcemeta::core::PointerTemplate::Wildcard::Property};
 
   EXPECT_FALSE(left.matches(right));
   EXPECT_FALSE(right.matches(left));
 }
 
-TEST(JSONPointer_template, matches_wildcard_property_conditional) {
+TEST(JSONPointer_template, matches_property_wildcard_property_conditional) {
   const sourcemeta::core::PointerTemplate left{
       sourcemeta::core::PointerTemplate::Condition{},
       sourcemeta::core::Pointer::Token{"foo"}};
 
   const sourcemeta::core::PointerTemplate right{
-      sourcemeta::core::PointerTemplate::Wildcard{}};
+      sourcemeta::core::PointerTemplate::Wildcard::Property};
 
   EXPECT_TRUE(left.matches(right));
   EXPECT_TRUE(right.matches(left));
 }
 
-TEST(JSONPointer_template, matches_wildcard_regex) {
+TEST(JSONPointer_template, matches_property_wildcard_regex) {
   const sourcemeta::core::PointerTemplate left{
       sourcemeta::core::PointerTemplate::Regex{"^f"}};
 
   const sourcemeta::core::PointerTemplate right{
-      sourcemeta::core::PointerTemplate::Wildcard{}};
+      sourcemeta::core::PointerTemplate::Wildcard::Property};
+
+  EXPECT_TRUE(left.matches(right));
+  EXPECT_TRUE(right.matches(left));
+}
+
+TEST(JSONPointer_template, matches_item_wildcard_regex) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::PointerTemplate::Regex{"^f"}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard::Item};
 
   EXPECT_FALSE(left.matches(right));
   EXPECT_FALSE(right.matches(left));
 }
 
-TEST(JSONPointer_template, matches_wildcard_negation) {
+TEST(JSONPointer_template, matches_key_wildcard_regex) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::PointerTemplate::Regex{"^f"}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard::Key};
+
+  EXPECT_FALSE(left.matches(right));
+  EXPECT_FALSE(right.matches(left));
+}
+
+TEST(JSONPointer_template, matches_property_wildcard_negation) {
   const sourcemeta::core::PointerTemplate left{
       sourcemeta::core::PointerTemplate::Negation{}};
 
   const sourcemeta::core::PointerTemplate right{
-      sourcemeta::core::PointerTemplate::Wildcard{}};
+      sourcemeta::core::PointerTemplate::Wildcard::Property};
+
+  EXPECT_FALSE(left.matches(right));
+  EXPECT_FALSE(right.matches(left));
+}
+
+TEST(JSONPointer_template, matches_item_wildcard_negation) {
+  const sourcemeta::core::PointerTemplate left{
+      sourcemeta::core::PointerTemplate::Negation{}};
+
+  const sourcemeta::core::PointerTemplate right{
+      sourcemeta::core::PointerTemplate::Wildcard::Item};
 
   EXPECT_FALSE(left.matches(right));
   EXPECT_FALSE(right.matches(left));


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
