### PR TITLE
Implement a `PointerTemplate::trivial` method

### DIFF
--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
@@ -6,7 +6,7 @@
 
 #include <sourcemeta/core/regex.h>
 
-#include <algorithm> // std::copy
+#include <algorithm> // std::copy, std::all_of
 #include <cassert>   // assert
 #include <iterator>  // std::back_inserter
 #include <variant>   // std::variant, std::holds_alternative, std::get
@@ -195,6 +195,24 @@ public:
   /// ```
   [[nodiscard]] auto empty() const noexcept -> bool {
     return this->data.empty();
+  }
+
+  /// Check if a JSON Pointer template only consists in normal non-templated
+  /// tokens. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/jsonpointer.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::PointerTemplate pointer;
+  /// pointer.emplace_back(sourcemeta::core::PointerTemplate::Wildcard::Property);
+  /// pointer.emplace_back(sourcemeta::core::Pointer::Token{"foo"});
+  /// assert(!pointer.trivial());
+  /// ```
+  [[nodiscard]] auto trivial() const noexcept -> bool {
+    return std::all_of(
+        this->data.cbegin(), this->data.cend(),
+        [](const auto &token) { return std::holds_alternative<Token>(token); });
   }
 
   /// Check if a JSON Pointer template matches another JSON Pointer template.

--- a/test/jsonpointer/jsonpointer_template_test.cc
+++ b/test/jsonpointer/jsonpointer_template_test.cc
@@ -194,6 +194,68 @@ TEST(JSONPointer_template, equality_with_negation_wildcard_false) {
   EXPECT_NE(left, right);
 }
 
+TEST(JSONPointer_template, trivial_empty) {
+  // const sourcemeta::core::PointerTemplate left{
+  // sourcemeta::core::PointerTemplate::Negation{}};
+  const sourcemeta::core::PointerTemplate pointer;
+  EXPECT_TRUE(pointer.trivial());
+}
+
+TEST(JSONPointer_template, trivial_wildcard_property) {
+  const sourcemeta::core::PointerTemplate pointer{
+      sourcemeta::core::PointerTemplate::Wildcard::Property};
+  EXPECT_FALSE(pointer.trivial());
+}
+
+TEST(JSONPointer_template, trivial_wildcard_item) {
+  const sourcemeta::core::PointerTemplate pointer{
+      sourcemeta::core::PointerTemplate::Wildcard::Item};
+  EXPECT_FALSE(pointer.trivial());
+}
+
+TEST(JSONPointer_template, trivial_wildcard_key) {
+  const sourcemeta::core::PointerTemplate pointer{
+      sourcemeta::core::PointerTemplate::Wildcard::Key};
+  EXPECT_FALSE(pointer.trivial());
+}
+
+TEST(JSONPointer_template, trivial_condition) {
+  const sourcemeta::core::PointerTemplate pointer{
+      sourcemeta::core::PointerTemplate::Condition{}};
+  EXPECT_FALSE(pointer.trivial());
+}
+
+TEST(JSONPointer_template, trivial_negation) {
+  const sourcemeta::core::PointerTemplate pointer{
+      sourcemeta::core::PointerTemplate::Negation{}};
+  EXPECT_FALSE(pointer.trivial());
+}
+
+TEST(JSONPointer_template, trivial_regex) {
+  const sourcemeta::core::PointerTemplate pointer{
+      sourcemeta::core::PointerTemplate::Regex{"^f"}};
+  EXPECT_FALSE(pointer.trivial());
+}
+
+TEST(JSONPointer_template, trivial_token_index) {
+  const sourcemeta::core::PointerTemplate pointer{
+      sourcemeta::core::Pointer::Token{5}};
+  EXPECT_TRUE(pointer.trivial());
+}
+
+TEST(JSONPointer_template, trivial_token_property) {
+  const sourcemeta::core::PointerTemplate pointer{
+      sourcemeta::core::Pointer::Token{"foo"}};
+  EXPECT_TRUE(pointer.trivial());
+}
+
+TEST(JSONPointer_template, trivial_mixed) {
+  const sourcemeta::core::PointerTemplate pointer{
+      sourcemeta::core::Pointer::Token{"foo"},
+      sourcemeta::core::PointerTemplate::Condition{}};
+  EXPECT_FALSE(pointer.trivial());
+}
+
 TEST(JSONPointer_template, pop_back) {
   const sourcemeta::core::Pointer base{"foo", "bar"};
   sourcemeta::core::PointerTemplate pointer{base};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
