### PR TITLE
Stop passing `pointer` and `dialect` to `SchemaTransformRule`

### DIFF
--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_transform.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_transform.h
@@ -42,9 +42,7 @@ namespace sourcemeta::core {
 ///   sourcemeta::core::SchemaTransformRule("my_rule", "My rule") {};
 ///
 ///   [[nodiscard]] auto condition(const sourcemeta::core::JSON &schema,
-///                                const std::string &dialect,
 ///                                const std::set<std::string> &vocabularies,
-///                                const sourcemeta::core::Pointer &pointer,
 ///                                const sourcemeta::core::SchemaFrame &,
 ///                                const sourcemeta::core::SchemaFrame::Location
 ///                                &)
@@ -82,20 +80,19 @@ public:
   [[nodiscard]] auto message() const -> const std::string &;
 
   /// Apply the rule to a schema
-  auto apply(JSON &schema, const Pointer &pointer,
-             const SchemaResolver &resolver, const SchemaFrame &frame,
+  auto apply(JSON &schema, const SchemaResolver &resolver,
+             const SchemaFrame &frame,
              const SchemaFrame::Location &location) const -> bool;
 
   /// Check if the rule applies to a schema
-  auto check(const JSON &schema, const Pointer &pointer,
-             const SchemaResolver &resolver, const SchemaFrame &frame,
+  auto check(const JSON &schema, const SchemaResolver &resolver,
+             const SchemaFrame &frame,
              const SchemaFrame::Location &location) const -> bool;
 
 private:
   /// The rule condition
   [[nodiscard]] virtual auto
-  condition(const JSON &schema, const std::string &dialect,
-            const std::set<std::string> &vocabularies, const Pointer &pointer,
+  condition(const JSON &schema, const std::set<std::string> &vocabularies,
             const SchemaFrame &frame,
             const SchemaFrame::Location &location) const -> bool = 0;
 
@@ -132,9 +129,7 @@ private:
 ///   MyRule() : sourcemeta::core::SchemaTransformRule("my_rule") {};
 ///
 ///   [[nodiscard]] auto condition(const sourcemeta::core::JSON &schema,
-///                                const std::string &dialect,
 ///                                const std::set<std::string> &vocabularies,
-///                                const sourcemeta::core::Pointer &pointer,
 ///                                const sourcemeta::core::SchemaFrame &,
 ///                                const sourcemeta::core::SchemaFrame::Location
 ///                                &)

--- a/src/extension/alterschema/antipattern/const_with_type.h
+++ b/src/extension/alterschema/antipattern/const_with_type.h
@@ -6,11 +6,12 @@ public:
             "Setting `type` alongside `const` is considered an anti-pattern, "
             "as the constant already implies its respective type"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/antipattern/duplicate_enum_values.h
+++ b/src/extension/alterschema/antipattern/duplicate_enum_values.h
@@ -5,11 +5,12 @@ public:
                             "Setting duplicate values in `enum` is "
                             "considered an anti-pattern"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/antipattern/duplicate_required_values.h
+++ b/src/extension/alterschema/antipattern/duplicate_required_values.h
@@ -6,11 +6,12 @@ public:
             "Setting duplicate values in `required` is considered an "
             "anti-pattern"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/antipattern/enum_with_type.h
+++ b/src/extension/alterschema/antipattern/enum_with_type.h
@@ -6,11 +6,12 @@ public:
             "Setting `type` alongside `enum` is considered an anti-pattern, as "
             "the enumeration choices already imply their respective types"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/antipattern/exclusive_maximum_number_and_maximum.h
+++ b/src/extension/alterschema/antipattern/exclusive_maximum_number_and_maximum.h
@@ -6,11 +6,12 @@ public:
             "Setting both `exclusiveMaximum` and `maximum` at the same time "
             "is considered an anti-pattern. You should choose one"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/antipattern/exclusive_minimum_number_and_minimum.h
+++ b/src/extension/alterschema/antipattern/exclusive_minimum_number_and_minimum.h
@@ -6,11 +6,12 @@ public:
             "Setting both `exclusiveMinimum` and `minimum` at the same time "
             "is considered an anti-pattern. You should choose one"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/desugar/boolean_true.h
+++ b/src/extension/alterschema/desugar/boolean_true.h
@@ -7,8 +7,7 @@ public:
         };
 
   [[nodiscard]] auto
-  condition(const sourcemeta::core::JSON &schema, const std::string &,
-            const std::set<std::string> &, const sourcemeta::core::Pointer &,
+  condition(const sourcemeta::core::JSON &schema, const std::set<std::string> &,
             const sourcemeta::core::SchemaFrame &,
             const sourcemeta::core::SchemaFrame::Location &) const
       -> bool override {

--- a/src/extension/alterschema/desugar/const_as_enum.h
+++ b/src/extension/alterschema/desugar/const_as_enum.h
@@ -5,11 +5,12 @@ public:
                             "Setting `const` is syntax sugar for an "
                             "enumeration of a single value"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/desugar/exclusive_maximum_integer_to_maximum.h
+++ b/src/extension/alterschema/desugar/exclusive_maximum_integer_to_maximum.h
@@ -6,11 +6,12 @@ public:
             "Setting `exclusiveMaximum` when `type` is `integer` is syntax "
             "sugar for `maximum`"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/desugar/exclusive_minimum_integer_to_minimum.h
+++ b/src/extension/alterschema/desugar/exclusive_minimum_integer_to_minimum.h
@@ -6,11 +6,12 @@ public:
             "Setting `exclusiveMinimum` when `type` is `integer` is syntax "
             "sugar for `minimum`"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/desugar/type_array_to_any_of_2020_12.h
+++ b/src/extension/alterschema/desugar/type_array_to_any_of_2020_12.h
@@ -7,9 +7,9 @@ public:
             "`anyOf` over the corresponding types"} {};
 
   [[nodiscard]] auto
-  condition(const sourcemeta::core::JSON &schema, const std::string &,
+  condition(const sourcemeta::core::JSON &schema,
             const std::set<std::string> &vocabularies,
-            const sourcemeta::core::Pointer &,
+
             const sourcemeta::core::SchemaFrame &frame,
             const sourcemeta::core::SchemaFrame::Location &) const
       -> bool override {

--- a/src/extension/alterschema/desugar/type_boolean_as_enum.h
+++ b/src/extension/alterschema/desugar/type_boolean_as_enum.h
@@ -6,11 +6,12 @@ public:
             "Setting `type` to `boolean` is syntax sugar for an enumeration "
             "of two values: `false` and `true`"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/desugar/type_null_as_enum.h
+++ b/src/extension/alterschema/desugar/type_null_as_enum.h
@@ -6,11 +6,12 @@ public:
             "Setting `type` to `null` is syntax sugar for an enumeration "
             "of a single value: `null`"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/implicit/max_contains_covered_by_max_items.h
+++ b/src/extension/alterschema/implicit/max_contains_covered_by_max_items.h
@@ -7,11 +7,12 @@ public:
             "equal to the array upper bound does not add any further "
             "constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/implicit/min_items_given_min_contains.h
+++ b/src/extension/alterschema/implicit/min_items_given_min_contains.h
@@ -6,11 +6,12 @@ public:
             "Every array has a minimum size of zero items but may be affected "
             "by `minContains`"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/implicit/min_items_implicit.h
+++ b/src/extension/alterschema/implicit/min_items_implicit.h
@@ -4,11 +4,12 @@ public:
       : SchemaTransformRule{"min_items_implicit",
                             "Every array has a minimum size of zero items"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(vocabularies,
                         {"http://json-schema.org/draft-07/schema#",
                          "http://json-schema.org/draft-06/schema#",

--- a/src/extension/alterschema/implicit/min_length_implicit.h
+++ b/src/extension/alterschema/implicit/min_length_implicit.h
@@ -5,11 +5,12 @@ public:
             "min_length_implicit",
             "Every string has a minimum length of zero characters"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/implicit/min_properties_covered_by_required.h
+++ b/src/extension/alterschema/implicit/min_properties_covered_by_required.h
@@ -6,11 +6,12 @@ public:
             "Setting `minProperties` to a number less than `required` does "
             "not add any further constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/implicit/min_properties_implicit.h
+++ b/src/extension/alterschema/implicit/min_properties_implicit.h
@@ -6,11 +6,12 @@ public:
             "The `minProperties` keyword has a logical default of 0 or the "
             "size of `required`"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/implicit/multiple_of_implicit.h
+++ b/src/extension/alterschema/implicit/multiple_of_implicit.h
@@ -4,11 +4,12 @@ public:
       : SchemaTransformRule{"multiple_of_implicit",
                             "The unit of `multipleOf` is the integer 1"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/implicit/properties_implicit.h
+++ b/src/extension/alterschema/implicit/properties_implicit.h
@@ -5,11 +5,12 @@ public:
                             "Every object has an implicit `properties` "
                             "that consists of the empty object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return ((vocabularies.contains(
                  "https://json-schema.org/draft/2020-12/vocab/validation") &&
              vocabularies.contains(

--- a/src/extension/alterschema/implicit/type_union_implicit.h
+++ b/src/extension/alterschema/implicit/type_union_implicit.h
@@ -5,11 +5,12 @@ public:
             "type_union_implicit",
             "Not setting `type` is equivalent to accepting any type"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     if (!schema.is_object()) {
       return false;
     }

--- a/src/extension/alterschema/redundant/additional_properties_default.h
+++ b/src/extension/alterschema/redundant/additional_properties_default.h
@@ -6,11 +6,12 @@ public:
             "Setting the `additionalProperties` keyword to the true schema "
             "does not add any further constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/applicator",

--- a/src/extension/alterschema/redundant/content_schema_default.h
+++ b/src/extension/alterschema/redundant/content_schema_default.h
@@ -6,11 +6,12 @@ public:
             "Setting the `contentSchema` keyword to the true schema "
             "does not add any further constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/content",

--- a/src/extension/alterschema/redundant/dependencies_default.h
+++ b/src/extension/alterschema/redundant/dependencies_default.h
@@ -6,11 +6,12 @@ public:
             "Setting the `dependencies` keyword to an empty object "
             "does not add any further constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(vocabularies,
                         {"http://json-schema.org/draft-07/schema#",
                          "http://json-schema.org/draft-06/schema#",

--- a/src/extension/alterschema/redundant/dependent_required_default.h
+++ b/src/extension/alterschema/redundant/dependent_required_default.h
@@ -6,11 +6,12 @@ public:
             "Setting the `dependentRequired` keyword to an empty object "
             "does not add any further constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/redundant/items_array_default.h
+++ b/src/extension/alterschema/redundant/items_array_default.h
@@ -5,11 +5,12 @@ public:
                             "Setting the `items` keyword to the empty array "
                             "does not add any further constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2019-09/vocab/applicator",

--- a/src/extension/alterschema/redundant/items_schema_default.h
+++ b/src/extension/alterschema/redundant/items_schema_default.h
@@ -5,11 +5,12 @@ public:
                             "Setting the `items` keyword to the true schema "
                             "does not add any further constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/applicator",

--- a/src/extension/alterschema/redundant/pattern_properties_default.h
+++ b/src/extension/alterschema/redundant/pattern_properties_default.h
@@ -6,11 +6,12 @@ public:
             "Setting the `patternProperties` keyword to the empty object "
             "does not add any further constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/applicator",

--- a/src/extension/alterschema/redundant/properties_default.h
+++ b/src/extension/alterschema/redundant/properties_default.h
@@ -6,11 +6,12 @@ public:
             "Setting the `properties` keyword to the empty object "
             "does not add any further constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/applicator",

--- a/src/extension/alterschema/redundant/unevaluated_items_default.h
+++ b/src/extension/alterschema/redundant/unevaluated_items_default.h
@@ -6,11 +6,12 @@ public:
             "Setting the `unevaluatedItems` keyword to the true schema "
             "does not add any further constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/unevaluated",

--- a/src/extension/alterschema/redundant/unevaluated_properties_default.h
+++ b/src/extension/alterschema/redundant/unevaluated_properties_default.h
@@ -6,11 +6,12 @@ public:
             "Setting the `unevaluatedProperties` keyword to the true schema "
             "does not add any further constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/unevaluated",

--- a/src/extension/alterschema/redundant/unsatisfiable_max_contains.h
+++ b/src/extension/alterschema/redundant/unsatisfiable_max_contains.h
@@ -7,11 +7,12 @@ public:
             "equal to the array upper bound does not add any further "
             "constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/redundant/unsatisfiable_min_properties.h
+++ b/src/extension/alterschema/redundant/unsatisfiable_min_properties.h
@@ -6,11 +6,12 @@ public:
             "Setting `minProperties` to a number less than `required` does "
             "not add any further constraint"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/simplify/dependencies_property_tautology.h
+++ b/src/extension/alterschema/simplify/dependencies_property_tautology.h
@@ -7,11 +7,12 @@ public:
             "that is already marked as required is an unnecessarily complex "
             "use of `dependencies`"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(vocabularies,
                         {"http://json-schema.org/draft-07/schema#",
                          "http://json-schema.org/draft-06/schema#",

--- a/src/extension/alterschema/simplify/dependent_required_tautology.h
+++ b/src/extension/alterschema/simplify/dependent_required_tautology.h
@@ -7,11 +7,12 @@ public:
             "that is already marked as required is an unnecessarily complex "
             "use of `dependentRequired`"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/simplify/equal_numeric_bounds_to_enum.h
+++ b/src/extension/alterschema/simplify/equal_numeric_bounds_to_enum.h
@@ -6,11 +6,12 @@ public:
             "Setting `minimum` and `maximum` to the same number only leaves "
             "one possible value"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/simplify/maximum_real_for_integer.h
+++ b/src/extension/alterschema/simplify/maximum_real_for_integer.h
@@ -6,11 +6,12 @@ public:
             "If an instance is guaranteed to be an integer, setting a real "
             "number upper bound is the same as a floor of that upper bound"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/simplify/minimum_real_for_integer.h
+++ b/src/extension/alterschema/simplify/minimum_real_for_integer.h
@@ -6,11 +6,12 @@ public:
             "If an instance is guaranteed to be an integer, setting a real "
             "number lower bound is the same as a ceil of that lower bound"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/simplify/single_type_array.h
+++ b/src/extension/alterschema/simplify/single_type_array.h
@@ -5,11 +5,12 @@ public:
                             "Setting `type` to an array of a single type is "
                             "the same as directly declaring such type"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/superfluous/content_media_type_without_encoding.h
+++ b/src/extension/alterschema/superfluous/content_media_type_without_encoding.h
@@ -6,11 +6,12 @@ public:
             "The `contentMediaType` keyword is meaningless "
             "without the presence of the `contentEncoding` keyword"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(vocabularies,
                         {"https://json-schema.org/draft/2020-12/vocab/content",
                          "https://json-schema.org/draft/2019-09/vocab/content",

--- a/src/extension/alterschema/superfluous/content_schema_without_media_type.h
+++ b/src/extension/alterschema/superfluous/content_schema_without_media_type.h
@@ -6,11 +6,12 @@ public:
             "The `contentSchema` keyword is meaningless without the presence "
             "of the `contentMediaType` keyword"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/content",

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_applicator_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_applicator_2019_09.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_applicator_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_applicator_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_content_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_content_2019_09.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_content_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_content_2020_12.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_draft0.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_draft0.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-00/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_draft1.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_draft1.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-01/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_draft2.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_draft2.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-02/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_draft3.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_draft3.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-03/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_draft4.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_draft4.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-04/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_draft6.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_draft6.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-06/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_draft7.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_draft7.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-07/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_format_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_format_2019_09.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_format_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_format_2020_12.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_unevaluated_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_unevaluated_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_validation_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_validation_2019_09.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_array_keywords_validation_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_array_keywords_validation_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to arrays will never match if the "
             "instance is guaranteed to be an array"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_applicator_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_applicator_2019_09.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_applicator_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_applicator_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_content_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_content_2019_09.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_content_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_content_2020_12.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft0.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft0.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-00/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft1.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft1.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-01/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft2.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft2.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-02/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft3.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft3.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-03/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft4.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft4.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-04/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft6.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft6.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-06/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft7.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_draft7.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-07/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_format_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_format_2019_09.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_format_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_format_2020_12.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_unevaluated_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_unevaluated_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_validation_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_validation_2019_09.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_boolean_keywords_validation_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_boolean_keywords_validation_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to booleans will never match if the "
             "instance is guaranteed to be a boolean"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_applicator_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_applicator_2019_09.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_applicator_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_applicator_2020_12.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_content_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_content_2019_09.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_content_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_content_2020_12.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_draft0.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_draft0.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-00/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_draft1.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_draft1.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-01/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_draft2.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_draft2.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-02/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_draft3.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_draft3.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-03/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_draft4.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_draft4.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-04/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_draft6.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_draft6.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-06/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_draft7.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_draft7.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-07/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_format_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_format_2019_09.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_format_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_format_2020_12.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_unevaluated_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_unevaluated_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_validation_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_validation_2019_09.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_null_keywords_validation_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_null_keywords_validation_2020_12.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to null values will never match if the "
             "instance is guaranteed to be null"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_applicator_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_applicator_2019_09.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_applicator_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_applicator_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_content_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_content_2019_09.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_content_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_content_2020_12.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft0.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft0.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-00/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft1.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft1.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-01/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft2.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft2.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-02/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft3.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft3.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-03/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft4.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft4.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-04/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft6.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft6.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-06/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft7.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_draft7.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-07/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_format_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_format_2019_09.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_format_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_format_2020_12.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_unevaluated_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_unevaluated_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_validation_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_validation_2019_09.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_numeric_keywords_validation_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_numeric_keywords_validation_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to numbers will never match if the "
             "instance is guaranteed to be a number"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_applicator_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_applicator_2019_09.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_applicator_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_applicator_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_content_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_content_2019_09.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_content_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_content_2020_12.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_draft0.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_draft0.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-00/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_draft1.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_draft1.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-01/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_draft2.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_draft2.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-02/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_draft3.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_draft3.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-03/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_draft4.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_draft4.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-04/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_draft6.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_draft6.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-06/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_draft7.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_draft7.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-07/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_format_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_format_2019_09.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_format_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_format_2020_12.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_unevaluated_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_unevaluated_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_validation_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_validation_2019_09.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_object_keywords_validation_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_object_keywords_validation_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to objects will never match if the "
             "instance is guaranteed to be an object"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_string_keywords_applicator_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_string_keywords_applicator_2019_09.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to strings will never match if the "
             "instance is guaranteed to be a string"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_string_keywords_applicator_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_string_keywords_applicator_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to strings will never match if the "
             "instance is guaranteed to be a string"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_string_keywords_draft0.h
+++ b/src/extension/alterschema/superfluous/drop_non_string_keywords_draft0.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to strings will never match if the "
             "instance is guaranteed to be a string"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-00/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_string_keywords_draft1.h
+++ b/src/extension/alterschema/superfluous/drop_non_string_keywords_draft1.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to strings will never match if the "
             "instance is guaranteed to be a string"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-01/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_string_keywords_draft2.h
+++ b/src/extension/alterschema/superfluous/drop_non_string_keywords_draft2.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to strings will never match if the "
             "instance is guaranteed to be a string"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "http://json-schema.org/draft-02/hyper-schema#") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_string_keywords_draft3.h
+++ b/src/extension/alterschema/superfluous/drop_non_string_keywords_draft3.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to strings will never match if the "
             "instance is guaranteed to be a string"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-03/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_string_keywords_draft4.h
+++ b/src/extension/alterschema/superfluous/drop_non_string_keywords_draft4.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to strings will never match if the "
             "instance is guaranteed to be a string"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-04/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_string_keywords_draft6.h
+++ b/src/extension/alterschema/superfluous/drop_non_string_keywords_draft6.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to strings will never match if the "
             "instance is guaranteed to be a string"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-06/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_string_keywords_draft7.h
+++ b/src/extension/alterschema/superfluous/drop_non_string_keywords_draft7.h
@@ -6,11 +6,12 @@ public:
             "Keywords that don't apply to strings will never match if the "
             "instance is guaranteed to be a string"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains("http://json-schema.org/draft-07/schema#") &&
            schema.is_object() && schema.defines("type") &&
            schema.at("type").is_string() &&

--- a/src/extension/alterschema/superfluous/drop_non_string_keywords_unevaluated_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_string_keywords_unevaluated_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to strings will never match if the "
             "instance is guaranteed to be a string"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_string_keywords_validation_2019_09.h
+++ b/src/extension/alterschema/superfluous/drop_non_string_keywords_validation_2019_09.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to strings will never match if the "
             "instance is guaranteed to be a string"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2019-09/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/drop_non_string_keywords_validation_2020_12.h
+++ b/src/extension/alterschema/superfluous/drop_non_string_keywords_validation_2020_12.h
@@ -7,11 +7,12 @@ public:
             "Keywords that don't apply to strings will never match if the "
             "instance is guaranteed to be a string"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            schema.is_object() && schema.defines("type") &&

--- a/src/extension/alterschema/superfluous/duplicate_allof_branches.h
+++ b/src/extension/alterschema/superfluous/duplicate_allof_branches.h
@@ -8,11 +8,12 @@ public:
             "unnecessary additional validation that is guaranteed to not "
             "affect the validation result"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/applicator",

--- a/src/extension/alterschema/superfluous/duplicate_anyof_branches.h
+++ b/src/extension/alterschema/superfluous/duplicate_anyof_branches.h
@@ -8,11 +8,12 @@ public:
             "unnecessary additional validation that is guaranteed to not "
             "affect the validation result"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/applicator",

--- a/src/extension/alterschema/superfluous/else_without_if.h
+++ b/src/extension/alterschema/superfluous/else_without_if.h
@@ -5,11 +5,12 @@ public:
                             "The `else` keyword is meaningless "
                             "without the presence of the `if` keyword"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/applicator",

--- a/src/extension/alterschema/superfluous/if_without_then_else.h
+++ b/src/extension/alterschema/superfluous/if_without_then_else.h
@@ -6,11 +6,12 @@ public:
             "The `if` keyword is meaningless "
             "without the presence of the `then` or `else` keywords"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/applicator",

--- a/src/extension/alterschema/superfluous/max_contains_without_contains.h
+++ b/src/extension/alterschema/superfluous/max_contains_without_contains.h
@@ -6,11 +6,12 @@ public:
                             "without the presence of the `contains` keyword"} {
         };
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/superfluous/min_contains_without_contains.h
+++ b/src/extension/alterschema/superfluous/min_contains_without_contains.h
@@ -6,11 +6,12 @@ public:
                             "without the presence of the `contains` keyword"} {
         };
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/src/extension/alterschema/superfluous/then_without_if.h
+++ b/src/extension/alterschema/superfluous/then_without_if.h
@@ -5,11 +5,12 @@ public:
                             "The `then` keyword is meaningless "
                             "without the presence of the `if` keyword"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/applicator",

--- a/src/extension/alterschema/syntax_sugar/enum_to_const.h
+++ b/src/extension/alterschema/syntax_sugar/enum_to_const.h
@@ -5,11 +5,12 @@ public:
             "enum_to_const",
             "An `enum` of a single value can be expressed as `const`"} {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &vocabularies,
-      const sourcemeta::core::Pointer &, const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const std::set<std::string> &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &) const
+      -> bool override {
     return contains_any(
                vocabularies,
                {"https://json-schema.org/draft/2020-12/vocab/validation",

--- a/test/jsonschema/jsonschema_transform_rules.h
+++ b/test/jsonschema/jsonschema_transform_rules.h
@@ -10,8 +10,7 @@ public:
             "example_rule_1", "Keyword foo is not permitted") {};
 
   [[nodiscard]] auto
-  condition(const sourcemeta::core::JSON &schema, const std::string &,
-            const std::set<std::string> &, const sourcemeta::core::Pointer &,
+  condition(const sourcemeta::core::JSON &schema, const std::set<std::string> &,
             const sourcemeta::core::SchemaFrame &,
             const sourcemeta::core::SchemaFrame::Location &) const
       -> bool override {
@@ -30,8 +29,7 @@ public:
             "example_rule_2", "Keyword bar is not permitted") {};
 
   [[nodiscard]] auto
-  condition(const sourcemeta::core::JSON &schema, const std::string &,
-            const std::set<std::string> &, const sourcemeta::core::Pointer &,
+  condition(const sourcemeta::core::JSON &schema, const std::set<std::string> &,
             const sourcemeta::core::SchemaFrame &,
             const sourcemeta::core::SchemaFrame::Location &) const
       -> bool override {
@@ -49,12 +47,12 @@ public:
       : sourcemeta::core::SchemaTransformRule("example_rule_3",
                                               "Example rule 3") {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &, const sourcemeta::core::Pointer &pointer,
-      const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
-    return !schema.defines("top") && pointer.empty();
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema, const std::set<std::string> &,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &location) const
+      -> bool override {
+    return !schema.defines("top") && location.pointer.empty();
   }
 
   auto transform(sourcemeta::core::JSON &schema) const -> void override {
@@ -69,8 +67,7 @@ public:
                                               "Example rule 4") {};
 
   [[nodiscard]] auto
-  condition(const sourcemeta::core::JSON &schema, const std::string &,
-            const std::set<std::string> &, const sourcemeta::core::Pointer &,
+  condition(const sourcemeta::core::JSON &schema, const std::set<std::string> &,
             const sourcemeta::core::SchemaFrame &,
             const sourcemeta::core::SchemaFrame::Location &) const
       -> bool override {
@@ -88,13 +85,13 @@ public:
       : sourcemeta::core::SchemaTransformRule("example_rule_5",
                                               "Example rule 5") {};
 
-  [[nodiscard]] auto condition(
-      const sourcemeta::core::JSON &schema, const std::string &,
-      const std::set<std::string> &, const sourcemeta::core::Pointer &pointer,
-      const sourcemeta::core::SchemaFrame &,
-      const sourcemeta::core::SchemaFrame::Location &) const -> bool override {
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema, const std::set<std::string> &,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &location) const
+      -> bool override {
     return !schema.defines("baz") &&
-           pointer == sourcemeta::core::Pointer{"properties", "baz"};
+           location.pointer == sourcemeta::core::Pointer{"properties", "baz"};
   }
 
   auto transform(sourcemeta::core::JSON &schema) const -> void override {
@@ -109,8 +106,7 @@ public:
                                               "Example rule 6") {};
 
   [[nodiscard]] auto
-  condition(const sourcemeta::core::JSON &schema, const std::string &,
-            const std::set<std::string> &, const sourcemeta::core::Pointer &,
+  condition(const sourcemeta::core::JSON &schema, const std::set<std::string> &,
             const sourcemeta::core::SchemaFrame &,
             const sourcemeta::core::SchemaFrame::Location &location) const
       -> bool override {
@@ -130,8 +126,7 @@ public:
                                               "My custom message") {};
 
   [[nodiscard]] auto
-  condition(const sourcemeta::core::JSON &schema, const std::string &,
-            const std::set<std::string> &, const sourcemeta::core::Pointer &,
+  condition(const sourcemeta::core::JSON &schema, const std::set<std::string> &,
             const sourcemeta::core::SchemaFrame &,
             const sourcemeta::core::SchemaFrame::Location &) const
       -> bool override {
@@ -152,8 +147,7 @@ public:
             "Example rule that conflicts with rule 1") {};
 
   [[nodiscard]] auto
-  condition(const sourcemeta::core::JSON &schema, const std::string &,
-            const std::set<std::string> &, const sourcemeta::core::Pointer &,
+  condition(const sourcemeta::core::JSON &schema, const std::set<std::string> &,
             const sourcemeta::core::SchemaFrame &,
             const sourcemeta::core::SchemaFrame::Location &) const
       -> bool override {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
