### PR TITLE
Don't enforce `wrap()` URIs to be absolute (they could be relative)

### DIFF
--- a/src/core/jsonschema/jsonschema.cc
+++ b/src/core/jsonschema/jsonschema.cc
@@ -694,7 +694,6 @@ auto sourcemeta::core::unidentify(
 
 auto sourcemeta::core::wrap(const sourcemeta::core::JSON::String &identifier)
     -> sourcemeta::core::JSON {
-  assert(URI{identifier}.is_absolute());
   auto result{JSON::make_object()};
   // JSON Schema 2020-12 is the first dialect that truly supports cross-dialect
   // references In practice, others do, but we can play it safe here

--- a/test/jsonschema/jsonschema_wrap_test.cc
+++ b/test/jsonschema/jsonschema_wrap_test.cc
@@ -15,6 +15,20 @@ TEST(JSONSchema_wrap, identifier_without_fragment) {
   EXPECT_EQ(result, expected);
 }
 
+// Should still work, as people might be relying on relative URIs
+// as identifiers though still correctly resolving those
+TEST(JSONSchema_wrap, identifier_relative) {
+  const auto identifier{"/foo/bar"};
+  const auto result{sourcemeta::core::wrap(identifier)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "/foo/bar"
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
 TEST(JSONSchema_wrap, identifier_with_fragment) {
   const auto identifier{"https://www.example.com#/foo/bar"};
   const auto result{sourcemeta::core::wrap(identifier)};


### PR DESCRIPTION
See: https://github.com/sourcemeta/jsonschema/issues/304#issuecomment-2814383860
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
