### PR TITLE
style(clang-tidy): consume json_error.h directly

### DIFF
--- a/src/core/json/include/sourcemeta/core/json.h
+++ b/src/core/json/include/sourcemeta/core/json.h
@@ -5,7 +5,6 @@
 #include <sourcemeta/core/json_export.h>
 #endif
 
-#include <sourcemeta/core/json_error.h>
 #include <sourcemeta/core/json_hash.h>
 #include <sourcemeta/core/json_value.h>
 

--- a/src/core/json/parser.h
+++ b/src/core/json/parser.h
@@ -4,6 +4,7 @@
 #include "grammar.h"
 
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/json_error.h>
 
 #include <cassert>    // assert
 #include <cctype>     // std::isxdigit

--- a/src/core/jsonl/iterator.cc
+++ b/src/core/jsonl/iterator.cc
@@ -1,3 +1,4 @@
+#include <sourcemeta/core/json_error.h>
 #include <sourcemeta/core/jsonl_iterator.h>
 
 #include "grammar.h"

--- a/src/core/yaml/yaml.cc
+++ b/src/core/yaml/yaml.cc
@@ -1,3 +1,4 @@
+#include <sourcemeta/core/json_error.h>
 #include <sourcemeta/core/yaml.h>
 
 #include <sstream>     // std::ostringstream, std::istringstream

--- a/test/json/json_error_test.cc
+++ b/test/json/json_error_test.cc
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/json_error.h>
 
 #include <exception>   // std::exception
 #include <string>      // std::string

--- a/test/json/json_parse_error_test.cc
+++ b/test/json/json_parse_error_test.cc
@@ -4,6 +4,7 @@
 #include <sstream>
 
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/json_error.h>
 
 #define __EXPECT_PARSE_ERROR(input, expected_line, expected_column,            \
                              expected_error, expected_message)                 \

--- a/test/json/jsontestsuite.cc
+++ b/test/json/jsontestsuite.cc
@@ -1,4 +1,5 @@
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/json_error.h>
 
 #include <gtest/gtest.h>
 

--- a/test/jsonl/jsonl_parse_error_test.cc
+++ b/test/jsonl/jsonl_parse_error_test.cc
@@ -3,6 +3,7 @@
 #include <exception>
 #include <sstream>
 
+#include <sourcemeta/core/json_error.h>
 #include <sourcemeta/core/jsonl.h>
 
 #define EXPECT_PARSE_ERROR(stream, expected_line, expected_column)             \


### PR DESCRIPTION
json_error.h is indirectly included via json.h
Refs https://github.com/sourcemeta/blaze/issues/429