### PR TITLE
style(clang-tidy): Clean include headers of src/core/json

### DIFF
--- a/src/core/json/include/sourcemeta/core/json.h
+++ b/src/core/json/include/sourcemeta/core/json.h
@@ -5,7 +5,6 @@
 #include <sourcemeta/core/json_export.h>
 #endif
 
-#include <sourcemeta/core/json_hash.h>
 #include <sourcemeta/core/json_value.h>
 
 #include <cstdint>    // std::uint64_t

--- a/src/core/json/include/sourcemeta/core/json_error.h
+++ b/src/core/json/include/sourcemeta/core/json_error.h
@@ -1,8 +1,6 @@
 #ifndef SOURCEMETA_CORE_JSON_ERROR_H_
 #define SOURCEMETA_CORE_JSON_ERROR_H_
 
-#include <string>
-#include <utility>
 #ifndef SOURCEMETA_CORE_JSON_EXPORT
 #include <sourcemeta/core/json_export.h>
 #endif
@@ -10,6 +8,8 @@
 #include <cstdint>    // std::uint64_t
 #include <exception>  // std::exception
 #include <filesystem> // std::filesystem::path
+#include <string>     // std::string
+#include <utility>    // std::move
 
 namespace sourcemeta::core {
 

--- a/src/core/json/include/sourcemeta/core/json_error.h
+++ b/src/core/json/include/sourcemeta/core/json_error.h
@@ -1,6 +1,8 @@
 #ifndef SOURCEMETA_CORE_JSON_ERROR_H_
 #define SOURCEMETA_CORE_JSON_ERROR_H_
 
+#include <string>
+#include <utility>
 #ifndef SOURCEMETA_CORE_JSON_EXPORT
 #include <sourcemeta/core/json_export.h>
 #endif

--- a/src/core/json/include/sourcemeta/core/json_object.h
+++ b/src/core/json/include/sourcemeta/core/json_object.h
@@ -1,9 +1,9 @@
 #ifndef SOURCEMETA_CORE_JSON_OBJECT_H_
 #define SOURCEMETA_CORE_JSON_OBJECT_H_
 
-#include <algorithm>        // std::swap
-#include <cassert>          // assert
-#include <functional>       // std::equal_to, std::less
+#include <algorithm> // std::swap
+#include <cassert>   // assert
+#include <cstddef>
 #include <initializer_list> // std::initializer_list
 #include <iterator>         // std::advance
 #include <utility>          // std::pair, std::move

--- a/src/core/json/include/sourcemeta/core/json_object.h
+++ b/src/core/json/include/sourcemeta/core/json_object.h
@@ -1,9 +1,9 @@
 #ifndef SOURCEMETA_CORE_JSON_OBJECT_H_
 #define SOURCEMETA_CORE_JSON_OBJECT_H_
 
-#include <algorithm> // std::swap
-#include <cassert>   // assert
-#include <cstddef>  // std::size_t
+#include <algorithm>        // std::swap
+#include <cassert>          // assert
+#include <cstddef>          // std::size_t
 #include <initializer_list> // std::initializer_list
 #include <iterator>         // std::advance
 #include <utility>          // std::pair, std::move

--- a/src/core/json/include/sourcemeta/core/json_object.h
+++ b/src/core/json/include/sourcemeta/core/json_object.h
@@ -3,7 +3,7 @@
 
 #include <algorithm> // std::swap
 #include <cassert>   // assert
-#include <cstddef>
+#include <cstddef>  // std::size_t
 #include <initializer_list> // std::initializer_list
 #include <iterator>         // std::advance
 #include <utility>          // std::pair, std::move

--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -1,6 +1,7 @@
 #ifndef SOURCEMETA_CORE_JSON_VALUE_H_
 #define SOURCEMETA_CORE_JSON_VALUE_H_
 
+#include <cstddef>
 #ifndef SOURCEMETA_CORE_JSON_EXPORT
 #include <sourcemeta/core/json_export.h>
 #endif
@@ -15,7 +16,6 @@
 #include <functional>       // std::less, std::reference_wrapper, std::function
 #include <initializer_list> // std::initializer_list
 #include <memory>           // std::allocator
-#include <optional>         // std::optional
 #include <set>              // std::set
 #include <sstream>          // std::basic_istringstream
 #include <string>           // std::basic_string, std::char_traits

--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -1,7 +1,6 @@
 #ifndef SOURCEMETA_CORE_JSON_VALUE_H_
 #define SOURCEMETA_CORE_JSON_VALUE_H_
 
-#include <cstddef>
 #ifndef SOURCEMETA_CORE_JSON_EXPORT
 #include <sourcemeta/core/json_export.h>
 #endif
@@ -22,6 +21,7 @@
 #include <string_view>      // std::basic_string_view
 #include <type_traits>      // std::enable_if_t, std::is_same_v
 #include <utility>          // std::pair
+#include <cstddef>          // std::size_t
 
 namespace sourcemeta::core {
 

--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -11,6 +11,7 @@
 
 #include <algorithm>        // std::any_of
 #include <cassert>          // assert
+#include <cstddef>          // std::size_t
 #include <cstdint>          // std::int64_t, std::uint8_t
 #include <functional>       // std::less, std::reference_wrapper, std::function
 #include <initializer_list> // std::initializer_list
@@ -21,7 +22,6 @@
 #include <string_view>      // std::basic_string_view
 #include <type_traits>      // std::enable_if_t, std::is_same_v
 #include <utility>          // std::pair
-#include <cstddef>          // std::size_t
 
 namespace sourcemeta::core {
 

--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -5,13 +5,13 @@
 #include <sourcemeta/core/json_error.h>
 #include <sourcemeta/core/json_value.h>
 
-#include <cassert>        // assert
-#include <fstream>        // std::ifstream
-#include <system_error>   // std::make_error_code, std::errc
-#include <cstdint>        // std::uint64_t
-#include <filesystem>     // std::filesystem
-#include <istream>        // std::basic_istream
-#include <ostream>        // std::basic_ostream
+#include <cassert>      // assert
+#include <cstdint>      // std::uint64_t
+#include <filesystem>   // std::filesystem
+#include <fstream>      // std::ifstream
+#include <istream>      // std::basic_istream
+#include <ostream>      // std::basic_ostream
+#include <system_error> // std::make_error_code, std::errc
 
 namespace sourcemeta::core {
 

--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -1,19 +1,17 @@
 #include "parser.h"
-#include "sourcemeta/core/json_error.h"
-#include "sourcemeta/core/json_value.h"
 #include "stringify.h"
 
-#include <cstdint>
-#include <filesystem>
-#include <istream>
-#include <memory>
-#include <ostream>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/json_error.h>
+#include <sourcemeta/core/json_value.h>
 
-#include <cassert> // assert
-#include <fstream> // std::ifstream
-#include <string>
-#include <system_error> // std::make_error_code, std::errc
+#include <cassert>        // assert
+#include <fstream>        // std::ifstream
+#include <system_error>   // std::make_error_code, std::errc
+#include <cstdint>        // std::uint64_t
+#include <filesystem>     // std::filesystem
+#include <istream>        // std::basic_istream
+#include <ostream>        // std::basic_ostream
 
 namespace sourcemeta::core {
 

--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -1,10 +1,18 @@
 #include "parser.h"
+#include "sourcemeta/core/json_error.h"
+#include "sourcemeta/core/json_value.h"
 #include "stringify.h"
 
+#include <cstdint>
+#include <filesystem>
+#include <istream>
+#include <memory>
+#include <ostream>
 #include <sourcemeta/core/json.h>
 
-#include <cassert>      // assert
-#include <fstream>      // std::ifstream
+#include <cassert> // assert
+#include <fstream> // std::ifstream
+#include <string>
 #include <system_error> // std::make_error_code, std::errc
 
 namespace sourcemeta::core {

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -1,13 +1,20 @@
+#include "sourcemeta/core/json_array.h"
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
 #include <sourcemeta/core/json_value.h>
 
 #include <algorithm> // std::find
 #include <cassert>   // assert
 #include <cmath>     // std::isinf, std::isnan, std::modf, std::trunc
 #include <numeric>   // std::transform
+#include <sstream>
 #include <stdexcept> // std::invalid_argument
 #include <string>    // std::to_string
-#include <utility>   // std::move
-#include <vector>    // std::vector
+#include <string_view>
+#include <utility> // std::move
+#include <vector>  // std::vector
 
 namespace sourcemeta::core {
 

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -1,20 +1,20 @@
-#include "sourcemeta/core/json_array.h"
-#include <cstddef>
-#include <cstdint>
-#include <functional>
-#include <initializer_list>
+#include <sourcemeta/core/json_array.h>
 #include <sourcemeta/core/json_value.h>
 
-#include <algorithm> // std::find
-#include <cassert>   // assert
-#include <cmath>     // std::isinf, std::isnan, std::modf, std::trunc
-#include <numeric>   // std::transform
-#include <sstream>
-#include <stdexcept> // std::invalid_argument
-#include <string>    // std::to_string
-#include <string_view>
-#include <utility> // std::move
-#include <vector>  // std::vector
+#include <algorithm>          // std::find
+#include <cassert>            // assert
+#include <cmath>              // std::isinf, std::isnan, std::modf, std::trunc
+#include <numeric>            // std::transform
+#include <sstream>            // std::basic_istringstream
+#include <stdexcept>          // std::invalid_argument
+#include <string>             // std::to_string
+#include <string_view>        // std::basic_string_view
+#include <utility>            // std::move
+#include <vector>             // std::vector
+#include <cstddef>            // std::size_t
+#include <cstdint>            // std::int64_t
+#include <functional>         // std::reference_wrapper
+#include <initializer_list>   // std::initializer_list
 
 namespace sourcemeta::core {
 

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -1,20 +1,20 @@
 #include <sourcemeta/core/json_array.h>
 #include <sourcemeta/core/json_value.h>
 
-#include <algorithm>          // std::find
-#include <cassert>            // assert
-#include <cmath>              // std::isinf, std::isnan, std::modf, std::trunc
-#include <numeric>            // std::transform
-#include <sstream>            // std::basic_istringstream
-#include <stdexcept>          // std::invalid_argument
-#include <string>             // std::to_string
-#include <string_view>        // std::basic_string_view
-#include <utility>            // std::move
-#include <vector>             // std::vector
-#include <cstddef>            // std::size_t
-#include <cstdint>            // std::int64_t
-#include <functional>         // std::reference_wrapper
-#include <initializer_list>   // std::initializer_list
+#include <algorithm>        // std::find
+#include <cassert>          // assert
+#include <cmath>            // std::isinf, std::isnan, std::modf, std::trunc
+#include <cstddef>          // std::size_t
+#include <cstdint>          // std::int64_t
+#include <functional>       // std::reference_wrapper
+#include <initializer_list> // std::initializer_list
+#include <numeric>          // std::transform
+#include <sstream>          // std::basic_istringstream
+#include <stdexcept>        // std::invalid_argument
+#include <string>           // std::to_string
+#include <string_view>      // std::basic_string_view
+#include <utility>          // std::move
+#include <vector>           // std::vector
 
 namespace sourcemeta::core {
 

--- a/src/core/json/parser.h
+++ b/src/core/json/parser.h
@@ -8,6 +8,7 @@
 
 #include <cassert>    // assert
 #include <cctype>     // std::isxdigit
+#include <cstddef>    // std::size_t
 #include <cstdint>    // std::uint64_t
 #include <functional> // std::reference_wrapper
 #include <istream>    // std::basic_istream
@@ -16,7 +17,6 @@
 #include <stack>      // std::stack
 #include <stdexcept>  // std::out_of_range
 #include <string>     // std::basic_string, std::stol, std::stod, std::stoul
-#include <cstddef>    // std::size_t
 
 namespace sourcemeta::core::internal {
 

--- a/src/core/json/parser.h
+++ b/src/core/json/parser.h
@@ -2,10 +2,9 @@
 #define SOURCEMETA_CORE_JSON_PARSER_H_
 
 #include "grammar.h"
-#include "sourcemeta/core/json_value.h"
 
-#include <cstddef>
 #include <sourcemeta/core/json_error.h>
+#include <sourcemeta/core/json_value.h>
 
 #include <cassert>    // assert
 #include <cctype>     // std::isxdigit
@@ -17,6 +16,7 @@
 #include <stack>      // std::stack
 #include <stdexcept>  // std::out_of_range
 #include <string>     // std::basic_string, std::stol, std::stod, std::stoul
+#include <cstddef>    // std::size_t
 
 namespace sourcemeta::core::internal {
 

--- a/src/core/json/parser.h
+++ b/src/core/json/parser.h
@@ -2,8 +2,9 @@
 #define SOURCEMETA_CORE_JSON_PARSER_H_
 
 #include "grammar.h"
+#include "sourcemeta/core/json_value.h"
 
-#include <sourcemeta/core/json.h>
+#include <cstddef>
 #include <sourcemeta/core/json_error.h>
 
 #include <cassert>    // assert

--- a/src/core/json/stringify.h
+++ b/src/core/json/stringify.h
@@ -2,15 +2,19 @@
 #define SOURCEMETA_CORE_JSON_STRINGIFY_H_
 
 #include "grammar.h"
+#include "sourcemeta/core/json_value.h"
 
-#include <sourcemeta/core/json.h>
+#include <cstddef>
+#include <cstdint>
 
 #include <algorithm> // std::transform, std::sort
 #include <iomanip>   // std::setprecision
 #include <ios>       // std::noshowpoint, std::fixed
 #include <iterator>  // std::next, std::cbegin, std::cend, std::back_inserter
 #include <ostream>   // std::basic_ostream
-#include <string>    // std::to_string
+#include <sstream>
+#include <string> // std::to_string
+#include <vector>
 
 namespace sourcemeta::core::internal {
 constexpr auto LINE_WIDTH{80};

--- a/src/core/json/stringify.h
+++ b/src/core/json/stringify.h
@@ -2,19 +2,19 @@
 #define SOURCEMETA_CORE_JSON_STRINGIFY_H_
 
 #include "grammar.h"
-#include "sourcemeta/core/json_value.h"
 
-#include <cstddef>
-#include <cstdint>
+#include <sourcemeta/core/json_value.h>
 
-#include <algorithm> // std::transform, std::sort
-#include <iomanip>   // std::setprecision
-#include <ios>       // std::noshowpoint, std::fixed
-#include <iterator>  // std::next, std::cbegin, std::cend, std::back_inserter
-#include <ostream>   // std::basic_ostream
-#include <sstream>
-#include <string> // std::to_string
-#include <vector>
+#include <algorithm>  // std::transform, std::sort
+#include <iomanip>    // std::setprecision
+#include <ios>        // std::noshowpoint, std::fixed
+#include <iterator>   // std::next, std::cbegin, std::cend, std::back_inserter
+#include <ostream>    // std::basic_ostream
+#include <sstream>    // std::ostringstream
+#include <string>     // std::to_string
+#include <vector>     // std::vector
+#include <cstddef>    // std::size_t
+#include <cstdint>    // std::int64_t
 
 namespace sourcemeta::core::internal {
 constexpr auto LINE_WIDTH{80};

--- a/src/core/json/stringify.h
+++ b/src/core/json/stringify.h
@@ -5,16 +5,16 @@
 
 #include <sourcemeta/core/json_value.h>
 
-#include <algorithm>  // std::transform, std::sort
-#include <iomanip>    // std::setprecision
-#include <ios>        // std::noshowpoint, std::fixed
-#include <iterator>   // std::next, std::cbegin, std::cend, std::back_inserter
-#include <ostream>    // std::basic_ostream
-#include <sstream>    // std::ostringstream
-#include <string>     // std::to_string
-#include <vector>     // std::vector
-#include <cstddef>    // std::size_t
-#include <cstdint>    // std::int64_t
+#include <algorithm> // std::transform, std::sort
+#include <cstddef>   // std::size_t
+#include <cstdint>   // std::int64_t
+#include <iomanip>   // std::setprecision
+#include <ios>       // std::noshowpoint, std::fixed
+#include <iterator>  // std::next, std::cbegin, std::cend, std::back_inserter
+#include <ostream>   // std::basic_ostream
+#include <sstream>   // std::ostringstream
+#include <string>    // std::to_string
+#include <vector>    // std::vector
 
 namespace sourcemeta::core::internal {
 constexpr auto LINE_WIDTH{80};


### PR DESCRIPTION
Reported by clang-tidy check `misc-include-cleaner` 
Refs: https://github.com/sourcemeta/blaze/issues/429