### PR TITLE
Include clean src core jsonl

### DIFF
--- a/src/core/jsonl/include/sourcemeta/core/jsonl.h
+++ b/src/core/jsonl/include/sourcemeta/core/jsonl.h
@@ -1,11 +1,11 @@
 #ifndef SOURCEMETA_CORE_JSONL_H_
 #define SOURCEMETA_CORE_JSONL_H_
 
+#include "sourcemeta/core/json_value.h"
 #ifndef SOURCEMETA_CORE_JSONL_EXPORT
 #include <sourcemeta/core/jsonl_export.h>
 #endif
 
-#include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonl_iterator.h>
 
 #include <istream> // std::basic_istream

--- a/src/core/jsonl/include/sourcemeta/core/jsonl.h
+++ b/src/core/jsonl/include/sourcemeta/core/jsonl.h
@@ -1,11 +1,11 @@
 #ifndef SOURCEMETA_CORE_JSONL_H_
 #define SOURCEMETA_CORE_JSONL_H_
 
-#include "sourcemeta/core/json_value.h"
 #ifndef SOURCEMETA_CORE_JSONL_EXPORT
 #include <sourcemeta/core/jsonl_export.h>
 #endif
 
+#include <sourcemeta/core/json_value.h>
 #include <sourcemeta/core/jsonl_iterator.h>
 
 #include <istream> // std::basic_istream

--- a/src/core/jsonl/include/sourcemeta/core/jsonl_iterator.h
+++ b/src/core/jsonl/include/sourcemeta/core/jsonl_iterator.h
@@ -1,11 +1,10 @@
 #ifndef SOURCEMETA_CORE_JSONL_ITERATOR_H_
 #define SOURCEMETA_CORE_JSONL_ITERATOR_H_
 
+#include "sourcemeta/core/json_value.h"
 #ifndef SOURCEMETA_CORE_JSONL_EXPORT
 #include <sourcemeta/core/jsonl_export.h>
 #endif
-
-#include <sourcemeta/core/json.h>
 
 #include <cstddef>  // std::ptrdiff_t
 #include <cstdint>  // std::uint64_t

--- a/src/core/jsonl/include/sourcemeta/core/jsonl_iterator.h
+++ b/src/core/jsonl/include/sourcemeta/core/jsonl_iterator.h
@@ -1,10 +1,11 @@
 #ifndef SOURCEMETA_CORE_JSONL_ITERATOR_H_
 #define SOURCEMETA_CORE_JSONL_ITERATOR_H_
 
-#include "sourcemeta/core/json_value.h"
 #ifndef SOURCEMETA_CORE_JSONL_EXPORT
 #include <sourcemeta/core/jsonl_export.h>
 #endif
+
+#include <sourcemeta/core/json_value.h>
 
 #include <cstddef>  // std::ptrdiff_t
 #include <cstdint>  // std::uint64_t

--- a/src/core/jsonl/iterator.cc
+++ b/src/core/jsonl/iterator.cc
@@ -1,7 +1,10 @@
+#include <istream>
 #include <sourcemeta/core/json_error.h>
 #include <sourcemeta/core/jsonl_iterator.h>
 
 #include "grammar.h"
+#include "sourcemeta/core/json.h"
+#include "sourcemeta/core/json_value.h"
 
 #include <cassert> // assert
 

--- a/src/core/jsonl/iterator.cc
+++ b/src/core/jsonl/iterator.cc
@@ -1,12 +1,12 @@
-#include <istream>
+#include <sourcemeta/core/json.h>
 #include <sourcemeta/core/json_error.h>
+#include <sourcemeta/core/json_value.h>
 #include <sourcemeta/core/jsonl_iterator.h>
 
 #include "grammar.h"
-#include "sourcemeta/core/json.h"
-#include "sourcemeta/core/json_value.h"
 
 #include <cassert> // assert
+#include <istream> // std::basic_istream
 
 namespace sourcemeta::core {
 

--- a/src/core/jsonl/jsonl.cc
+++ b/src/core/jsonl/jsonl.cc
@@ -1,3 +1,5 @@
+#include "sourcemeta/core/json_value.h"
+#include <istream>
 #include <sourcemeta/core/jsonl.h>
 
 namespace sourcemeta::core {

--- a/src/core/jsonl/jsonl.cc
+++ b/src/core/jsonl/jsonl.cc
@@ -1,6 +1,7 @@
-#include "sourcemeta/core/json_value.h"
-#include <istream>
+#include <sourcemeta/core/json_value.h>
 #include <sourcemeta/core/jsonl.h>
+
+#include <istream> // std::basic_istream
 
 namespace sourcemeta::core {
 


### PR DESCRIPTION
Reported by clang-tidy check misc-include-cleaner
Refs: https://github.com/sourcemeta/blaze/issues/429