### PR TITLE
style(clang-tidy): Clean include headers of src/core/jsonpointer

### DIFF
--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
@@ -1,14 +1,14 @@
 #ifndef SOURCEMETA_CORE_JSONPOINTER_H_
 #define SOURCEMETA_CORE_JSONPOINTER_H_
 
-#include "sourcemeta/core/json_hash.h"
-#include "sourcemeta/core/json_value.h"
 #ifndef SOURCEMETA_CORE_JSONPOINTER_EXPORT
 #include <sourcemeta/core/jsonpointer_export.h>
 #endif
 
 #include <sourcemeta/core/uri.h>
 
+#include <sourcemeta/core/json_hash.h>
+#include <sourcemeta/core/json_value.h>
 #include <sourcemeta/core/jsonpointer.h>
 #include <sourcemeta/core/jsonpointer_pointer.h>
 #include <sourcemeta/core/jsonpointer_subpointer_walker.h>

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
@@ -1,17 +1,16 @@
 #ifndef SOURCEMETA_CORE_JSONPOINTER_H_
 #define SOURCEMETA_CORE_JSONPOINTER_H_
 
+#include "sourcemeta/core/json_hash.h"
+#include "sourcemeta/core/json_value.h"
 #ifndef SOURCEMETA_CORE_JSONPOINTER_EXPORT
 #include <sourcemeta/core/jsonpointer_export.h>
 #endif
 
-#include <sourcemeta/core/json.h>
 #include <sourcemeta/core/uri.h>
 
 #include <sourcemeta/core/jsonpointer.h>
-#include <sourcemeta/core/jsonpointer_error.h>
 #include <sourcemeta/core/jsonpointer_pointer.h>
-#include <sourcemeta/core/jsonpointer_position.h>
 #include <sourcemeta/core/jsonpointer_subpointer_walker.h>
 #include <sourcemeta/core/jsonpointer_template.h>
 #include <sourcemeta/core/jsonpointer_walker.h>

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
@@ -1,11 +1,11 @@
 #ifndef SOURCEMETA_CORE_JSONPOINTER_POINTER_H_
 #define SOURCEMETA_CORE_JSONPOINTER_POINTER_H_
 
-#include <cstddef>
 #include <sourcemeta/core/jsonpointer_token.h>
 
 #include <algorithm>        // std::copy, std::equal
 #include <cassert>          // assert
+#include <cstddef>          // std::size_t
 #include <functional>       // std::reference_wrapper
 #include <initializer_list> // std::initializer_list
 #include <iterator>         // std::advance, std::back_inserter

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
@@ -1,6 +1,7 @@
 #ifndef SOURCEMETA_CORE_JSONPOINTER_POINTER_H_
 #define SOURCEMETA_CORE_JSONPOINTER_POINTER_H_
 
+#include <cstddef>
 #include <sourcemeta/core/jsonpointer_token.h>
 
 #include <algorithm>        // std::copy, std::equal
@@ -8,7 +9,6 @@
 #include <functional>       // std::reference_wrapper
 #include <initializer_list> // std::initializer_list
 #include <iterator>         // std::advance, std::back_inserter
-#include <sstream>          // std::basic_ostringstream
 #include <type_traits>      // std::enable_if_t, std::is_same_v
 #include <utility>          // std::move
 #include <vector>           // std::vector

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
@@ -1,15 +1,15 @@
 #ifndef SOURCEMETA_CORE_JSONPOINTER_POSITION_H_
 #define SOURCEMETA_CORE_JSONPOINTER_POSITION_H_
 
-#include "sourcemeta/core/json_hash.h"
-#include "sourcemeta/core/json_value.h"
-#include <cstddef>
 #ifndef SOURCEMETA_CORE_JSONPOINTER_EXPORT
 #include <sourcemeta/core/jsonpointer_export.h>
 #endif
 
+#include <sourcemeta/core/json_hash.h>
+#include <sourcemeta/core/json_value.h>
 #include <sourcemeta/core/jsonpointer_pointer.h>
 
+#include <cstddef>  // std::size_t
 #include <cstdint>  // std::uint64_t
 #include <map>      // std::map
 #include <optional> // std::optional

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
@@ -1,11 +1,13 @@
 #ifndef SOURCEMETA_CORE_JSONPOINTER_POSITION_H_
 #define SOURCEMETA_CORE_JSONPOINTER_POSITION_H_
 
+#include "sourcemeta/core/json_hash.h"
+#include "sourcemeta/core/json_value.h"
+#include <cstddef>
 #ifndef SOURCEMETA_CORE_JSONPOINTER_EXPORT
 #include <sourcemeta/core/jsonpointer_export.h>
 #endif
 
-#include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer_pointer.h>
 
 #include <cstdint>  // std::uint64_t

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_subpointer_walker.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_subpointer_walker.h
@@ -4,8 +4,6 @@
 #include <cstddef>  // std::ptrdiff_t
 #include <iterator> // std::forward_iterator_tag
 
-#include <sourcemeta/core/jsonpointer_pointer.h>
-
 namespace sourcemeta::core {
 
 /// @ingroup jsonpointer

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
@@ -1,16 +1,15 @@
 #ifndef SOURCEMETA_CORE_JSONPOINTER_TEMPLATE_H_
 #define SOURCEMETA_CORE_JSONPOINTER_TEMPLATE_H_
 
-#include <initializer_list>
-
 #include <sourcemeta/core/regex.h>
 
-#include <algorithm> // std::copy, std::all_of
-#include <cassert>   // assert
-#include <iterator>  // std::back_inserter
-#include <optional>  // std::optional, std::nullopt
-#include <variant>   // std::variant, std::holds_alternative, std::get
-#include <vector>    // std::vector
+#include <algorithm>        // std::copy, std::all_of
+#include <cassert>          // assert
+#include <initializer_list> // std::initializer_list
+#include <iterator>         // std::back_inserter
+#include <optional>         // std::optional, std::nullopt
+#include <variant>          // std::variant, std::holds_alternative, std::get
+#include <vector>           // std::vector
 
 namespace sourcemeta::core {
 

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
@@ -1,8 +1,7 @@
 #ifndef SOURCEMETA_CORE_JSONPOINTER_TEMPLATE_H_
 #define SOURCEMETA_CORE_JSONPOINTER_TEMPLATE_H_
 
-#include <sourcemeta/core/jsonpointer_pointer.h>
-#include <sourcemeta/core/jsonpointer_token.h>
+#include <initializer_list>
 
 #include <sourcemeta/core/regex.h>
 

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_token.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_token.h
@@ -1,7 +1,7 @@
 #ifndef SOURCEMETA_CORE_JSONPOINTER_TOKEN_H_
 #define SOURCEMETA_CORE_JSONPOINTER_TOKEN_H_
 
-#include <sourcemeta/core/json.h>
+#include "sourcemeta/core/json_value.h"
 
 #include <cassert> // assert
 

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_token.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_token.h
@@ -1,7 +1,7 @@
 #ifndef SOURCEMETA_CORE_JSONPOINTER_TOKEN_H_
 #define SOURCEMETA_CORE_JSONPOINTER_TOKEN_H_
 
-#include "sourcemeta/core/json_value.h"
+#include <sourcemeta/core/json_value.h>
 
 #include <cassert> // assert
 

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_walker.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_walker.h
@@ -1,9 +1,10 @@
 #ifndef SOURCEMETA_CORE_JSONPOINTER_WALKER_H_
 #define SOURCEMETA_CORE_JSONPOINTER_WALKER_H_
 
-#include "sourcemeta/core/json_value.h"
-#include <cstddef>
-#include <vector> // std::vector
+#include <sourcemeta/core/json_value.h>
+
+#include <cstddef> // std::size_t
+#include <vector>  // std::vector
 
 namespace sourcemeta::core {
 

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_walker.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_walker.h
@@ -1,10 +1,9 @@
 #ifndef SOURCEMETA_CORE_JSONPOINTER_WALKER_H_
 #define SOURCEMETA_CORE_JSONPOINTER_WALKER_H_
 
+#include "sourcemeta/core/json_value.h"
+#include <cstddef>
 #include <vector> // std::vector
-
-#include <sourcemeta/core/json.h>
-#include <sourcemeta/core/jsonpointer_pointer.h>
 
 namespace sourcemeta::core {
 

--- a/src/core/jsonpointer/jsonpointer.cc
+++ b/src/core/jsonpointer/jsonpointer.cc
@@ -1,20 +1,20 @@
-#include <ostream>
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/json_hash.h>
+#include <sourcemeta/core/json_value.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/jsonpointer_pointer.h>
+#include <sourcemeta/core/uri.h>
 
 #include "grammar.h"
 #include "parser.h"
-#include "sourcemeta/core/json.h"
-#include "sourcemeta/core/json_hash.h"
-#include "sourcemeta/core/json_value.h"
-#include "sourcemeta/core/jsonpointer_pointer.h"
-#include "sourcemeta/core/uri.h"
 #include "stringify.h"
 
-#include <cassert>  // assert
-#include <iterator> // std::cbegin, std::cend, std::prev
-#include <memory>   // std::allocator
-#include <sstream>  // std::basic_ostringstream, std::basic_stringstream
-#include <string>
+#include <cassert>     // assert
+#include <iterator>    // std::cbegin, std::cend, std::prev
+#include <memory>      // std::allocator
+#include <ostream>     // std::basic_ostream
+#include <sstream>     // std::basic_ostringstream, std::basic_stringstream
+#include <string>      // std::basic_string
 #include <type_traits> // std::is_same_v
 #include <utility>     // std::move
 

--- a/src/core/jsonpointer/jsonpointer.cc
+++ b/src/core/jsonpointer/jsonpointer.cc
@@ -1,14 +1,20 @@
+#include <ostream>
 #include <sourcemeta/core/jsonpointer.h>
 
 #include "grammar.h"
 #include "parser.h"
+#include "sourcemeta/core/json.h"
+#include "sourcemeta/core/json_hash.h"
+#include "sourcemeta/core/json_value.h"
+#include "sourcemeta/core/jsonpointer_pointer.h"
+#include "sourcemeta/core/uri.h"
 #include "stringify.h"
 
-#include <cassert>     // assert
-#include <functional>  // std::reference_wrapper
-#include <iterator>    // std::cbegin, std::cend, std::prev
-#include <memory>      // std::allocator
-#include <sstream>     // std::basic_ostringstream, std::basic_stringstream
+#include <cassert>  // assert
+#include <iterator> // std::cbegin, std::cend, std::prev
+#include <memory>   // std::allocator
+#include <sstream>  // std::basic_ostringstream, std::basic_stringstream
+#include <string>
 #include <type_traits> // std::is_same_v
 #include <utility>     // std::move
 

--- a/src/core/jsonpointer/parser.h
+++ b/src/core/jsonpointer/parser.h
@@ -2,12 +2,12 @@
 #define SOURCEMETA_CORE_JSONPOINTER_PARSER_H_
 
 #include "grammar.h"
-#include "sourcemeta/core/json_value.h"
 
-#include <cstdint>
+#include <sourcemeta/core/json_value.h>
 #include <sourcemeta/core/jsonpointer.h>
 #include <sourcemeta/core/jsonpointer_error.h>
 
+#include <cstdint>   // std::uint64_t
 #include <istream>   // std::basic_istream
 #include <sstream>   // std::basic_stringstream
 #include <stdexcept> // std::out_of_range

--- a/src/core/jsonpointer/parser.h
+++ b/src/core/jsonpointer/parser.h
@@ -2,9 +2,11 @@
 #define SOURCEMETA_CORE_JSONPOINTER_PARSER_H_
 
 #include "grammar.h"
+#include "sourcemeta/core/json_value.h"
 
+#include <cstdint>
+#include <sourcemeta/core/jsonpointer.h>
 #include <sourcemeta/core/jsonpointer_error.h>
-#include <sourcemeta/core/jsonpointer_pointer.h>
 
 #include <istream>   // std::basic_istream
 #include <sstream>   // std::basic_stringstream

--- a/src/core/jsonpointer/position.cc
+++ b/src/core/jsonpointer/position.cc
@@ -1,3 +1,7 @@
+#include "sourcemeta/core/json_value.h"
+#include <cstddef>
+#include <cstdint>
+#include <optional>
 #include <sourcemeta/core/jsonpointer_position.h>
 
 #include <cassert> // assert

--- a/src/core/jsonpointer/position.cc
+++ b/src/core/jsonpointer/position.cc
@@ -1,10 +1,10 @@
-#include "sourcemeta/core/json_value.h"
-#include <cstddef>
-#include <cstdint>
-#include <optional>
+#include <sourcemeta/core/json_value.h>
 #include <sourcemeta/core/jsonpointer_position.h>
 
-#include <cassert> // assert
+#include <cassert>  // assert
+#include <cstddef>  // std::size_t
+#include <cstdint>  // std::uint64_t
+#include <optional> // std::optional
 
 namespace sourcemeta::core {
 

--- a/src/core/jsonpointer/stringify.h
+++ b/src/core/jsonpointer/stringify.h
@@ -2,14 +2,16 @@
 #define SOURCEMETA_CORE_JSONPOINTER_STRINGIFY_H_
 
 #include "grammar.h"
+#include "sourcemeta/core/json_value.h"
 
-#include <sourcemeta/core/json.h>
-#include <sourcemeta/core/jsonpointer_pointer.h>
+#include <cassert>
+#include <ios>
 #include <sourcemeta/core/uri.h>
 
 #include <ostream> // std::basic_ostream
 #include <sstream> // std::basic_istringstream
 #include <string>  // std::to_string, std::basic_string
+#include <variant> // std::holds_alternative
 
 namespace sourcemeta::core::internal {
 inline auto

--- a/src/core/jsonpointer/stringify.h
+++ b/src/core/jsonpointer/stringify.h
@@ -2,12 +2,12 @@
 #define SOURCEMETA_CORE_JSONPOINTER_STRINGIFY_H_
 
 #include "grammar.h"
-#include "sourcemeta/core/json_value.h"
 
-#include <cassert>
-#include <ios>
+#include <sourcemeta/core/json_value.h>
 #include <sourcemeta/core/uri.h>
 
+#include <cassert> // assert
+#include <ios>     // std::basic_ostream
 #include <ostream> // std::basic_ostream
 #include <sstream> // std::basic_istringstream
 #include <string>  // std::to_string, std::basic_string

--- a/test/jsonpointer/jsonpointer_error_test.cc
+++ b/test/jsonpointer/jsonpointer_error_test.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/jsonpointer_error.h>
 
 #include <exception>   // std::exception
 #include <string>      // std::string

--- a/test/jsonpointer/jsonpointer_parse_error_test.cc
+++ b/test/jsonpointer/jsonpointer_parse_error_test.cc
@@ -4,7 +4,9 @@
 #include <string>
 
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/json_error.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/jsonpointer_error.h>
 
 #define EXPECT_JSON_PARSE_ERROR(input)                                         \
   try {                                                                        \

--- a/test/jsonpointer/jsonpointer_position_test.cc
+++ b/test/jsonpointer/jsonpointer_position_test.cc
@@ -2,6 +2,7 @@
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/jsonpointer_position.h>
 
 TEST(JSONPointer_position, track_1) {
   const auto input{R"JSON([

--- a/test/jsonpointer/jsonpointer_token_test.cc
+++ b/test/jsonpointer/jsonpointer_token_test.cc
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 #include <type_traits>
 

--- a/test/jsonpointer/jsonpointer_weakpointer_test.cc
+++ b/test/jsonpointer/jsonpointer_weakpointer_test.cc
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 #include <type_traits>
 


### PR DESCRIPTION
Reported by clang-tidy check misc-include-cleaner
Refs: sourcemeta/blaze#429