### PR TITLE
Disable `MissingIncludes` in ClangTidy

### DIFF
--- a/cmake/common/targets/clang-tidy.config
+++ b/cmake/common/targets/clang-tidy.config
@@ -5,3 +5,8 @@ Checks: '-*,bugprone-*,clang-analyzer-*,clang-diagnostic-*,modernize-*,concurren
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 FormatStyle: none
+CheckOptions:
+  # See https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html
+  # Otherwise ClangTidy wants us to directly include private headers from our modules
+  - key: misc-include-cleaner.MissingIncludes
+    value: 'false'


### PR DESCRIPTION
See: https://github.com/sourcemeta/core/pull/1650#issuecomment-2906062409
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
