### PR TITLE
Implement a `JSON::at_or` method for objects

### DIFF
--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -761,6 +761,43 @@ public:
                         const typename Object::Container::hash_type hash)
       -> JSON &;
 
+  /// This method retrieves an object property or a user provided value if such
+  /// property is not defined.
+  ///
+  /// For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::JSON my_object =
+  ///   sourcemeta::core::parse_json("{ \"foo\": 1, \"bar\": 2 }");
+  /// const sourcemeta::core::JSON default_value{3};
+  /// assert(my_object.at_or("baz", default_value).to_integer() == 3);
+  /// ```
+  [[nodiscard]] auto at_or(const String &key, const JSON &otherwise) const
+      -> const JSON &;
+
+  /// This method retrieves an object property given a pre-calculated property
+  /// hash, or a user provided value if such property is not defined.
+  ///
+  /// For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::JSON my_object =
+  ///   sourcemeta::core::parse_json("{ \"foo\": 1, \"bar\": 2 }");
+  /// const sourcemeta::core::JSON default_value{3};
+  /// assert(my_object.at_or("foo",
+  ///   my_object.as_object().hash("foo"),
+  ///   default_value).to_integer() == 1);
+  /// ```
+  [[nodiscard]] auto at_or(const String &key,
+                           const typename Object::Container::hash_type hash,
+                           const JSON &otherwise) const -> const JSON &;
+
   /// This method retrieves a reference to the first element of a JSON array.
   /// This method is undefined if the input JSON instance is an empty array. For
   /// example:

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -504,6 +504,20 @@ JSON::at(const String &key,
   return this->data_object.data.at(key, hash);
 }
 
+[[nodiscard]] auto JSON::at_or(const String &key,
+                               const typename Object::Container::hash_type hash,
+                               const JSON &otherwise) const -> const JSON & {
+  assert(this->is_object());
+  const auto result{this->try_at(key, hash)};
+  return result ? *result : otherwise;
+}
+
+[[nodiscard]] auto JSON::at_or(const String &key, const JSON &otherwise) const
+    -> const JSON & {
+  assert(this->is_object());
+  return this->at_or(key, this->data_object.data.hash(key), otherwise);
+}
+
 [[nodiscard]] auto JSON::front() -> JSON & {
   assert(this->is_array());
   assert(!this->empty());

--- a/test/json/json_object_test.cc
+++ b/test/json/json_object_test.cc
@@ -779,3 +779,45 @@ TEST(JSON_object, merge_with_overlap) {
   EXPECT_FALSE(document.at("bar").to_boolean());
   EXPECT_EQ(document.at("baz").to_integer(), 9);
 }
+
+TEST(JSON_object, at_or_defined) {
+  const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}},
+                                        {"bar", sourcemeta::core::JSON{1}}};
+  const sourcemeta::core::JSON default_value{99};
+
+  const auto &result{document.at_or("foo", default_value)};
+  EXPECT_TRUE(result.is_boolean());
+  EXPECT_TRUE(result.to_boolean());
+}
+
+TEST(JSON_object, at_or_defined_with_hash) {
+  const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}},
+                                        {"bar", sourcemeta::core::JSON{1}}};
+  const sourcemeta::core::JSON default_value{99};
+
+  const auto hash{document.as_object().hash("foo")};
+  const auto &result{document.at_or("foo", hash, default_value)};
+  EXPECT_TRUE(result.is_boolean());
+  EXPECT_TRUE(result.to_boolean());
+}
+
+TEST(JSON_object, at_or_not_defined) {
+  const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}},
+                                        {"bar", sourcemeta::core::JSON{1}}};
+  const sourcemeta::core::JSON default_value{99};
+
+  const auto &result{document.at_or("baz", default_value)};
+  EXPECT_TRUE(result.is_integer());
+  EXPECT_EQ(result.to_integer(), 99);
+}
+
+TEST(JSON_object, at_or_not_defined_with_hash) {
+  const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}},
+                                        {"bar", sourcemeta::core::JSON{1}}};
+  const sourcemeta::core::JSON default_value{99};
+
+  const auto hash{document.as_object().hash("baz")};
+  const auto &result{document.at_or("baz", hash, default_value)};
+  EXPECT_TRUE(result.is_integer());
+  EXPECT_EQ(result.to_integer(), 99);
+}


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1694
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
