### PR TITLE
Implement a `JSON::trim` method for trimming strings

### DIFF
--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -1522,6 +1522,29 @@ public:
   /// ```
   auto merge(const JSON::Object &other) -> void;
 
+  /// Return a trimmed version of the string. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::core::JSON document{" \r\t  Hello World\n\v   \f"};
+  /// assert(document.trim() == "Hello World");
+  /// ```
+  [[nodiscard]] auto trim() const -> JSON::String;
+
+  /// Trim the string in-place. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::JSON document{" \r\t  Hello World\n\v   \f"};
+  /// document.trim();
+  /// assert(document.to_string() == "Hello World");
+  /// ```
+  auto trim() -> const JSON::String &;
+
   /*
    * Transform operations
    */

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -867,6 +867,21 @@ auto JSON::merge(const JSON::Object &other) -> void {
   }
 }
 
+[[nodiscard]] auto JSON::trim() const -> JSON::String {
+  assert(this->is_string());
+  auto copy = *this;
+  copy.trim();
+  return copy.to_string();
+}
+
+auto JSON::trim() -> const JSON::String & {
+  assert(this->is_string());
+  constexpr auto WHITESPACE = " \t\n\r\v\f";
+  this->data_string.erase(this->data_string.find_last_not_of(WHITESPACE) + 1);
+  this->data_string.erase(0, this->data_string.find_first_not_of(WHITESPACE));
+  return this->to_string();
+}
+
 auto JSON::rename(const JSON::String &key, JSON::String &&to) -> void {
   assert(this->is_object());
   auto &object{this->data_object};

--- a/test/json/json_string_test.cc
+++ b/test/json/json_string_test.cc
@@ -108,3 +108,16 @@ TEST(JSON_string, contains_character_false) {
   const sourcemeta::core::JSON document{"foo"};
   EXPECT_FALSE(document.contains('b'));
 }
+
+TEST(JSON_string, trim_const) {
+  const sourcemeta::core::JSON document{" \r\t  foo   bar\n\v   \f"};
+  EXPECT_EQ(document.trim(), "foo   bar");
+  EXPECT_EQ(document.to_string(), " \r\t  foo   bar\n\v   \f");
+}
+
+TEST(JSON_string, trim_in_place) {
+  sourcemeta::core::JSON document{" \r\t  foo   bar\n\v   \f"};
+  const auto &result{document.trim()};
+  EXPECT_EQ(result, "foo   bar");
+  EXPECT_EQ(document.to_string(), "foo   bar");
+}


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1696
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
