### PR TITLE
style(clang-tidy): fix cppcoreguidelines init variables

### DIFF
--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -359,7 +359,7 @@ auto JSON::operator-=(const JSON &substractive) -> JSON & {
     return false;
   } else if (this->is_real()) {
     const auto value{this->to_real()};
-    Real integral;
+    Real integral = 0.0;
     return !std::isinf(value) && !std::isnan(value) &&
            std::modf(value, &integral) == 0.0;
   } else {
@@ -659,14 +659,14 @@ JSON::at(const String &key,
   const auto dividend_value{this->as_real()};
 
   // Every real number that represents an integral is divisible by 0.5.
-  Real dividend_integral;
+  Real dividend_integral = 0;
   if (std::modf(dividend_value, &dividend_integral) == 0.0 &&
       divisor_value == 0.5) {
     return true;
   }
 
   const auto division{dividend_value / divisor_value};
-  Real integral;
+  Real integral = 0;
   return !std::isinf(division) && !std::isnan(division) &&
          std::modf(division, &integral) == 0.0;
 }

--- a/src/core/uri/uri.cc
+++ b/src/core/uri/uri.cc
@@ -20,7 +20,7 @@ static auto uri_normalize(UriUriA *uri) -> void {
 }
 
 static auto uri_to_string(const UriUriA *const uri) -> std::string {
-  int size;
+  int size = 0;
   if (uriToStringCharsRequiredA(uri, &size) != URI_SUCCESS) {
     throw sourcemeta::core::URIError{"Could not determine URI size"};
   }
@@ -48,7 +48,7 @@ static auto uri_text_range(const UriTextRangeA *const range)
 }
 
 static auto uri_parse(const std::string &data, UriUriA *uri) -> void {
-  const char *error_position;
+  const char *error_position = nullptr;
   switch (uriParseSingleUriA(uri, data.c_str(), &error_position)) {
     case URI_ERROR_SYNTAX:
       // TODO: Test the positions of this error


### PR DESCRIPTION
fixes: #1663