### PR TITLE
Implement a `URI::empty` method for checking if URIs are empty

### DIFF
--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -140,6 +140,17 @@ public:
   /// ```
   auto is_ipv6() const -> bool;
 
+  /// Check if the URI corresponds to the empty URI. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::URI uri{""};
+  /// assert(uri.empty());
+  /// ```
+  auto empty() const -> bool;
+
   /// Get the scheme part of the URI, if any. For example:
   ///
   /// ```cpp

--- a/src/core/uri/uri.cc
+++ b/src/core/uri/uri.cc
@@ -256,6 +256,13 @@ auto URI::is_fragment_only() const -> bool {
          this->fragment().has_value() && !this->query().has_value();
 }
 
+auto URI::empty() const -> bool {
+  return !this->path_.has_value() && !this->userinfo_.has_value() &&
+         !this->host_.has_value() && !this->port_.has_value() &&
+         !this->scheme_.has_value() && !this->fragment_.has_value() &&
+         !this->query_.has_value();
+}
+
 auto URI::scheme() const -> std::optional<std::string_view> {
   return this->scheme_;
 }

--- a/test/uri/CMakeLists.txt
+++ b/test/uri/CMakeLists.txt
@@ -2,6 +2,7 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME uri
   SOURCES
     uri_test.cc
     uri_fragment_test.cc
+    uri_empty_test.cc
     uri_host_test.cc
     uri_path_test.cc
     uri_parse_test.cc

--- a/test/uri/uri_empty_test.cc
+++ b/test/uri/uri_empty_test.cc
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/core/uri.h>
+
+TEST(URI_empty, empty) {
+  const sourcemeta::core::URI uri{""};
+  EXPECT_TRUE(uri.empty());
+}
+
+TEST(URI_empty, hier_only) {
+  const sourcemeta::core::URI uri{"example.com"};
+  EXPECT_FALSE(uri.empty());
+}
+
+TEST(URI_empty, path_only) {
+  const sourcemeta::core::URI uri{"/foo/bar"};
+  EXPECT_FALSE(uri.empty());
+}
+
+TEST(URI_empty, query_only) {
+  const sourcemeta::core::URI uri{"?foo=bar"};
+  EXPECT_FALSE(uri.empty());
+}
+
+TEST(URI_empty, fragment_only) {
+  const sourcemeta::core::URI uri{"#foo"};
+  EXPECT_FALSE(uri.empty());
+}
+
+TEST(URI_empty, fragment_empty_only) {
+  const sourcemeta::core::URI uri{"#"};
+  EXPECT_FALSE(uri.empty());
+}
+
+TEST(URI_empty, urn_path) {
+  const sourcemeta::core::URI uri{"urn:example:animal:ferret:nose"};
+  EXPECT_FALSE(uri.empty());
+}


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1712
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
