### PR TITLE
Throw `SchemaUnknownDialectError` in `metaschema()`

### DIFF
--- a/src/core/jsonschema/jsonschema.cc
+++ b/src/core/jsonschema/jsonschema.cc
@@ -236,8 +236,7 @@ auto sourcemeta::core::metaschema(
     const std::optional<std::string> &default_dialect) -> JSON {
   const auto maybe_dialect{sourcemeta::core::dialect(schema, default_dialect)};
   if (!maybe_dialect.has_value()) {
-    throw sourcemeta::core::SchemaError(
-        "Could not the determine dialect of the schema");
+    throw sourcemeta::core::SchemaUnknownDialectError();
   }
 
   const auto maybe_metaschema{resolver(maybe_dialect.value())};

--- a/test/jsonschema/jsonschema_metaschema_test.cc
+++ b/test/jsonschema/jsonschema_metaschema_test.cc
@@ -44,7 +44,7 @@ TEST(JSONSchema_metaschema, no_dialect) {
 
   EXPECT_THROW(sourcemeta::core::metaschema(
                    schema, sourcemeta::core::schema_official_resolver),
-               sourcemeta::core::SchemaError);
+               sourcemeta::core::SchemaUnknownDialectError);
 }
 
 TEST(JSONSchema_metaschema, unknown_dialect) {


### PR DESCRIPTION
See: https://github.com/sourcemeta/core/commit/483b23ce7dcf1c3d182fbb54607984b3cd83c8a7#r160222217
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
