### PR TITLE
style(clang-tidy): fix bugprone-branch-clone error

### DIFF
--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -355,15 +355,13 @@ auto JSON::operator-=(const JSON &substractive) -> JSON & {
 }
 
 [[nodiscard]] auto JSON::is_integer_real() const noexcept -> bool {
-  if (this->is_integer()) {
+  if (!this->is_real()) {
     return false;
-  } else if (this->is_real()) {
+  } else {
     const auto value{this->to_real()};
     Real integral = 0.0;
     return !std::isinf(value) && !std::isnan(value) &&
            std::modf(value, &integral) == 0.0;
-  } else {
-    return false;
   }
 }
 


### PR DESCRIPTION
Rest of the bugprone-branch-clone reports are false positives. The branches are different.
fixes #1654