### PR TITLE
Lint unnecessary `allOf` wrappers for `$ref` in 2019-09 and later

### DIFF
--- a/src/extension/alterschema/CMakeLists.txt
+++ b/src/extension/alterschema/CMakeLists.txt
@@ -138,6 +138,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME alterschema
     linter/drop_non_string_keywords_unevaluated_2020_12.h
     linter/drop_non_string_keywords_validation_2019_09.h
     linter/drop_non_string_keywords_validation_2020_12.h
+    linter/unnecessary_allof_ref_wrapper.h
     linter/duplicate_allof_branches.h
     linter/duplicate_anyof_branches.h
     linter/else_without_if.h

--- a/src/extension/alterschema/alterschema.cc
+++ b/src/extension/alterschema/alterschema.cc
@@ -169,6 +169,7 @@ template <typename T> auto every_item_is_boolean(const T &container) -> bool {
 #include "linter/then_without_if.h"
 #include "linter/unevaluated_items_default.h"
 #include "linter/unevaluated_properties_default.h"
+#include "linter/unnecessary_allof_ref_wrapper.h"
 #include "linter/unsatisfiable_max_contains.h"
 #include "linter/unsatisfiable_min_properties.h"
 } // namespace sourcemeta::core
@@ -273,6 +274,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode)
   bundle.add<DropNonStringKeywordsUnevaluated_2020_12>();
   bundle.add<DropNonStringKeywordsValidation_2019_09>();
   bundle.add<DropNonStringKeywordsValidation_2020_12>();
+  bundle.add<UnnecessaryAllOfRefWrapper>();
   bundle.add<DuplicateAllOfBranches>();
   bundle.add<DuplicateAnyOfBranches>();
   bundle.add<ElseWithoutIf>();

--- a/src/extension/alterschema/linter/unnecessary_allof_ref_wrapper.h
+++ b/src/extension/alterschema/linter/unnecessary_allof_ref_wrapper.h
@@ -1,0 +1,74 @@
+class UnnecessaryAllOfRefWrapper final : public SchemaTransformRule {
+public:
+  UnnecessaryAllOfRefWrapper()
+      : SchemaTransformRule{"unnecessary_allof_ref_wrapper",
+                            "Wrapping `$ref` in `allOf` is unnecessary in JSON "
+                            "Schema 2019-09 and later versions as `$ref` does "
+                            "not override sibling keywords anymore"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::core::Vocabularies &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &,
+            const sourcemeta::core::SchemaWalker &,
+            const sourcemeta::core::SchemaResolver &) const
+      -> sourcemeta::core::SchemaTransformRule::Result override {
+    if (!((vocabularies.contains(
+               "https://json-schema.org/draft/2020-12/vocab/core") &&
+           vocabularies.contains(
+               "https://json-schema.org/draft/2020-12/vocab/applicator")) ||
+          (vocabularies.contains(
+               "https://json-schema.org/draft/2019-09/vocab/core") &&
+           vocabularies.contains(
+               "https://json-schema.org/draft/2019-09/vocab/applicator")))) {
+      return false;
+    }
+
+    if (!schema.is_object() || schema.defines("$ref") ||
+        !schema.defines("allOf") || !schema.at("allOf").is_array() ||
+        schema.at("allOf").empty()) {
+      return false;
+    }
+
+    bool match{false};
+    for (const auto &entry : schema.at("allOf").as_array()) {
+      if (entry.is_object() && entry.defines("$ref")) {
+        if (match) {
+          return false;
+        } else {
+          match = true;
+        }
+      }
+    }
+
+    return match;
+  }
+
+  auto transform(JSON &schema) const -> void override {
+    // TODO: We should have a way for the condition to pass data to the
+    // transform, so we don't have to loop from scratch once more to figure out
+    // what index to remove
+    auto &array{schema.at("allOf").as_array()};
+    auto iterator{array.begin()};
+    for (; iterator != array.end(); ++iterator) {
+      if (iterator->is_object() && iterator->defines("$ref")) {
+        break;
+      }
+    }
+
+    assert(iterator != array.end());
+    auto reference{std::move(iterator->at("$ref"))};
+    if (iterator->size() == 1) {
+      schema.at("allOf").erase(iterator);
+      if (schema.at("allOf").empty()) {
+        schema.erase("allOf");
+      }
+    } else {
+      iterator->erase("$ref");
+    }
+
+    schema.assign("$ref", std::move(reference));
+  }
+};

--- a/test/alterschema/alterschema_lint_2019_09_test.cc
+++ b/test/alterschema/alterschema_lint_2019_09_test.cc
@@ -1570,3 +1570,113 @@ TEST(AlterSchema_lint_2019_09, equal_numeric_bounds_to_enum_2) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_2019_09, unnecessary_allof_ref_wrapper_1) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "allOf": [
+      { "$ref": "https://example.com" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "https://example.com"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2019_09, unnecessary_allof_ref_wrapper_2) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "allOf": [
+      { "$ref": "https://example.com/foo" },
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "allOf": [
+      { "$ref": "https://example.com/foo" },
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2019_09, unnecessary_allof_ref_wrapper_3) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "https://example.com/foo",
+    "allOf": [
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "https://example.com/foo",
+    "allOf": [
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2019_09, unnecessary_allof_ref_wrapper_4) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "allOf": [
+      { "type": "number" },
+      { "$ref": "https://example.com" },
+      { "type": "integer" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "https://example.com",
+    "allOf": [
+      { "type": "number" },
+      { "type": "integer" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2019_09, unnecessary_allof_ref_wrapper_5) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "allOf": [
+      { 
+        "type": "integer",
+        "$ref": "https://example.com"
+      }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "https://example.com",
+    "allOf": [
+      { "type": "integer" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -1732,3 +1732,113 @@ TEST(AlterSchema_lint_2020_12, equal_numeric_bounds_to_enum_2) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_2020_12, unnecessary_allof_ref_wrapper_1) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+      { "$ref": "https://example.com" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2020_12, unnecessary_allof_ref_wrapper_2) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+      { "$ref": "https://example.com/foo" },
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+      { "$ref": "https://example.com/foo" },
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2020_12, unnecessary_allof_ref_wrapper_3) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com/foo",
+    "allOf": [
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com/foo",
+    "allOf": [
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2020_12, unnecessary_allof_ref_wrapper_4) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+      { "type": "number" },
+      { "$ref": "https://example.com" },
+      { "type": "integer" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com",
+    "allOf": [
+      { "type": "number" },
+      { "type": "integer" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2020_12, unnecessary_allof_ref_wrapper_5) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+      {
+        "type": "integer",
+        "$ref": "https://example.com"
+      }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com",
+    "allOf": [
+      { "type": "integer" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_draft4_test.cc
+++ b/test/alterschema/alterschema_lint_draft4_test.cc
@@ -741,3 +741,23 @@ TEST(AlterSchema_lint_draft4, equal_numeric_bounds_to_enum_2) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft4, unnecessary_allof_ref_wrapper_1) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "allOf": [
+      { "$ref": "https://example.com" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "allOf": [
+      { "$ref": "https://example.com" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_draft6_test.cc
+++ b/test/alterschema/alterschema_lint_draft6_test.cc
@@ -1092,3 +1092,23 @@ TEST(AlterSchema_lint_draft6, equal_numeric_bounds_to_enum_2) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft6, unnecessary_allof_ref_wrapper_1) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "allOf": [
+      { "$ref": "https://example.com" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "allOf": [
+      { "$ref": "https://example.com" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -1188,3 +1188,23 @@ TEST(AlterSchema_lint_draft7, equal_numeric_bounds_to_enum_2) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft7, unnecessary_allof_ref_wrapper_1) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "allOf": [
+      { "$ref": "https://example.com" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "allOf": [
+      { "$ref": "https://example.com" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1737
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
