### PR TITLE
Fix `JSONFileParseError` to return a `const` reference of the path

### DIFF
--- a/src/core/json/include/sourcemeta/core/json_error.h
+++ b/src/core/json/include/sourcemeta/core/json_error.h
@@ -82,7 +82,7 @@ public:
         path_{path} {}
 
   /// Get the file path of the error
-  [[nodiscard]] auto path() const noexcept -> const std::filesystem::path {
+  [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
     return path_;
   }
 


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1741
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
