### PR TITLE
style(clang-tidy): Supress cppcoreguidelines-avoid-non-const-global-variables

### DIFF
--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -15,6 +15,7 @@
 
 namespace sourcemeta::core {
 
+//NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
                 std::uint64_t &line, std::uint64_t &column,
                 const JSON::ParseCallback &callback) -> JSON {
@@ -27,6 +28,7 @@ auto parse_json(const std::basic_string<JSON::Char, JSON::CharTraits> &input,
   return internal_parse_json(input, line, column, callback);
 }
 
+//NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
                 const JSON::ParseCallback &callback) -> JSON {
   std::uint64_t line{1};

--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -15,7 +15,7 @@
 
 namespace sourcemeta::core {
 
-//NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
                 std::uint64_t &line, std::uint64_t &column,
                 const JSON::ParseCallback &callback) -> JSON {
@@ -28,7 +28,7 @@ auto parse_json(const std::basic_string<JSON::Char, JSON::CharTraits> &input,
   return internal_parse_json(input, line, column, callback);
 }
 
-//NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
                 const JSON::ParseCallback &callback) -> JSON {
   std::uint64_t line{1};

--- a/src/core/yaml/yaml.cc
+++ b/src/core/yaml/yaml.cc
@@ -109,6 +109,7 @@ auto internal_parse_json(yaml_parser_t *parser) -> sourcemeta::core::JSON {
 
 namespace sourcemeta::core {
 
+//NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 auto parse_yaml(std::basic_istream<JSON::Char, JSON::CharTraits> &stream)
     -> JSON {
   std::basic_ostringstream<JSON::Char, JSON::CharTraits> buffer;

--- a/src/core/yaml/yaml.cc
+++ b/src/core/yaml/yaml.cc
@@ -109,7 +109,7 @@ auto internal_parse_json(yaml_parser_t *parser) -> sourcemeta::core::JSON {
 
 namespace sourcemeta::core {
 
-//NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 auto parse_yaml(std::basic_istream<JSON::Char, JSON::CharTraits> &stream)
     -> JSON {
   std::basic_ostringstream<JSON::Char, JSON::CharTraits> buffer;


### PR DESCRIPTION
… false positives

fixes #1662