### PR TITLE
style(clang-tidy): Fix `cppcoreguidelines-noexcept-move-operations` errors

### DIFF
--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -216,9 +216,9 @@ public:
 
   /// Misc constructors
   JSON(const JSON &);
-  JSON(JSON &&);
+  JSON(JSON &&) noexcept;
   auto operator=(const JSON &) -> JSON &;
-  auto operator=(JSON &&) -> JSON &;
+  auto operator=(JSON &&) noexcept -> JSON &;
 
   /// Destructor
   ~JSON();

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -117,7 +117,7 @@ JSON::JSON(const JSON &other) : current_type{other.current_type} {
   }
 }
 
-JSON::JSON(JSON &&other) : current_type{other.current_type} {
+JSON::JSON(JSON &&other) noexcept : current_type{other.current_type} {
   switch (other.current_type) {
     case Type::Boolean:
       this->data_boolean = other.data_boolean;
@@ -174,7 +174,7 @@ auto JSON::operator=(const JSON &other) -> JSON & {
   return *this;
 }
 
-auto JSON::operator=(JSON &&other) -> JSON & {
+auto JSON::operator=(JSON &&other) noexcept -> JSON & {
   this->maybe_destruct_union();
   this->current_type = other.current_type;
   switch (other.current_type) {

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -61,7 +61,7 @@ public:
   URI(const URI &other);
 
   /// Move constructor
-  URI(URI &&other);
+  URI(URI &&other) noexcept;
 
   /// Check if the URI is absolute. For example:
   ///

--- a/src/core/uri/uri.cc
+++ b/src/core/uri/uri.cc
@@ -138,7 +138,7 @@ URI::~URI() { uriFreeUriMembersA(&this->internal->uri); }
 // TODO: Test the copy constructor
 URI::URI(const URI &other) : URI{other.recompose()} {}
 
-URI::URI(URI &&other)
+URI::URI(URI &&other) noexcept
     : data{std::move(other.data)}, internal{std::move(other.internal)} {
   this->parsed = other.parsed;
   this->path_ = std::move(other.path_);


### PR DESCRIPTION
fixes #1666