### PR TITLE
style(clang-tidy): Disable `misc-const-correctness`

### DIFF
--- a/cmake/common/targets/clang-tidy.config
+++ b/cmake/common/targets/clang-tidy.config
@@ -11,7 +11,7 @@ Checks: '-*,
           performance-*,
           portability-*,
           objc-*,
-          misc-*,-misc-no-recursion'
+          misc-*,-misc-no-recursion,-misc-const-correctness'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 FormatStyle: none


### PR DESCRIPTION
closes #1675

Mostly reporting false positives, creating noise.
The check doesn't notice the modification after initialization properly.