### PR TITLE
style(clang-tidy): disable `misc-unused-parameters`

### DIFF
--- a/cmake/common/targets/clang-tidy.config
+++ b/cmake/common/targets/clang-tidy.config
@@ -11,7 +11,7 @@ Checks: '-*,
           performance-*,
           portability-*,
           objc-*,
-          misc-*,-misc-no-recursion'
+          misc-*,-misc-no-recursion,-misc-unused-parameters'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 FormatStyle: none


### PR DESCRIPTION
closes #1677

This doesn't understand the usage of parameter inside the function. The check is similar to the -Wunused-parameter compiler diagnostic. => This doesn't add much value but noise.