### PR TITLE
style(clang-tidy): partially fix misc-include-cleaner

### DIFF
--- a/src/core/uri/escaping.cc
+++ b/src/core/uri/escaping.cc
@@ -5,7 +5,10 @@
 #include <algorithm> // std::copy
 #include <cassert>   // assert
 #include <cctype>    // std::isalnum
+#include <istream>   // std::istream
+#include <ostream>   // std::ostream
 #include <sstream>   // std::ostringstream
+#include <string>    // std::string
 
 namespace sourcemeta::core {
 


### PR DESCRIPTION
Refs #1684