### PR TITLE
style(clang-tidy): fix `bugprone-return-const-ref-from-parameter`

### DIFF
--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -798,6 +798,16 @@ public:
                            const typename Object::Container::hash_type hash,
                            const JSON &otherwise) const -> const JSON &;
 
+  // Constant reference parameters can accept xvalues which will be destructed
+  // after the call. When the function returns such a parameter also as constant
+  // reference, then the returned reference can be used after the object it
+  // refers to has been destroyed.
+  // https://clang.llvm.org/extra/clang-tidy/checks/bugprone/return-const-ref-from-parameter.html
+  // This overload avoids mis-uses of retuning const reference parameter as
+  // constant reference.
+  [[nodiscard]] auto at_or(const String &key,
+                           const typename Object::Container::hash_type hash,
+                           JSON &&otherwise) const -> const JSON & = delete;
   /// This method retrieves a reference to the first element of a JSON array.
   /// This method is undefined if the input JSON instance is an empty array. For
   /// example:

--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -808,6 +808,7 @@ public:
   [[nodiscard]] auto at_or(const String &key,
                            const typename Object::Container::hash_type hash,
                            JSON &&otherwise) const -> const JSON & = delete;
+
   /// This method retrieves a reference to the first element of a JSON array.
   /// This method is undefined if the input JSON instance is an empty array. For
   /// example:


### PR DESCRIPTION
Reported with #1754
Refs #1657