### PR TITLE
style(clang-tidy): fix `bugprone-optional-value-conversion`

### DIFF
--- a/src/core/jsonschema/frame.cc
+++ b/src/core/jsonschema/frame.cc
@@ -579,15 +579,15 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
       if (this->mode_ == SchemaFrame::Mode::Instances) {
         store(this->locations_, this->instances_, SchemaReferenceType::Static,
               SchemaFrame::LocationType::Resource, default_id_canonical,
-              root_id.value(), root_id.value(), path,
-              sourcemeta::core::empty_pointer, root_dialect.value(),
-              root_base_dialect.value(), {{}}, std::nullopt);
+              root_id, root_id.value(), path, sourcemeta::core::empty_pointer,
+              root_dialect.value(), root_base_dialect.value(), {{}},
+              std::nullopt);
       } else {
         store(this->locations_, this->instances_, SchemaReferenceType::Static,
               SchemaFrame::LocationType::Resource, default_id_canonical,
-              root_id.value(), root_id.value(), path,
-              sourcemeta::core::empty_pointer, root_dialect.value(),
-              root_base_dialect.value(), {}, std::nullopt);
+              root_id, root_id.value(), path, sourcemeta::core::empty_pointer,
+              root_dialect.value(), root_base_dialect.value(), {},
+              std::nullopt);
       }
 
       base_uris.insert({path, {default_id_canonical}});

--- a/src/core/jsonschema/walker.cc
+++ b/src/core/jsonschema/walker.cc
@@ -415,7 +415,7 @@ sourcemeta::core::SchemaIterator::SchemaIterator(
     this->subschemas.push_back(std::move(entry));
   } else {
     const auto base_dialect{
-        sourcemeta::core::base_dialect(schema, resolver, dialect.value())};
+        sourcemeta::core::base_dialect(schema, resolver, dialect)};
     assert(base_dialect.has_value());
     walk(std::nullopt, pointer, instance_location, instance_location,
          this->subschemas, schema, walker, resolver, dialect.value(),
@@ -434,7 +434,7 @@ sourcemeta::core::SchemaIteratorFlat::SchemaIteratorFlat(
     sourcemeta::core::Pointer pointer;
     sourcemeta::core::PointerTemplate instance_location;
     const auto base_dialect{
-        sourcemeta::core::base_dialect(schema, resolver, dialect.value())};
+        sourcemeta::core::base_dialect(schema, resolver, dialect)};
     assert(base_dialect.has_value());
     walk(std::nullopt, pointer, instance_location, instance_location,
          this->subschemas, schema, walker, resolver, dialect.value(),

--- a/src/core/uri/uri.cc
+++ b/src/core/uri/uri.cc
@@ -532,7 +532,7 @@ auto URI::canonicalize() -> URI & {
                                      result_port.value() == 443};
 
     if (!is_default_http_port && !is_default_https_port) {
-      this->port_ = result_port.value();
+      this->port_ = result_port;
     } else {
       this->port_ = std::nullopt;
     }


### PR DESCRIPTION
Reported with #1754