### PR TITLE
style(clang-tidy): fix bugprone-exception-escape

### DIFF
--- a/src/core/jsonschema/frame.cc
+++ b/src/core/jsonschema/frame.cc
@@ -222,6 +222,8 @@ auto store(
   instances[pointer_from_root] = instance_locations;
 }
 
+// Check misunderstood struct to be a function
+// NOLINTNEXTLINE(bugprone-exception-escape)
 struct InternalEntry {
   const sourcemeta::core::SchemaIteratorEntry common;
   const std::optional<sourcemeta::core::JSON::String> id;
@@ -257,6 +259,8 @@ auto traverse_origin_instance_locations(
   }
 }
 
+// Check misunderstood struct to be a function
+// NOLINTNEXTLINE(bugprone-exception-escape)
 struct CacheSubschema {
   const sourcemeta::core::PointerTemplate instance_location{};
   const sourcemeta::core::PointerTemplate relative_instance_location{};


### PR DESCRIPTION
Two reports were about struct. We are suppressing them for now. Let's revisit when it creates noice on actual functions.