### PR TITLE
Linter: add rule to remove default multipleOf: 1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "cstddef": "cpp"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "cstddef": "cpp"
+    }
+}

--- a/src/extension/alterschema/CMakeLists.txt
+++ b/src/extension/alterschema/CMakeLists.txt
@@ -38,6 +38,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME alterschema
     linter/dependent_required_default.h
     linter/items_array_default.h
     linter/items_schema_default.h
+    linter/multiple_of_default.h
     linter/pattern_properties_default.h
     linter/properties_default.h
     linter/unevaluated_items_default.h

--- a/src/extension/alterschema/alterschema.cc
+++ b/src/extension/alterschema/alterschema.cc
@@ -73,6 +73,7 @@ static auto every_item_is_boolean(const T &container) -> bool {
 #include "linter/maximum_real_for_integer.h"
 #include "linter/min_contains_without_contains.h"
 #include "linter/minimum_real_for_integer.h"
+#include "linter/multiple_of_default.h"
 #include "linter/non_applicable_type_specific_keywords.h"
 #include "linter/pattern_properties_default.h"
 #include "linter/properties_default.h"
@@ -141,6 +142,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode)
       bundle.add<DependentRequiredDefault>();
       bundle.add<ItemsArrayDefault>();
       bundle.add<ItemsSchemaDefault>();
+      bundle.add<MultipleOfDefault>();
       bundle.add<PatternPropertiesDefault>();
       bundle.add<PropertiesDefault>();
       bundle.add<UnevaluatedItemsDefault>();

--- a/src/extension/alterschema/linter/multiple_of_default.h
+++ b/src/extension/alterschema/linter/multiple_of_default.h
@@ -22,7 +22,6 @@ public:
                 "http://json-schema.org/draft-06/schema#",
                 "http://json-schema.org/draft-04/schema#"}) &&
            schema.is_object() && schema.defines("multipleOf") &&
-           schema.at("multipleOf").is_number() &&
            ((schema.at("multipleOf").is_integer() &&
              schema.at("multipleOf").to_integer() == 1) ||
             (schema.at("multipleOf").is_real() &&

--- a/src/extension/alterschema/linter/multiple_of_default.h
+++ b/src/extension/alterschema/linter/multiple_of_default.h
@@ -1,0 +1,35 @@
+class MultipleOfDefault final : public SchemaTransformRule {
+public:
+  MultipleOfDefault()
+      : SchemaTransformRule{
+            "multiple_of_default",
+            "Setting `multipleOf` to 1 does not add any further constraint"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::core::Vocabularies &vocabularies,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &,
+            const sourcemeta::core::SchemaWalker &,
+            const sourcemeta::core::SchemaResolver &) const
+      -> sourcemeta::core::SchemaTransformRule::Result override {
+    return contains_any(
+               vocabularies,
+               {"https://json-schema.org/draft/2020-12/vocab/validation",
+                "https://json-schema.org/draft/2019-09/vocab/validation",
+                "http://json-schema.org/draft-07/schema#",
+                "http://json-schema.org/draft-06/schema#",
+                "http://json-schema.org/draft-04/schema#"}) &&
+           schema.is_object() && schema.defines("multipleOf") &&
+           schema.at("multipleOf").is_number() &&
+           ((schema.at("multipleOf").is_integer() &&
+             schema.at("multipleOf").to_integer() == 1) ||
+            (schema.at("multipleOf").is_real() &&
+             schema.at("multipleOf").to_real() == 1.0));
+  }
+
+  auto transform(JSON &schema) const -> void override {
+    schema.erase("multipleOf");
+  }
+};

--- a/test/alterschema/alterschema_lint_2019_09_test.cc
+++ b/test/alterschema/alterschema_lint_2019_09_test.cc
@@ -1661,8 +1661,7 @@ TEST(AlterSchema_lint_2019_09, unnecessary_allof_ref_wrapper_5) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "allOf": [
-      { 
-        "type": "integer",
+      { "type": "integer",
         "$ref": "https://example.com"
       }
     ]
@@ -1676,6 +1675,40 @@ TEST(AlterSchema_lint_2019_09, unnecessary_allof_ref_wrapper_5) {
     "allOf": [
       { "type": "integer" }
     ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2019_09, multiple_of_default_1) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "integer",
+    "multipleOf": 1
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "integer"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2019_09, multiple_of_default_2) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "multipleOf": 1.0,
+    "contains": { "type": "string" }
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "contains": { "type": "string" }
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_2019_09_test.cc
+++ b/test/alterschema/alterschema_lint_2019_09_test.cc
@@ -1661,7 +1661,8 @@ TEST(AlterSchema_lint_2019_09, unnecessary_allof_ref_wrapper_5) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "allOf": [
-      { "type": "integer",
+      { 
+        "type": "integer",
         "$ref": "https://example.com"
       }
     ]

--- a/test/alterschema/alterschema_lint_2019_09_test.cc
+++ b/test/alterschema/alterschema_lint_2019_09_test.cc
@@ -1713,3 +1713,39 @@ TEST(AlterSchema_lint_2019_09, multiple_of_default_2) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_2019_09, multiple_of_default_3) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "multipleOf": 1.2,
+    "type": "number"
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "multipleOf": 1.2,
+    "type": "number"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2019_09, multiple_of_default_no_change_1) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "integer",
+    "multipleOf": 2
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "integer",
+    "multipleOf": 2
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -1842,3 +1842,55 @@ TEST(AlterSchema_lint_2020_12, unnecessary_allof_ref_wrapper_5) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_2020_12, multiple_of_default_1) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "integer",
+    "multipleOf": 1
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "integer"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2020_12, multiple_of_default_2) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "multipleOf": 1.0,
+    "unevaluatedProperties": false
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "unevaluatedProperties": false
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2020_12, multiple_of_default_no_change_string_value) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "integer",
+    "multipleOf": "1"
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "integer",
+    "multipleOf": "1"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -1894,3 +1894,21 @@ TEST(AlterSchema_lint_2020_12, multiple_of_default_no_change_string_value) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_2020_12, multiple_of_default_no_change_numeric_value) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "number",
+    "multipleOf": 2.5
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "number",
+    "multipleOf": 2.5
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_draft4_test.cc
+++ b/test/alterschema/alterschema_lint_draft4_test.cc
@@ -761,3 +761,126 @@ TEST(AlterSchema_lint_draft4, unnecessary_allof_ref_wrapper_1) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft4, multiple_of_default_1) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "integer",
+    "multipleOf": 1
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "integer"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_draft4, multiple_of_default_2) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "number",
+    "multipleOf": 1.0
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "number"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_draft4, multiple_of_default_3) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "multipleOf": 1,
+    "minimum": 0
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "minimum": 0
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_draft4, multiple_of_default_no_change_1) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "integer",
+    "multipleOf": 2
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "integer",
+    "multipleOf": 2
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_draft4, multiple_of_default_no_change_2) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "number",
+    "multipleOf": 0.5
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "number",
+    "multipleOf": 0.5
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_draft4, multiple_of_default_no_change_zero) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "number",
+    "multipleOf": 0
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "number",
+    "multipleOf": 0
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_draft4, multiple_of_default_no_change_negative) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "number",
+    "multipleOf": -1
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "number",
+    "multipleOf": -1
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_draft6_test.cc
+++ b/test/alterschema/alterschema_lint_draft6_test.cc
@@ -1112,3 +1112,37 @@ TEST(AlterSchema_lint_draft6, unnecessary_allof_ref_wrapper_1) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft6, multiple_of_default_1) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": "integer",
+    "multipleOf": 1
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": "integer"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_draft6, multiple_of_default_2) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "multipleOf": 1.0,
+    "maximum": 100
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "maximum": 100
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -1208,3 +1208,41 @@ TEST(AlterSchema_lint_draft7, unnecessary_allof_ref_wrapper_1) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(AlterSchema_lint_draft7, multiple_of_default_1) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "integer",
+    "multipleOf": 1
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "integer"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_draft7, multiple_of_default_2) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "multipleOf": 1,
+    "properties": {
+      "age": { "type": "number" }
+    }
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "age": { "type": "number" }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}


### PR DESCRIPTION
### Implementation

**Rule ID**: multiple_of_default
**Description**: "Setting multipleOf to 1 does not add any further constraint"
**Condition**: Detects multipleOf: 1 (integer) or multipleOf: 1.0 (real) in JSON Schema objects
**Transform**: Removes the redundant multipleOf property
**Dialects**: Supports draft4, draft6, draft7, 2019-09, and 2020-12

- Registered the rule in the Readability mode (not common rules) since it removes redundant default values
- Properly categorized alongside other Default rules like AdditionalPropertiesDefault
- Comprehensive Test Coverage: Added 16 test cases across all supported JSON Schema drafts:

### Test cases: 
Positive cases: multipleOf: 1 and multipleOf: 1.0 removal
Negative cases: No change for non-1 values (multipleOf: 2, multipleOf: 0.5)
Edge cases: String values ("1"), zero (0), negative (-1) - all correctly preserved
Context preservation: Tests with various other keywords to ensure proper behavior