### PR TITLE
Fix `to_json<WeakPointer>` incorrectly returning an `std::optional`

### DIFF
--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
@@ -579,7 +579,7 @@ auto to_json(const T &value) -> JSON {
 /// Serialise a WeakPointer as JSON
 template <typename T>
   requires std::is_same_v<T, WeakPointer>
-auto to_json(const T &value) -> std::optional<JSON> {
+auto to_json(const T &value) -> JSON {
   return JSON{to_string(value)};
 }
 

--- a/test/jsonpointer/jsonpointer_json_auto_test.cc
+++ b/test/jsonpointer/jsonpointer_json_auto_test.cc
@@ -6,6 +6,7 @@ TEST(JSONPointer_json_auto, foo_bar_baz) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const auto result{sourcemeta::core::to_json(pointer)};
   const sourcemeta::core::JSON expected{"/foo/bar/baz"};
+  EXPECT_EQ(result.size(), 12);
   EXPECT_EQ(result, expected);
   const auto back{
       sourcemeta::core::from_json<sourcemeta::core::Pointer>(result)};
@@ -37,5 +38,6 @@ TEST(JSONWeakPointer_json_auto, to_json_foo_bar_baz) {
 
   const auto result{sourcemeta::core::to_json(pointer)};
   const sourcemeta::core::JSON expected{"/foo/bar/baz"};
+  EXPECT_EQ(result.size(), 12);
   EXPECT_EQ(result, expected);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
