### PR TITLE
Update `allOf` in-place when removing artificial `$ref` wrappers

### DIFF
--- a/src/extension/alterschema/linter/unnecessary_allof_ref_wrapper.h
+++ b/src/extension/alterschema/linter/unnecessary_allof_ref_wrapper.h
@@ -59,16 +59,17 @@ public:
     }
 
     assert(iterator != array.end());
-    auto reference{std::move(iterator->at("$ref"))};
-    if (iterator->size() == 1) {
-      schema.at("allOf").erase(iterator);
-      if (schema.at("allOf").empty()) {
-        schema.erase("allOf");
-      }
-    } else {
-      iterator->erase("$ref");
-    }
 
-    schema.assign("$ref", std::move(reference));
+    auto reference{iterator->at("$ref")};
+    if (iterator->size() > 1) {
+      schema.try_assign_before("$ref", std::move(reference), "allOf");
+      iterator->erase("$ref");
+    } else if (schema.at("allOf").size() == 1) {
+      schema.at("allOf").into(std::move(reference));
+      schema.rename("allOf", "$ref");
+    } else {
+      schema.try_assign_before("$ref", std::move(reference), "allOf");
+      schema.at("allOf").erase(iterator);
+    }
   }
 };

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -1843,6 +1843,109 @@ TEST(AlterSchema_lint_2020_12, unnecessary_allof_ref_wrapper_5) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(AlterSchema_lint_2020_12, unnecessary_allof_ref_wrapper_6) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+      { "$ref": "https://example.com" }
+    ],
+    "title": "Foo"
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com",
+    "title": "Foo"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+
+  // We expect the `$ref` keyword to take the place of `allOf` in
+  // terms of keyword ordering
+  std::vector<sourcemeta::core::JSON::String> keywords;
+  for (const auto &entry : document.as_object()) {
+    keywords.emplace_back(entry.first);
+  }
+
+  EXPECT_EQ(keywords.size(), 3);
+  EXPECT_EQ(keywords.at(0), "$schema");
+  EXPECT_EQ(keywords.at(1), "$ref");
+  EXPECT_EQ(keywords.at(2), "title");
+}
+
+TEST(AlterSchema_lint_2020_12, unnecessary_allof_ref_wrapper_7) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+      { "$ref": "https://example.com" },
+      { "type": "string" }
+    ],
+    "title": "Foo"
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com",
+    "allOf": [
+      { "type": "string" }
+    ],
+    "title": "Foo"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+
+  // We expect the `$ref` keyword to take the place of `allOf` in
+  // terms of keyword ordering
+  std::vector<sourcemeta::core::JSON::String> keywords;
+  for (const auto &entry : document.as_object()) {
+    keywords.emplace_back(entry.first);
+  }
+
+  EXPECT_EQ(keywords.size(), 4);
+  EXPECT_EQ(keywords.at(0), "$schema");
+  EXPECT_EQ(keywords.at(1), "$ref");
+  EXPECT_EQ(keywords.at(2), "allOf");
+  EXPECT_EQ(keywords.at(3), "title");
+}
+
+TEST(AlterSchema_lint_2020_12, unnecessary_allof_ref_wrapper_8) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "allOf": [
+      { "type": "string", "$ref": "https://example.com" }
+    ],
+    "title": "Foo"
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com",
+    "allOf": [ { "type": "string" } ],
+    "title": "Foo"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+
+  // We expect the `$ref` keyword to take the place of `allOf` in
+  // terms of keyword ordering
+  std::vector<sourcemeta::core::JSON::String> keywords;
+  for (const auto &entry : document.as_object()) {
+    keywords.emplace_back(entry.first);
+  }
+
+  EXPECT_EQ(keywords.size(), 4);
+  EXPECT_EQ(keywords.at(0), "$schema");
+  EXPECT_EQ(keywords.at(1), "$ref");
+  EXPECT_EQ(keywords.at(2), "allOf");
+  EXPECT_EQ(keywords.at(3), "title");
+}
+
 TEST(AlterSchema_lint_2020_12, multiple_of_default_1) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1826
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
