### PR TITLE
Add `const` iterators to `SchemaTransformer`

### DIFF
--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_transform.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_transform.h
@@ -242,6 +242,9 @@ public:
              const std::optional<JSON::String> &default_id = std::nullopt) const
       -> bool;
 
+  auto begin() const -> auto { return this->rules.cbegin(); }
+  auto end() const -> auto { return this->rules.cend(); }
+
 private:
 // Exporting symbols that depends on the standard C++ library is considered
 // safe.

--- a/test/jsonschema/jsonschema_transformer_test.cc
+++ b/test/jsonschema/jsonschema_transformer_test.cc
@@ -3,6 +3,7 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonschema.h>
 
+#include <set>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -1186,4 +1187,21 @@ TEST(JSONSchema_transformer, rereference_fixed_7) {
   })JSON");
 
   EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_transformer, iterators) {
+  sourcemeta::core::SchemaTransformer bundle;
+  bundle.add<ExampleRule1>();
+  bundle.add<ExampleRule2>();
+  bundle.add<ExampleRule3>();
+
+  std::set<std::string> rules;
+  for (const auto &entry : bundle) {
+    rules.insert(entry.first);
+  }
+
+  EXPECT_EQ(rules.size(), 3);
+  EXPECT_TRUE(rules.contains("example_rule_1"));
+  EXPECT_TRUE(rules.contains("example_rule_2"));
+  EXPECT_TRUE(rules.contains("example_rule_3"));
 }


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1836
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
