### PR TITLE
Remove redundant cxx standard

### DIFF
--- a/cmake/common/clang-tidy.cmake
+++ b/cmake/common/clang-tidy.cmake
@@ -112,7 +112,6 @@ function(sourcemeta_clang_tidy_attempt_enable)
       OUTPUT_VARIABLE MACOSX_RESOURCE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
     set(CMAKE_CXX_CLANG_TIDY
       "${CLANG_TIDY_BIN};--config-file=${CLANG_TIDY_CONFIG};-header-filter=${PROJECT_SOURCE_DIR}/src/*"
-      "--extra-arg=-std=c++${CMAKE_CXX_STANDARD}"
       "--extra-arg=-isysroot"
       "--extra-arg=${MACOSX_SDK_PATH}"
       "--extra-arg=-resource-dir=${MACOSX_RESOURCE_PATH}"


### PR DESCRIPTION
C++ Standard flag is available in the compilation database.