### PR TITLE
Extend `PointerPositionTracker` with a `to_json` method

### DIFF
--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
@@ -54,6 +54,7 @@ public:
   [[nodiscard]] auto get(const Pointer &pointer) const
       -> std::optional<Position>;
   [[nodiscard]] auto size() const -> std::size_t;
+  [[nodiscard]] auto to_json() const -> JSON;
 
 private:
 // Exporting symbols that depends on the standard C++ library is considered

--- a/src/core/jsonpointer/position.cc
+++ b/src/core/jsonpointer/position.cc
@@ -1,5 +1,5 @@
 #include <sourcemeta/core/json_value.h>
-#include <sourcemeta/core/jsonpointer_position.h>
+#include <sourcemeta/core/jsonpointer.h>
 
 #include <cassert>  // assert
 #include <cstddef>  // std::size_t
@@ -42,6 +42,15 @@ auto PointerPositionTracker::get(const Pointer &pointer) const
 
 auto PointerPositionTracker::size() const -> std::size_t {
   return this->data.size();
+}
+
+auto PointerPositionTracker::to_json() const -> JSON {
+  auto result{JSON::make_object()};
+  for (const auto &entry : this->data) {
+    result.assign(to_string(entry.first),
+                  sourcemeta::core::to_json(entry.second));
+  }
+  return result;
 }
 
 } // namespace sourcemeta::core

--- a/test/jsonpointer/jsonpointer_position_test.cc
+++ b/test/jsonpointer/jsonpointer_position_test.cc
@@ -37,3 +37,26 @@ TEST(JSONPointer_position, track_1) {
   EXPECT_EQ(tracker.get(pointer_4).value(),
             sourcemeta::core::PointerPositionTracker::Position({4, 14, 4, 14}));
 }
+
+TEST(JSONPointer_position, to_json_1) {
+  const auto input{R"JSON([
+  {
+    "foo": {
+      "bar": 3
+    }
+  }
+])JSON"};
+
+  sourcemeta::core::PointerPositionTracker tracker;
+  sourcemeta::core::parse_json(input, std::ref(tracker));
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "": [ 1, 1, 7, 1 ],
+    "/0": [ 2, 3, 6, 3 ],
+    "/0/foo": [ 3, 12, 5, 5 ],
+    "/0/foo/bar": [ 4, 14, 4, 14 ]
+  })JSON")};
+
+  EXPECT_EQ(tracker.to_json(), expected);
+  EXPECT_EQ(sourcemeta::core::to_json(tracker), expected);
+}


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1854
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
