### PR TITLE
Support `unsigned long long` in `to_json()`

### DIFF
--- a/src/core/json/include/sourcemeta/core/json_auto.h
+++ b/src/core/json/include/sourcemeta/core/json_auto.h
@@ -209,9 +209,18 @@ auto from_json(const JSON &value) -> std::optional<T> {
 
 /// @ingroup json
 template <typename T>
-  requires std::constructible_from<JSON, T>
+  requires(std::constructible_from<JSON, T> &&
+           // Otherwise MSVC gets confused
+           !std::is_same_v<T, unsigned long long>)
 auto to_json(const T &value) -> JSON {
   return JSON{value};
+}
+
+/// @ingroup json
+template <typename T>
+  requires std::is_same_v<T, unsigned long long>
+auto to_json(const T value) -> JSON {
+  return JSON{static_cast<std::int64_t>(value)};
 }
 
 /// @ingroup json

--- a/test/json/json_auto_test.cc
+++ b/test/json/json_auto_test.cc
@@ -286,6 +286,16 @@ TEST(JSON_auto, unordered_set_without_iterators) {
   EXPECT_EQ(value, back.value());
 }
 
+TEST(JSON_auto, unsigned_long_long) {
+  const unsigned long long value{15};
+  const auto result{sourcemeta::core::to_json(value)};
+  const auto expected{sourcemeta::core::JSON{15}};
+  EXPECT_EQ(result, expected);
+  const auto back{sourcemeta::core::from_json<unsigned long long>(result)};
+  EXPECT_TRUE(back.has_value());
+  EXPECT_EQ(value, back.value());
+}
+
 TEST(JSON_auto, pair) {
   const std::pair<std::string, std::size_t> value{"foo", 1};
   const auto result{sourcemeta::core::to_json(value)};


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1851
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
