### PR TITLE
Fix ClangTidy GZIP warnings

### DIFF
--- a/src/core/gzip/gzip.cc
+++ b/src/core/gzip/gzip.cc
@@ -114,8 +114,8 @@ auto gzip(std::istream &stream) -> std::string {
   return output.str();
 }
 
-auto gzip(std::string input) -> std::string {
-  std::istringstream stream{std::move(input)};
+auto gzip(const std::string &input) -> std::string {
+  std::istringstream stream{input};
   return gzip(stream);
 }
 
@@ -125,8 +125,8 @@ auto gunzip(std::istream &stream) -> std::string {
   return output.str();
 }
 
-auto gunzip(std::string input) -> std::string {
-  std::istringstream stream{std::move(input)};
+auto gunzip(const std::string &input) -> std::string {
+  std::istringstream stream{input};
   return gunzip(stream);
 }
 

--- a/src/core/gzip/include/sourcemeta/core/gzip.h
+++ b/src/core/gzip/include/sourcemeta/core/gzip.h
@@ -70,7 +70,7 @@ SOURCEMETA_CORE_GZIP_EXPORT auto gzip(std::istream &stream) -> std::string;
 /// const auto result{sourcemeta::core::gzip("Hello World")};
 /// assert(!result.empty());
 /// ```
-SOURCEMETA_CORE_GZIP_EXPORT auto gzip(std::string input) -> std::string;
+SOURCEMETA_CORE_GZIP_EXPORT auto gzip(const std::string &input) -> std::string;
 
 /// @ingroup gzip
 ///
@@ -118,7 +118,8 @@ SOURCEMETA_CORE_GZIP_EXPORT auto gunzip(std::istream &stream) -> std::string;
 /// const auto result{sourcemeta::core::gunzip("Hello World")};
 /// assert(result == "Hello World");
 /// ```
-SOURCEMETA_CORE_GZIP_EXPORT auto gunzip(std::string input) -> std::string;
+SOURCEMETA_CORE_GZIP_EXPORT auto gunzip(const std::string &input)
+    -> std::string;
 
 } // namespace sourcemeta::core
 


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1893
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
