### PR TITLE
Add backticks around `$ref` in `draft_ref_siblings.h`

### DIFF
--- a/src/extension/alterschema/linter/draft_ref_siblings.h
+++ b/src/extension/alterschema/linter/draft_ref_siblings.h
@@ -3,7 +3,7 @@ public:
   DraftRefSiblings()
       : SchemaTransformRule{"draft_ref_siblings",
                             "In Draft 7 and older dialects, keywords sibling "
-                            "to $ref are never evaluated"} {}
+                            "to `$ref` are never evaluated"} {}
 
   [[nodiscard]] auto
   condition(const sourcemeta::core::JSON &schema,


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
