### PR TITLE
Make `BuildAdapterFilesystem::mark` thread safe

### DIFF
--- a/src/extension/build/adapter_filesystem.cc
+++ b/src/extension/build/adapter_filesystem.cc
@@ -4,6 +4,7 @@
 
 #include <cassert> // assert
 #include <fstream> // std::ofstream
+#include <mutex>   // std::unique_lock
 
 namespace sourcemeta::core {
 
@@ -76,24 +77,30 @@ auto BuildAdapterFilesystem::refresh(const node_type &path) -> void {
   // too much on file-system specific non-sense
   const auto value{std::filesystem::file_time_type::clock::now()};
   // Because builds are typically ran in parallel
-  std::lock_guard<std::mutex> lock{this->mutex};
+  std::unique_lock lock{this->mutex};
   this->marks.insert_or_assign(path, value);
 }
 
-auto BuildAdapterFilesystem::mark(const node_type &path) const
+auto BuildAdapterFilesystem::mark(const node_type &path)
     -> std::optional<mark_type> {
   assert(path.is_absolute());
-  if (std::filesystem::exists(path)) {
+
+  {
+    // Because a read operation while a write operation is taking place is
+    // undefined behaviour
+    std::shared_lock lock{this->mutex};
     const auto match{this->marks.find(path)};
-    if (match == this->marks.cend()) {
-      // Keep in mind that depending on the OS, filesystem, and even standard
-      // library implementation, this value might not be very reliable. In fact,
-      // in many cases it can be outdated. Therefore, we never cache this value
-      return std::filesystem::last_write_time(path);
-    } else {
+    if (match != this->marks.end()) {
       return match->second;
     }
-  } else {
+  }
+
+  try {
+    // Keep in mind that depending on the OS, filesystem, and even standard
+    // library implementation, this value might not be very reliable. In fact,
+    // in many cases it can be outdated. Therefore, we never cache this value
+    return std::filesystem::last_write_time(path);
+  } catch (const std::filesystem::filesystem_error &) {
     return std::nullopt;
   }
 }

--- a/src/extension/build/include/sourcemeta/core/build_adapter_filesystem.h
+++ b/src/extension/build/include/sourcemeta/core/build_adapter_filesystem.h
@@ -10,8 +10,8 @@
 // NOLINTEND(misc-include-cleaner)
 
 #include <filesystem>    // std::filesystem
-#include <mutex>         // std::mutex, std::lock_guard
 #include <optional>      // std::optional
+#include <shared_mutex>  // std::shared_mutex
 #include <string>        // std::string
 #include <unordered_map> // std::unordered_map
 
@@ -34,10 +34,7 @@ public:
                           const BuildDependencies<node_type> &dependencies)
       -> void;
   auto refresh(const node_type &path) -> void;
-
-  [[nodiscard]] auto mark(const node_type &path) const
-      -> std::optional<mark_type>;
-
+  [[nodiscard]] auto mark(const node_type &path) -> std::optional<mark_type>;
   [[nodiscard]] auto is_newer_than(const mark_type left,
                                    const mark_type right) const -> bool;
 
@@ -50,7 +47,7 @@ private:
 #endif
   std::string extension{".deps"};
   std::unordered_map<node_type, mark_type> marks;
-  std::mutex mutex;
+  std::shared_mutex mutex;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251 4275)
 #endif


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
