### PR TITLE
Get rid of `mutable` in AlterSchema rules

### DIFF
--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_transform.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_transform.h
@@ -135,7 +135,7 @@ private:
 
   /// The rule transformation. If this virtual method is not overriden,
   /// then the rule condition is considered to not be fixable.
-  virtual auto transform(JSON &schema) const -> void;
+  virtual auto transform(JSON &schema, const Result &result) const -> void;
 
 // Exporting symbols that depends on the standard C++ library is considered
 // safe.

--- a/src/core/jsonschema/transformer.cc
+++ b/src/core/jsonschema/transformer.cc
@@ -39,7 +39,7 @@ auto SchemaTransformRule::message() const -> const std::string & {
   return this->message_;
 }
 
-auto SchemaTransformRule::transform(JSON &) const -> void {
+auto SchemaTransformRule::transform(JSON &, const Result &) const -> void {
   throw SchemaAbortError("This rule cannot be automatically transformed");
 }
 
@@ -64,7 +64,7 @@ auto SchemaTransformRule::apply(JSON &schema, const JSON &root,
   }
 
   try {
-    this->transform(schema);
+    this->transform(schema, outcome);
   } catch (const SchemaAbortError &) {
     return {false, std::move(outcome)};
   }

--- a/src/extension/alterschema/canonicalizer/boolean_true.h
+++ b/src/extension/alterschema/canonicalizer/boolean_true.h
@@ -17,7 +17,7 @@ public:
     return schema.is_boolean() && schema.to_boolean();
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.into(sourcemeta::core::JSON::make_object());
   }
 };

--- a/src/extension/alterschema/canonicalizer/const_as_enum.h
+++ b/src/extension/alterschema/canonicalizer/const_as_enum.h
@@ -25,7 +25,7 @@ public:
     return APPLIES_TO_KEYWORDS("const");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     auto values = sourcemeta::core::JSON::make_array();
     values.push_back(schema.at("const"));
     schema.at("const").into(std::move(values));

--- a/src/extension/alterschema/canonicalizer/exclusive_maximum_integer_to_maximum.h
+++ b/src/extension/alterschema/canonicalizer/exclusive_maximum_integer_to_maximum.h
@@ -30,7 +30,7 @@ public:
     return APPLIES_TO_KEYWORDS("exclusiveMaximum", "type");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     if (schema.at("exclusiveMaximum").is_integer()) {
       auto new_maximum = schema.at("exclusiveMaximum");
       new_maximum += sourcemeta::core::JSON{-1};

--- a/src/extension/alterschema/canonicalizer/exclusive_minimum_integer_to_minimum.h
+++ b/src/extension/alterschema/canonicalizer/exclusive_minimum_integer_to_minimum.h
@@ -30,7 +30,7 @@ public:
     return APPLIES_TO_KEYWORDS("exclusiveMinimum", "type");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     if (schema.at("exclusiveMinimum").is_integer()) {
       auto new_minimum = schema.at("exclusiveMinimum");
       new_minimum += sourcemeta::core::JSON{1};

--- a/src/extension/alterschema/canonicalizer/max_contains_covered_by_max_items.h
+++ b/src/extension/alterschema/canonicalizer/max_contains_covered_by_max_items.h
@@ -29,7 +29,7 @@ public:
     return APPLIES_TO_KEYWORDS("maxContains", "maxItems");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.assign("maxContains", schema.at("maxItems"));
   }
 };

--- a/src/extension/alterschema/canonicalizer/min_items_given_min_contains.h
+++ b/src/extension/alterschema/canonicalizer/min_items_given_min_contains.h
@@ -27,7 +27,7 @@ public:
     return true;
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     if (schema.defines("contains") && schema.defines("minContains") &&
         schema.at("minContains").is_integer()) {
       schema.assign("minItems", sourcemeta::core::JSON{

--- a/src/extension/alterschema/canonicalizer/min_items_implicit.h
+++ b/src/extension/alterschema/canonicalizer/min_items_implicit.h
@@ -28,7 +28,7 @@ public:
     return true;
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.assign("minItems", sourcemeta::core::JSON{0});
   }
 };

--- a/src/extension/alterschema/canonicalizer/min_length_implicit.h
+++ b/src/extension/alterschema/canonicalizer/min_length_implicit.h
@@ -31,7 +31,7 @@ public:
     return true;
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.assign("minLength", sourcemeta::core::JSON{0});
   }
 };

--- a/src/extension/alterschema/canonicalizer/min_properties_covered_by_required.h
+++ b/src/extension/alterschema/canonicalizer/min_properties_covered_by_required.h
@@ -31,7 +31,7 @@ public:
     return APPLIES_TO_KEYWORDS("minProperties", "required");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.assign("minProperties",
                   sourcemeta::core::JSON{schema.at("required").size()});
   }

--- a/src/extension/alterschema/canonicalizer/min_properties_implicit.h
+++ b/src/extension/alterschema/canonicalizer/min_properties_implicit.h
@@ -29,7 +29,7 @@ public:
     return true;
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     if (schema.defines("required") && schema.at("required").is_array()) {
       schema.assign("minProperties",
                     sourcemeta::core::JSON{schema.at("required").size()});

--- a/src/extension/alterschema/canonicalizer/multiple_of_implicit.h
+++ b/src/extension/alterschema/canonicalizer/multiple_of_implicit.h
@@ -28,7 +28,7 @@ public:
     return true;
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.assign("multipleOf", sourcemeta::core::JSON{1});
   }
 };

--- a/src/extension/alterschema/canonicalizer/properties_implicit.h
+++ b/src/extension/alterschema/canonicalizer/properties_implicit.h
@@ -37,7 +37,7 @@ public:
     return true;
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.assign("properties", sourcemeta::core::JSON::make_object());
   }
 };

--- a/src/extension/alterschema/canonicalizer/type_array_to_any_of_2020_12.h
+++ b/src/extension/alterschema/canonicalizer/type_array_to_any_of_2020_12.h
@@ -45,7 +45,7 @@ public:
     return APPLIES_TO_KEYWORDS("type");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     const std::set<std::string> keep{"$schema", "$id", "$anchor",
                                      "$dynamicAnchor", "$vocabulary"};
     auto disjunctors{sourcemeta::core::JSON::make_array()};

--- a/src/extension/alterschema/canonicalizer/type_boolean_as_enum.h
+++ b/src/extension/alterschema/canonicalizer/type_boolean_as_enum.h
@@ -32,7 +32,7 @@ public:
     return APPLIES_TO_KEYWORDS("type");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     auto choices = sourcemeta::core::JSON::make_array();
     choices.push_back(sourcemeta::core::JSON{false});
     choices.push_back(sourcemeta::core::JSON{true});

--- a/src/extension/alterschema/canonicalizer/type_null_as_enum.h
+++ b/src/extension/alterschema/canonicalizer/type_null_as_enum.h
@@ -32,7 +32,7 @@ public:
     return APPLIES_TO_KEYWORDS("type");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     auto choices = sourcemeta::core::JSON::make_array();
     choices.push_back(sourcemeta::core::JSON{nullptr});
     schema.at("type").into(std::move(choices));

--- a/src/extension/alterschema/canonicalizer/type_union_implicit.h
+++ b/src/extension/alterschema/canonicalizer/type_union_implicit.h
@@ -77,7 +77,7 @@ public:
     return true;
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     auto types{sourcemeta::core::JSON::make_array()};
 
     // All possible JSON Schema types

--- a/src/extension/alterschema/linter/additional_items_with_schema_items.h
+++ b/src/extension/alterschema/linter/additional_items_with_schema_items.h
@@ -26,7 +26,7 @@ public:
     return APPLIES_TO_KEYWORDS("additionalItems", "items");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("additionalItems");
   }
 };

--- a/src/extension/alterschema/linter/additional_properties_default.h
+++ b/src/extension/alterschema/linter/additional_properties_default.h
@@ -35,7 +35,7 @@ public:
     return APPLIES_TO_KEYWORDS("additionalProperties");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("additionalProperties");
   }
 };

--- a/src/extension/alterschema/linter/const_with_type.h
+++ b/src/extension/alterschema/linter/const_with_type.h
@@ -44,5 +44,7 @@ public:
     return APPLIES_TO_KEYWORDS("const", "type");
   }
 
-  auto transform(JSON &schema) const -> void override { schema.erase("type"); }
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("type");
+  }
 };

--- a/src/extension/alterschema/linter/content_media_type_without_encoding.h
+++ b/src/extension/alterschema/linter/content_media_type_without_encoding.h
@@ -25,7 +25,7 @@ public:
     return APPLIES_TO_KEYWORDS("contentMediaType");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("contentMediaType");
   }
 };

--- a/src/extension/alterschema/linter/content_schema_default.h
+++ b/src/extension/alterschema/linter/content_schema_default.h
@@ -27,7 +27,7 @@ public:
     return APPLIES_TO_KEYWORDS("contentSchema");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("contentSchema");
   }
 };

--- a/src/extension/alterschema/linter/content_schema_without_media_type.h
+++ b/src/extension/alterschema/linter/content_schema_without_media_type.h
@@ -24,7 +24,7 @@ public:
     return APPLIES_TO_KEYWORDS("contentSchema");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("contentSchema");
   }
 };

--- a/src/extension/alterschema/linter/definitions_to_defs.h
+++ b/src/extension/alterschema/linter/definitions_to_defs.h
@@ -23,7 +23,7 @@ public:
     return APPLIES_TO_KEYWORDS("definitions");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.rename("definitions", "$defs");
   }
 

--- a/src/extension/alterschema/linter/dependencies_default.h
+++ b/src/extension/alterschema/linter/dependencies_default.h
@@ -27,7 +27,7 @@ public:
     return APPLIES_TO_KEYWORDS("dependencies");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("dependencies");
   }
 };

--- a/src/extension/alterschema/linter/dependencies_property_tautology.h
+++ b/src/extension/alterschema/linter/dependencies_property_tautology.h
@@ -39,7 +39,7 @@ public:
     return APPLIES_TO_KEYWORDS("dependencies", "required");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     auto requirements{schema.at("required")};
     while (true) {
       bool match{false};

--- a/src/extension/alterschema/linter/dependent_required_default.h
+++ b/src/extension/alterschema/linter/dependent_required_default.h
@@ -26,7 +26,7 @@ public:
     return APPLIES_TO_KEYWORDS("dependentRequired");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("dependentRequired");
   }
 };

--- a/src/extension/alterschema/linter/dependent_required_tautology.h
+++ b/src/extension/alterschema/linter/dependent_required_tautology.h
@@ -34,7 +34,7 @@ public:
     return APPLIES_TO_KEYWORDS("dependentRequired", "required");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     auto requirements{schema.at("required")};
     while (true) {
       bool match{false};

--- a/src/extension/alterschema/linter/draft_official_dialect_without_empty_fragment.h
+++ b/src/extension/alterschema/linter/draft_official_dialect_without_empty_fragment.h
@@ -35,7 +35,8 @@ public:
     return APPLIES_TO_KEYWORDS("$schema");
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema, const Result &) const
+      -> void override {
     auto dialect{std::move(schema.at("$schema")).to_string()};
     dialect += "#";
     schema.at("$schema").into(sourcemeta::core::JSON{dialect});

--- a/src/extension/alterschema/linter/duplicate_allof_branches.h
+++ b/src/extension/alterschema/linter/duplicate_allof_branches.h
@@ -30,7 +30,7 @@ public:
     return APPLIES_TO_KEYWORDS("allOf");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     auto collection = schema.at("allOf");
     std::sort(collection.as_array().begin(), collection.as_array().end());
     auto last =

--- a/src/extension/alterschema/linter/duplicate_anyof_branches.h
+++ b/src/extension/alterschema/linter/duplicate_anyof_branches.h
@@ -30,7 +30,7 @@ public:
     return APPLIES_TO_KEYWORDS("anyOf");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     auto collection = schema.at("anyOf");
     std::sort(collection.as_array().begin(), collection.as_array().end());
     auto last =

--- a/src/extension/alterschema/linter/duplicate_enum_values.h
+++ b/src/extension/alterschema/linter/duplicate_enum_values.h
@@ -30,7 +30,7 @@ public:
     return APPLIES_TO_KEYWORDS("enum");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     // We want to be super careful to maintain the current ordering
     // as we delete the duplicates
     auto &enumeration{schema.at("enum")};

--- a/src/extension/alterschema/linter/duplicate_required_values.h
+++ b/src/extension/alterschema/linter/duplicate_required_values.h
@@ -28,7 +28,7 @@ public:
     return APPLIES_TO_KEYWORDS("required");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     auto collection = schema.at("required");
     std::sort(collection.as_array().begin(), collection.as_array().end());
     auto last =

--- a/src/extension/alterschema/linter/else_empty.h
+++ b/src/extension/alterschema/linter/else_empty.h
@@ -23,5 +23,7 @@ public:
     return APPLIES_TO_KEYWORDS("else");
   }
 
-  auto transform(JSON &schema) const -> void override { schema.erase("else"); }
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("else");
+  }
 };

--- a/src/extension/alterschema/linter/else_without_if.h
+++ b/src/extension/alterschema/linter/else_without_if.h
@@ -23,5 +23,7 @@ public:
     return APPLIES_TO_KEYWORDS("else");
   }
 
-  auto transform(JSON &schema) const -> void override { schema.erase("else"); }
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("else");
+  }
 };

--- a/src/extension/alterschema/linter/enum_to_const.h
+++ b/src/extension/alterschema/linter/enum_to_const.h
@@ -26,7 +26,7 @@ public:
     return APPLIES_TO_KEYWORDS("enum");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     auto front{schema.at("enum").front()};
     schema.at("enum").into(front);
     schema.rename("enum", "const");

--- a/src/extension/alterschema/linter/enum_with_type.h
+++ b/src/extension/alterschema/linter/enum_with_type.h
@@ -51,5 +51,7 @@ public:
     return APPLIES_TO_KEYWORDS("enum", "type");
   }
 
-  auto transform(JSON &schema) const -> void override { schema.erase("type"); }
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("type");
+  }
 };

--- a/src/extension/alterschema/linter/equal_numeric_bounds_to_const.h
+++ b/src/extension/alterschema/linter/equal_numeric_bounds_to_const.h
@@ -34,7 +34,7 @@ public:
     return APPLIES_TO_KEYWORDS("minimum", "maximum");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.rename("minimum", "const");
     schema.erase("type");
     schema.erase("maximum");

--- a/src/extension/alterschema/linter/equal_numeric_bounds_to_enum.h
+++ b/src/extension/alterschema/linter/equal_numeric_bounds_to_enum.h
@@ -31,7 +31,7 @@ public:
     return APPLIES_TO_KEYWORDS("minimum", "maximum");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     sourcemeta::core::JSON values = sourcemeta::core::JSON::make_array();
     values.push_back(schema.at("minimum"));
     schema.assign("enum", std::move(values));

--- a/src/extension/alterschema/linter/exclusive_maximum_number_and_maximum.h
+++ b/src/extension/alterschema/linter/exclusive_maximum_number_and_maximum.h
@@ -28,7 +28,7 @@ public:
     return APPLIES_TO_KEYWORDS("exclusiveMaximum", "maximum");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     if (schema.at("maximum") < schema.at("exclusiveMaximum")) {
       schema.erase("exclusiveMaximum");
     } else {

--- a/src/extension/alterschema/linter/exclusive_minimum_number_and_minimum.h
+++ b/src/extension/alterschema/linter/exclusive_minimum_number_and_minimum.h
@@ -28,7 +28,7 @@ public:
     return APPLIES_TO_KEYWORDS("exclusiveMinimum", "minimum");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     if (schema.at("exclusiveMinimum") < schema.at("minimum")) {
       schema.erase("exclusiveMinimum");
     } else {

--- a/src/extension/alterschema/linter/if_without_then_else.h
+++ b/src/extension/alterschema/linter/if_without_then_else.h
@@ -25,5 +25,7 @@ public:
     return APPLIES_TO_KEYWORDS("if");
   }
 
-  auto transform(JSON &schema) const -> void override { schema.erase("if"); }
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("if");
+  }
 };

--- a/src/extension/alterschema/linter/items_array_default.h
+++ b/src/extension/alterschema/linter/items_array_default.h
@@ -30,5 +30,7 @@ public:
     return APPLIES_TO_KEYWORDS("items");
   }
 
-  auto transform(JSON &schema) const -> void override { schema.erase("items"); }
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("items");
+  }
 };

--- a/src/extension/alterschema/linter/items_schema_default.h
+++ b/src/extension/alterschema/linter/items_schema_default.h
@@ -32,5 +32,7 @@ public:
     return APPLIES_TO_KEYWORDS("items");
   }
 
-  auto transform(JSON &schema) const -> void override { schema.erase("items"); }
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("items");
+  }
 };

--- a/src/extension/alterschema/linter/max_contains_without_contains.h
+++ b/src/extension/alterschema/linter/max_contains_without_contains.h
@@ -25,7 +25,7 @@ public:
     return APPLIES_TO_KEYWORDS("maxContains");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("maxContains");
   }
 };

--- a/src/extension/alterschema/linter/maximum_real_for_integer.h
+++ b/src/extension/alterschema/linter/maximum_real_for_integer.h
@@ -32,7 +32,7 @@ public:
     return APPLIES_TO_KEYWORDS("maximum");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     const auto current{schema.at("maximum").to_real()};
     const auto new_value{static_cast<std::int64_t>(std::floor(current))};
     schema.assign("maximum", sourcemeta::core::JSON{new_value});

--- a/src/extension/alterschema/linter/min_contains_without_contains.h
+++ b/src/extension/alterschema/linter/min_contains_without_contains.h
@@ -25,7 +25,7 @@ public:
     return APPLIES_TO_KEYWORDS("minContains");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("minContains");
   }
 };

--- a/src/extension/alterschema/linter/minimum_real_for_integer.h
+++ b/src/extension/alterschema/linter/minimum_real_for_integer.h
@@ -32,7 +32,7 @@ public:
     return APPLIES_TO_KEYWORDS("minimum");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     const auto current{schema.at("minimum").to_real()};
     const auto new_value{static_cast<std::int64_t>(std::ceil(current))};
     schema.assign("minimum", sourcemeta::core::JSON{new_value});

--- a/src/extension/alterschema/linter/modern_official_dialect_with_empty_fragment.h
+++ b/src/extension/alterschema/linter/modern_official_dialect_with_empty_fragment.h
@@ -26,7 +26,8 @@ public:
     return APPLIES_TO_KEYWORDS("$schema");
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema, const Result &) const
+      -> void override {
     auto dialect{std::move(schema.at("$schema")).to_string()};
     dialect.pop_back();
     schema.at("$schema").into(sourcemeta::core::JSON{dialect});

--- a/src/extension/alterschema/linter/multiple_of_default.h
+++ b/src/extension/alterschema/linter/multiple_of_default.h
@@ -29,7 +29,7 @@ public:
     return APPLIES_TO_KEYWORDS("multipleOf");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("multipleOf");
   }
 };

--- a/src/extension/alterschema/linter/non_applicable_type_specific_keywords.h
+++ b/src/extension/alterschema/linter/non_applicable_type_specific_keywords.h
@@ -75,7 +75,6 @@ public:
     // so we cannot remove anything from it.
     ONLY_CONTINUE_IF(!current_types.empty());
 
-    this->blacklist.clear();
     std::vector<Pointer> positions;
     for (const auto &entry : schema.as_object()) {
       const auto metadata{walker(entry.first, vocabularies)};
@@ -91,7 +90,6 @@ public:
                                [&current_types](const auto keyword_type) {
                                  return current_types.contains(keyword_type);
                                })) {
-        this->blacklist.emplace_back(entry.first);
         positions.push_back(Pointer{entry.first});
       }
     }
@@ -100,10 +98,9 @@ public:
     return APPLIES_TO_POINTERS(std::move(positions));
   }
 
-  auto transform(JSON &schema) const -> void override {
-    schema.erase_keys(this->blacklist.cbegin(), this->blacklist.cend());
+  auto transform(JSON &schema, const Result &result) const -> void override {
+    for (const auto &location : result.locations) {
+      schema.erase(location.at(0).to_property());
+    }
   }
-
-private:
-  mutable std::vector<JSON::String> blacklist;
 };

--- a/src/extension/alterschema/linter/not_false.h
+++ b/src/extension/alterschema/linter/not_false.h
@@ -23,5 +23,7 @@ public:
     return APPLIES_TO_KEYWORDS("not");
   }
 
-  auto transform(JSON &schema) const -> void override { schema.erase("not"); }
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("not");
+  }
 };

--- a/src/extension/alterschema/linter/pattern_properties_default.h
+++ b/src/extension/alterschema/linter/pattern_properties_default.h
@@ -29,7 +29,7 @@ public:
     return APPLIES_TO_KEYWORDS("patternProperties");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("patternProperties");
   }
 };

--- a/src/extension/alterschema/linter/properties_default.h
+++ b/src/extension/alterschema/linter/properties_default.h
@@ -32,7 +32,7 @@ public:
     return APPLIES_TO_KEYWORDS("properties");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("properties");
   }
 };

--- a/src/extension/alterschema/linter/property_names_default.h
+++ b/src/extension/alterschema/linter/property_names_default.h
@@ -27,7 +27,7 @@ public:
     return APPLIES_TO_KEYWORDS("propertyNames");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("propertyNames");
   }
 };

--- a/src/extension/alterschema/linter/property_names_type_default.h
+++ b/src/extension/alterschema/linter/property_names_type_default.h
@@ -35,7 +35,7 @@ public:
     return APPLIES_TO_POINTERS({{"propertyNames", "type"}});
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.at("propertyNames").erase("type");
   }
 };

--- a/src/extension/alterschema/linter/single_type_array.h
+++ b/src/extension/alterschema/linter/single_type_array.h
@@ -31,7 +31,7 @@ public:
     return APPLIES_TO_KEYWORDS("type");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     auto type{schema.at("type").front()};
     schema.at("type").into(std::move(type));
   }

--- a/src/extension/alterschema/linter/then_empty.h
+++ b/src/extension/alterschema/linter/then_empty.h
@@ -23,5 +23,7 @@ public:
     return APPLIES_TO_KEYWORDS("then");
   }
 
-  auto transform(JSON &schema) const -> void override { schema.erase("then"); }
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("then");
+  }
 };

--- a/src/extension/alterschema/linter/then_without_if.h
+++ b/src/extension/alterschema/linter/then_without_if.h
@@ -23,5 +23,7 @@ public:
     return APPLIES_TO_KEYWORDS("then");
   }
 
-  auto transform(JSON &schema) const -> void override { schema.erase("then"); }
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("then");
+  }
 };

--- a/src/extension/alterschema/linter/unevaluated_items_default.h
+++ b/src/extension/alterschema/linter/unevaluated_items_default.h
@@ -28,7 +28,7 @@ public:
     return APPLIES_TO_KEYWORDS("unevaluatedItems");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("unevaluatedItems");
   }
 };

--- a/src/extension/alterschema/linter/unevaluated_properties_default.h
+++ b/src/extension/alterschema/linter/unevaluated_properties_default.h
@@ -28,7 +28,7 @@ public:
     return APPLIES_TO_KEYWORDS("unevaluatedProperties");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("unevaluatedProperties");
   }
 };

--- a/src/extension/alterschema/linter/unnecessary_allof_wrapper_draft.h
+++ b/src/extension/alterschema/linter/unnecessary_allof_wrapper_draft.h
@@ -57,7 +57,7 @@ public:
     return APPLIES_TO_POINTERS(std::move(locations));
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     for (auto &entry : schema.at("allOf").as_array()) {
       if (entry.is_object()) {
         std::vector<JSON::String> blacklist;

--- a/src/extension/alterschema/linter/unnecessary_allof_wrapper_modern.h
+++ b/src/extension/alterschema/linter/unnecessary_allof_wrapper_modern.h
@@ -64,7 +64,7 @@ public:
     return APPLIES_TO_POINTERS(std::move(locations));
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     for (auto &entry : schema.at("allOf").as_array()) {
       if (entry.is_object()) {
         std::vector<JSON::String> blacklist;

--- a/src/extension/alterschema/linter/unnecessary_allof_wrapper_properties.h
+++ b/src/extension/alterschema/linter/unnecessary_allof_wrapper_properties.h
@@ -46,7 +46,7 @@ public:
     return false;
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     for (auto &entry : schema.at("allOf").as_array()) {
       if (entry.is_object() && entry.defines("properties")) {
         std::vector<JSON::String> blacklist;

--- a/src/extension/alterschema/linter/unsatisfiable_max_contains.h
+++ b/src/extension/alterschema/linter/unsatisfiable_max_contains.h
@@ -29,7 +29,7 @@ public:
     return APPLIES_TO_KEYWORDS("maxContains", "maxItems");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("maxContains");
   }
 };

--- a/src/extension/alterschema/linter/unsatisfiable_min_properties.h
+++ b/src/extension/alterschema/linter/unsatisfiable_min_properties.h
@@ -31,7 +31,7 @@ public:
     return APPLIES_TO_KEYWORDS("minProperties", "required");
   }
 
-  auto transform(JSON &schema) const -> void override {
+  auto transform(JSON &schema, const Result &) const -> void override {
     schema.erase("minProperties");
   }
 };

--- a/test/jsonschema/jsonschema_transform_rules.h
+++ b/test/jsonschema/jsonschema_transform_rules.h
@@ -20,7 +20,9 @@ public:
     return schema.defines("foo");
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.erase("foo");
   }
 };
@@ -47,7 +49,9 @@ public:
     }
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.erase("foo");
   }
 };
@@ -77,7 +81,9 @@ public:
     }
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.erase("foo");
   }
 };
@@ -99,7 +105,9 @@ public:
     return schema.defines("bar");
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.erase("bar");
   }
 };
@@ -122,7 +130,9 @@ public:
     return !schema.defines("top") && location.pointer.empty();
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.assign("top", sourcemeta::core::JSON{true});
   }
 };
@@ -144,7 +154,9 @@ public:
     return !schema.defines("here");
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.assign("here", sourcemeta::core::JSON{true});
   }
 };
@@ -168,7 +180,9 @@ public:
            location.pointer == sourcemeta::core::Pointer{"properties", "baz"};
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.assign("baz", sourcemeta::core::JSON{true});
   }
 };
@@ -192,7 +206,9 @@ public:
            location.dialect == "http://json-schema.org/draft-03/schema#";
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.assign("draft", sourcemeta::core::JSON{3});
   }
 };
@@ -214,7 +230,9 @@ public:
     return schema.defines("foo");
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.erase("foo");
   }
 };
@@ -238,7 +256,9 @@ public:
     return schema.defines("$schema") && schema.size() == 1;
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.assign("foo", sourcemeta::core::JSON{true});
   }
 };
@@ -282,7 +302,9 @@ public:
     return schema.defines("definitions") && !schema.defines("$defs");
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.rename("definitions", "$defs");
   }
 };
@@ -306,7 +328,9 @@ public:
     return schema.defines("definitions") && !schema.defines("$defs");
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.rename("definitions", "$defs");
   }
 
@@ -339,7 +363,9 @@ public:
            (schema.defines("$id") || schema.defines("$anchor"));
   }
 
-  auto transform(sourcemeta::core::JSON &schema) const -> void override {
+  auto transform(sourcemeta::core::JSON &schema,
+                 const sourcemeta::core::SchemaTransformRule::Result &) const
+      -> void override {
     schema.erase_keys({"$id", "$anchor"});
   }
 };


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
