### PR TITLE
Always add explicit identifiers in `bundle()`

### DIFF
--- a/src/core/jsonschema/bundle.cc
+++ b/src/core/jsonschema/bundle.cc
@@ -258,6 +258,17 @@ auto bundle(JSON &schema, const SchemaWalker &walker,
     return;
   }
 
+  // If the schema identifier is implicit, add it to the top-level of the
+  // bundled schema. Otherwise, potential relative references based on this
+  // implicit base URI will likely not resolve unless end users happen to
+  // know that this implicit base URI is.
+  if (default_id.has_value() &&
+      !identify(schema, resolver, SchemaIdentificationStrategy::Strict,
+                default_dialect)
+           .has_value()) {
+    reidentify(schema, default_id.value(), resolver, default_dialect);
+  }
+
   const auto vocabularies{
       sourcemeta::core::vocabularies(schema, resolver, default_dialect)};
   if (vocabularies.contains(

--- a/test/jsonschema/jsonschema_bundle_test.cc
+++ b/test/jsonschema/jsonschema_bundle_test.cc
@@ -179,6 +179,7 @@ TEST(JSONSchema_bundle, with_default_id) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://www.sourcemeta.com/default",
     "items": { "$ref": "test-2" },
     "$defs": {
       "https://www.sourcemeta.com/test-2": {


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1967
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
