### PR TITLE
Test `URI::extension` on a URI with an empty fragment

### DIFF
--- a/test/uri/uri_extension_test.cc
+++ b/test/uri/uri_extension_test.cc
@@ -52,6 +52,12 @@ TEST(URI_extension, absolute_trailing_period) {
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com/foo.json");
 }
 
+TEST(URI_extension, empty_fragment) {
+  sourcemeta::core::URI uri{"https://www.sourcemeta.com/foo#"};
+  uri.extension(".json");
+  EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com/foo.json#");
+}
+
 TEST(URI_extension, fragment_only) {
   sourcemeta::core::URI uri{"#foo"};
   uri.extension("json");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
