### PR TITLE
Fix segfault when running `JSON::unique()` on different threads

### DIFF
--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -741,8 +741,10 @@ JSON::defines_any(std::initializer_list<JSON::String> keys) const -> bool {
     return true;
   }
 
-  static std::vector<std::uint64_t> cache;
-  cache.reserve(size);
+  // If we re-use the vector across threads, then we will segfault
+  thread_local std::vector<std::uint64_t> cache;
+  cache.clear();
+  cache.resize(size);
 
   for (std::size_t index = 0; index < size; index++) {
     cache[index] = items[index].fast_hash();


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
