### PR TITLE
Fix `URI::relative_to` emitting relative references that do not round-trip

### DIFF
--- a/src/core/uri/resolution.cc
+++ b/src/core/uri/resolution.cc
@@ -30,6 +30,13 @@ auto merge_paths(const std::string &base_path, const std::string &ref_path,
   return base_path.substr(0, last_slash + 1) + ref_path;
 }
 
+// RFC 3986 Section 4.2: "A relative reference that begins with two slash
+// characters is termed a network-path reference", so a leading slash can only
+// be dropped from a path when another one does not immediately follow it
+auto can_drop_leading_slash(const std::string &path) -> bool {
+  return path.length() > 1 && path.starts_with('/') && path[1] != '/';
+}
+
 } // namespace
 
 namespace sourcemeta::core {
@@ -205,8 +212,7 @@ auto URI::relative_to(const URI &base) -> URI & {
     // there. Without an authority, merging appends the reference to a base
     // path that has no segments at all, so dropping the slash would name a
     // rootless path instead. A path of just "/" names the root either way
-    if (base.host_.has_value() && relative_path.starts_with('/') &&
-        relative_path.length() > 1) {
+    if (base.host_.has_value() && can_drop_leading_slash(relative_path)) {
       relative_path.erase(0, 1);
     }
 
@@ -224,10 +230,14 @@ auto URI::relative_to(const URI &base) -> URI & {
   // Case 2: Check if this_path starts with base_path followed by "/"
   // This handles: base="/foo" and this="/foo/bar" = "bar"
   // But NOT: base="/spec" and this="/spec/" (different resources)
+  // RFC 3986 Section 5.2.2 uses a reference path that starts with a slash as
+  // is, so a remainder that begins with one would drop the base prefix rather
+  // than name something below it
   const std::string base_with_slash =
       base_path.ends_with('/') ? base_path : base_path + "/";
   if (this_path.starts_with(base_with_slash) &&
-      this_path.length() > base_with_slash.length()) {
+      this_path.length() > base_with_slash.length() &&
+      this_path[base_with_slash.length()] != '/') {
     auto relative_path = this_path.substr(base_with_slash.length());
 
     this->scheme_.reset();
@@ -310,7 +320,14 @@ auto URI::relative_to(const URI &base) -> URI & {
   }
 
   if (current_base_parent == "/" && this_path.starts_with('/')) {
-    relative_path += this_path.substr(1);
+    // Without a parent segment to step out of, the reference is the target
+    // path minus the slash that merging puts back, unless that slash cannot
+    // be dropped, in which case the whole path names the target on its own
+    if (relative_path.empty() && !can_drop_leading_slash(this_path)) {
+      relative_path = this_path;
+    } else {
+      relative_path += this_path.substr(1);
+    }
 
     this->scheme_.reset();
     this->userinfo_.reset();

--- a/src/core/uri/resolution.cc
+++ b/src/core/uri/resolution.cc
@@ -193,7 +193,35 @@ auto URI::relative_to(const URI &base) -> URI & {
 
   const auto &base_path = base.path_.value_or("");
 
-  // Case 1: Check if this_path starts with base_path followed by "/"
+  // Case 1: Base has no path or empty path
+  // Examples: "https://example.com" or "schema:"
+  // Strip leading slash and make relative
+  if (base_path.empty()) {
+    auto relative_path = this_path;
+
+    // RFC 3986 Section 5.2.3: "If the base URI has a defined authority
+    // component and an empty path, then return a string consisting of "/"
+    // concatenated with the reference's path", so the leading slash is implied
+    // there. Without an authority, merging appends the reference to a base
+    // path that has no segments at all, so dropping the slash would name a
+    // rootless path instead. A path of just "/" names the root either way
+    if (base.host_.has_value() && relative_path.starts_with('/') &&
+        relative_path.length() > 1) {
+      relative_path.erase(0, 1);
+    }
+
+    this->scheme_.reset();
+    this->userinfo_.reset();
+    this->host_.reset();
+    this->port_.reset();
+    this->path_ = relative_path.empty()
+                      ? std::nullopt
+                      : std::optional<std::string>{relative_path};
+
+    return *this;
+  }
+
+  // Case 2: Check if this_path starts with base_path followed by "/"
   // This handles: base="/foo" and this="/foo/bar" = "bar"
   // But NOT: base="/spec" and this="/spec/" (different resources)
   const std::string base_with_slash =
@@ -217,7 +245,7 @@ auto URI::relative_to(const URI &base) -> URI & {
   const auto base_last_slash = base_path.rfind('/');
   const auto this_last_slash = this_path.rfind('/');
 
-  // Case 2: Check if both paths share the same parent directory (siblings)
+  // Case 3: Check if both paths share the same parent directory (siblings)
   // This handles: base="/test/bar.json" and this="/test/foo.json" =
   // "foo.json"
   if (base_last_slash != std::string::npos &&
@@ -232,33 +260,14 @@ auto URI::relative_to(const URI &base) -> URI & {
       this->userinfo_.reset();
       this->host_.reset();
       this->port_.reset();
-      this->path_ = relative_path.empty()
-                        ? std::nullopt
-                        : std::optional<std::string>{relative_path};
+      // RFC 3986 Section 5.4.1 resolves "" back to the path of the base and
+      // "./" to the directory that contains it, so a target that is exactly
+      // that directory has no last segment to name and takes a dot segment
+      this->path_ =
+          relative_path.empty() ? std::string{"./"} : std::move(relative_path);
 
       return *this;
     }
-  }
-
-  // Case 3: Base has no path or empty path
-  // Examples: "https://example.com" or "schema:"
-  // Strip leading slash and make relative
-  if (base_path.empty()) {
-    auto relative_path = this_path;
-
-    if (relative_path.starts_with('/')) {
-      relative_path = relative_path.substr(1);
-    }
-
-    this->scheme_.reset();
-    this->userinfo_.reset();
-    this->host_.reset();
-    this->port_.reset();
-    this->path_ = relative_path.empty()
-                      ? std::nullopt
-                      : std::optional<std::string>{relative_path};
-
-    return *this;
   }
 
   // Case 4: General case - compute relative path using .. segments

--- a/src/core/uri/resolution.cc
+++ b/src/core/uri/resolution.cc
@@ -296,6 +296,15 @@ auto URI::relative_to(const URI &base) -> URI & {
     if (this_path.starts_with(current_base_parent)) {
       const auto remainder{this_path.substr(current_base_parent.length())};
       if (!remainder.empty()) {
+        // A remainder that opens with an empty segment would turn the whole
+        // reference into an absolute path that keeps nothing of the base. A
+        // leading "./" stands in for the directory the merge already supplies
+        // and is consumed along with its own slash, which leaves the slash
+        // that opens the remainder to form the empty segment
+        if (relative_path.empty() && remainder.starts_with('/')) {
+          relative_path += "./";
+        }
+
         relative_path += remainder;
       }
 

--- a/test/uri/uri_relative_to_test.cc
+++ b/test/uri/uri_relative_to_test.cc
@@ -499,9 +499,36 @@ TEST(target_with_empty_first_segment_from_nested_base_resolves_back) {
   const sourcemeta::core::URI base{"https://example.com/a/b"};
   sourcemeta::core::URI uri{"https://example.com//bar"};
   uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "..//bar");
   sourcemeta::core::URI resolved{uri.recompose()};
   resolved.resolve_from(base);
   EXPECT_EQ(resolved.recompose(), "https://example.com//bar");
+}
+
+TEST(target_with_empty_segment_below_directory_base) {
+  const sourcemeta::core::URI base{"https://example.com/foo/"};
+  sourcemeta::core::URI uri{"https://example.com/foo//bar"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), ".//bar");
+}
+
+TEST(target_with_empty_segment_below_directory_base_resolves_back) {
+  const sourcemeta::core::URI base{"https://example.com/foo/"};
+  sourcemeta::core::URI uri{"https://example.com/foo//bar"};
+  uri.relative_to(base);
+  sourcemeta::core::URI resolved{uri.recompose()};
+  resolved.resolve_from(base);
+  EXPECT_EQ(resolved.recompose(), "https://example.com/foo//bar");
+}
+
+TEST(target_with_empty_segment_below_nested_directory_base_resolves_back) {
+  const sourcemeta::core::URI base{"https://example.com/a/b/c.json"};
+  sourcemeta::core::URI uri{"https://example.com/a/b//d"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), ".//d");
+  sourcemeta::core::URI resolved{uri.recompose()};
+  resolved.resolve_from(base);
+  EXPECT_EQ(resolved.recompose(), "https://example.com/a/b//d");
 }
 
 TEST(target_is_absolute_path_of_base_without_authority) {

--- a/test/uri/uri_relative_to_test.cc
+++ b/test/uri/uri_relative_to_test.cc
@@ -461,6 +461,49 @@ TEST(target_is_root_of_base_without_path_resolves_back) {
   EXPECT_EQ(resolved.recompose(), "https://example.com/");
 }
 
+TEST(target_with_empty_first_segment_of_base_without_path) {
+  const sourcemeta::core::URI base{"https://example.com"};
+  sourcemeta::core::URI uri{"https://example.com//foo"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "/.//foo");
+}
+
+TEST(target_with_empty_first_segment_of_base_without_path_resolves_back) {
+  const sourcemeta::core::URI base{"https://example.com"};
+  sourcemeta::core::URI uri{"https://example.com//foo"};
+  uri.relative_to(base);
+  sourcemeta::core::URI resolved{uri.recompose()};
+  resolved.resolve_from(base);
+  EXPECT_EQ(resolved.recompose(), "https://example.com//foo");
+}
+
+TEST(target_with_empty_first_segment_of_root_base_resolves_back) {
+  const sourcemeta::core::URI base{"https://example.com/foo"};
+  sourcemeta::core::URI uri{"https://example.com//bar"};
+  uri.relative_to(base);
+  sourcemeta::core::URI resolved{uri.recompose()};
+  resolved.resolve_from(base);
+  EXPECT_EQ(resolved.recompose(), "https://example.com//bar");
+}
+
+TEST(target_with_empty_segment_below_base_resolves_back) {
+  const sourcemeta::core::URI base{"https://example.com/foo"};
+  sourcemeta::core::URI uri{"https://example.com/foo//bar"};
+  uri.relative_to(base);
+  sourcemeta::core::URI resolved{uri.recompose()};
+  resolved.resolve_from(base);
+  EXPECT_EQ(resolved.recompose(), "https://example.com/foo//bar");
+}
+
+TEST(target_with_empty_first_segment_from_nested_base_resolves_back) {
+  const sourcemeta::core::URI base{"https://example.com/a/b"};
+  sourcemeta::core::URI uri{"https://example.com//bar"};
+  uri.relative_to(base);
+  sourcemeta::core::URI resolved{uri.recompose()};
+  resolved.resolve_from(base);
+  EXPECT_EQ(resolved.recompose(), "https://example.com//bar");
+}
+
 TEST(target_is_absolute_path_of_base_without_authority) {
   const sourcemeta::core::URI base{"schema:"};
   sourcemeta::core::URI uri{"schema:/foo"};

--- a/test/uri/uri_relative_to_test.cc
+++ b/test/uri/uri_relative_to_test.cc
@@ -382,3 +382,97 @@ TEST(relative_to_slashless_base_path) {
   target.relative_to(sourcemeta::core::URI{"schema:foo"});
   EXPECT_EQ(target.recompose(), "schema:bar");
 }
+
+TEST(target_is_directory_of_base) {
+  const sourcemeta::core::URI base{"https://example.com/test/foo.json"};
+  sourcemeta::core::URI uri{"https://example.com/test/"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "./");
+}
+
+TEST(target_is_directory_of_base_resolves_back) {
+  const sourcemeta::core::URI base{"https://example.com/test/foo.json"};
+  sourcemeta::core::URI uri{"https://example.com/test/"};
+  uri.relative_to(base);
+  sourcemeta::core::URI resolved{uri.recompose()};
+  resolved.resolve_from(base);
+  EXPECT_EQ(resolved.recompose(), "https://example.com/test/");
+}
+
+TEST(target_is_nested_directory_of_base) {
+  const sourcemeta::core::URI base{"https://example.com/foo/bar/baz.json"};
+  sourcemeta::core::URI uri{"https://example.com/foo/bar/"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "./");
+}
+
+TEST(target_is_directory_of_base_with_query) {
+  const sourcemeta::core::URI base{"https://example.com/test/foo.json"};
+  sourcemeta::core::URI uri{"https://example.com/test/?q=1"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "./?q=1");
+}
+
+TEST(target_is_directory_of_base_with_query_resolves_back) {
+  const sourcemeta::core::URI base{"https://example.com/test/foo.json"};
+  sourcemeta::core::URI uri{"https://example.com/test/?q=1"};
+  uri.relative_to(base);
+  sourcemeta::core::URI resolved{uri.recompose()};
+  resolved.resolve_from(base);
+  EXPECT_EQ(resolved.recompose(), "https://example.com/test/?q=1");
+}
+
+TEST(target_is_directory_of_base_with_fragment) {
+  const sourcemeta::core::URI base{"https://example.com/test/foo.json"};
+  sourcemeta::core::URI uri{"https://example.com/test/#baz"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "./#baz");
+}
+
+TEST(target_is_directory_of_base_with_fragment_resolves_back) {
+  const sourcemeta::core::URI base{"https://example.com/test/foo.json"};
+  sourcemeta::core::URI uri{"https://example.com/test/#baz"};
+  uri.relative_to(base);
+  sourcemeta::core::URI resolved{uri.recompose()};
+  resolved.resolve_from(base);
+  EXPECT_EQ(resolved.recompose(), "https://example.com/test/#baz");
+}
+
+TEST(file_target_is_directory_of_base) {
+  const sourcemeta::core::URI base{"file:///home/user/schemas/base.json"};
+  sourcemeta::core::URI uri{"file:///home/user/schemas/"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "./");
+}
+
+TEST(target_is_root_of_base_without_path) {
+  const sourcemeta::core::URI base{"https://example.com"};
+  sourcemeta::core::URI uri{"https://example.com/"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "/");
+}
+
+TEST(target_is_root_of_base_without_path_resolves_back) {
+  const sourcemeta::core::URI base{"https://example.com"};
+  sourcemeta::core::URI uri{"https://example.com/"};
+  uri.relative_to(base);
+  sourcemeta::core::URI resolved{uri.recompose()};
+  resolved.resolve_from(base);
+  EXPECT_EQ(resolved.recompose(), "https://example.com/");
+}
+
+TEST(target_is_absolute_path_of_base_without_authority) {
+  const sourcemeta::core::URI base{"schema:"};
+  sourcemeta::core::URI uri{"schema:/foo"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "/foo");
+}
+
+TEST(target_is_absolute_path_of_base_without_authority_resolves_back) {
+  const sourcemeta::core::URI base{"schema:"};
+  sourcemeta::core::URI uri{"schema:/foo"};
+  uri.relative_to(base);
+  sourcemeta::core::URI resolved{uri.recompose()};
+  resolved.resolve_from(base);
+  EXPECT_EQ(resolved.recompose(), "schema:/foo");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

