### PR TITLE
Fix JSON array construction depending on initializer list arity

### DIFF
--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -227,22 +227,6 @@ public:
   /// ```
   explicit JSON(const Char *const value);
 
-  /// This constructor creates a JSON array from a set of other JSON documents.
-  /// For example:
-  ///
-  /// ```cpp
-  /// #include <sourcemeta/core/json.h>
-  /// #include <cassert>
-  ///
-  /// const sourcemeta::core::JSON my_array{
-  ///   sourcemeta::core::JSON{1},
-  ///   sourcemeta::core::JSON{2},
-  ///   sourcemeta::core::JSON{3}};
-  ///
-  /// assert(my_array.is_array());
-  /// ```
-  explicit JSON(std::initializer_list<JSON> values);
-
   /// A copy constructor for the array type.
   explicit JSON(const Array &value);
 
@@ -296,6 +280,28 @@ public:
   /// This function is particularly handy for programatically constructing
   /// arrays.
   static auto make_array() -> JSON;
+
+  /// This function creates a JSON array out of a list of other JSON documents.
+  /// For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <cassert>
+  ///
+  /// const auto document = sourcemeta::core::JSON::make_array({
+  ///   sourcemeta::core::JSON{1},
+  ///   sourcemeta::core::JSON{2},
+  ///   sourcemeta::core::JSON{3}});
+  ///
+  /// assert(document.is_array());
+  /// assert(document.size() == 3);
+  /// ```
+  ///
+  /// Note that a list of this kind always copies each of its documents, as the
+  /// language offers no way of moving out of one. Prefer starting from an
+  /// empty array and moving each document into it when the cost of those
+  /// copies matters.
+  static auto make_array(std::initializer_list<JSON> values) -> JSON;
 
   /// This function creates an empty JSON object. For example:
   ///

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -160,22 +160,6 @@ JSON::JSON(const Char *const value) : current_type{Type::String} {
   std::construct_at(&this->data_string, value);
 }
 
-JSON::JSON(std::initializer_list<JSON> values) : current_type{Type::Array} {
-// For direct-list-initialization (e.g. JSON x{other_json}), the C++ standard
-// mandates that initializer_list constructors are preferred over copy/move
-// constructors. GCC and MSVC follow this strictly, so a single-element brace
-// init ends up here instead of the copy constructor. Handle this case before
-// constructing the array to avoid an unnecessary heap allocation.
-#if defined(__GNUC__) || defined(_MSC_VER)
-  if (values.size() == 1) {
-    this->current_type = Type::Null;
-    this->operator=(*values.begin());
-    return;
-  }
-#endif
-  std::construct_at(&this->data_array, values);
-}
-
 JSON::JSON(const Array &value) : current_type{Type::Array} {
   std::construct_at(&this->data_array, value);
 }
@@ -468,10 +452,6 @@ JSON::~JSON() {
       }
 
       while (!pending.empty()) {
-        // Use copy-init so the move constructor is selected. Direct-list-init
-        // would route through JSON(initializer_list<JSON>) on GCC and MSVC,
-        // whose single-element workaround takes the slower copy-and-replace
-        // path instead of a direct move
         JSON node = std::move(pending.back());
         pending.pop_back();
         if (node.current_type == Type::Array) {
@@ -503,6 +483,13 @@ JSON::~JSON() {
 }
 
 auto JSON::make_array() -> JSON { return JSON{Array{}}; }
+
+auto JSON::make_array(std::initializer_list<JSON> values) -> JSON {
+  JSON result{nullptr};
+  std::construct_at(&result.data_array, values);
+  result.current_type = Type::Array;
+  return result;
+}
 
 auto JSON::make_object() -> JSON { return JSON{Object{}}; }
 

--- a/test/json/json_array_test.cc
+++ b/test/json/json_array_test.cc
@@ -36,9 +36,9 @@ TEST(move_traits) {
       std::is_nothrow_move_constructible<sourcemeta::core::JSON::Array>::value);
 }
 
-TEST(initializer_list_2_booleans) {
-  const sourcemeta::core::JSON document{sourcemeta::core::JSON{false},
-                                        sourcemeta::core::JSON{true}};
+TEST(make_array_2_booleans) {
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{false}, sourcemeta::core::JSON{true}})};
 
   EXPECT_TRUE(document.is_array());
   EXPECT_EQ(document.size(), 2);
@@ -49,9 +49,71 @@ TEST(initializer_list_2_booleans) {
   EXPECT_TRUE(document.at(1).to_boolean());
 }
 
+TEST(make_array_3_integers) {
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
+       sourcemeta::core::JSON{3}})};
+
+  EXPECT_TRUE(document.is_array());
+  EXPECT_EQ(document.size(), 3);
+  EXPECT_EQ(document.array_size(), 3);
+  EXPECT_EQ(document.at(0).to_integer(), 1);
+  EXPECT_EQ(document.at(1).to_integer(), 2);
+  EXPECT_EQ(document.at(2).to_integer(), 3);
+}
+
+TEST(make_array_empty_initializer_list) {
+  const auto document{sourcemeta::core::JSON::make_array({})};
+
+  EXPECT_TRUE(document.is_array());
+  EXPECT_EQ(document.size(), 0);
+  EXPECT_EQ(document.array_size(), 0);
+}
+
+TEST(make_array_1_integer) {
+  const sourcemeta::core::JSON element{1};
+  const auto document{sourcemeta::core::JSON::make_array({element})};
+
+  EXPECT_TRUE(document.is_array());
+  EXPECT_EQ(document.size(), 1);
+  EXPECT_EQ(document.array_size(), 1);
+  EXPECT_EQ(document.at(0).to_integer(), 1);
+}
+
+TEST(make_array_1_array) {
+  const auto element{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2}})};
+  const auto document{sourcemeta::core::JSON::make_array({element})};
+
+  EXPECT_TRUE(document.is_array());
+  EXPECT_EQ(document.size(), 1);
+  EXPECT_TRUE(document.at(0).is_array());
+  EXPECT_EQ(document.at(0).size(), 2);
+}
+
+TEST(brace_initialization_from_integer_document) {
+  const sourcemeta::core::JSON element{1};
+  const sourcemeta::core::JSON document{element};
+
+  EXPECT_FALSE(document.is_array());
+  EXPECT_TRUE(document.is_integer());
+  EXPECT_EQ(document.to_integer(), 1);
+}
+
+TEST(brace_initialization_from_array_document) {
+  const auto element{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2}})};
+  const sourcemeta::core::JSON document{element};
+
+  EXPECT_TRUE(document.is_array());
+  EXPECT_EQ(document.size(), 2);
+  EXPECT_EQ(document.at(0).to_integer(), 1);
+  EXPECT_EQ(document.at(1).to_integer(), 2);
+}
+
 TEST(type) {
-  const sourcemeta::core::JSON document{sourcemeta::core::JSON{false},
-                                        sourcemeta::core::JSON{true}};
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{false}, sourcemeta::core::JSON{true}})};
   EXPECT_EQ(document.type(), sourcemeta::core::JSON::Type::Array);
 }
 
@@ -84,9 +146,9 @@ TEST(push_back_booleans) {
 }
 
 TEST(boolean_iterator) {
-  const sourcemeta::core::JSON document{sourcemeta::core::JSON{true},
-                                        sourcemeta::core::JSON{false},
-                                        sourcemeta::core::JSON{false}};
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{true}, sourcemeta::core::JSON{false},
+       sourcemeta::core::JSON{false}})};
 
   std::vector<bool> result;
   for (const auto &element : document.as_array()) {
@@ -100,9 +162,9 @@ TEST(boolean_iterator) {
 }
 
 TEST(reverse_boolean_iterator) {
-  const sourcemeta::core::JSON document{sourcemeta::core::JSON{true},
-                                        sourcemeta::core::JSON{false},
-                                        sourcemeta::core::JSON{false}};
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{true}, sourcemeta::core::JSON{false},
+       sourcemeta::core::JSON{false}})};
 
   std::vector<bool> result;
   for (auto iterator = document.as_array().crbegin();
@@ -117,8 +179,8 @@ TEST(reverse_boolean_iterator) {
 }
 
 TEST(push_back_json_copy) {
-  sourcemeta::core::JSON document{sourcemeta::core::JSON{1},
-                                  sourcemeta::core::JSON{2}};
+  auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2}})};
 
   EXPECT_TRUE(document.is_array());
   EXPECT_EQ(document.size(), 2);
@@ -138,8 +200,8 @@ TEST(push_back_json_copy) {
 }
 
 TEST(push_back_json_move) {
-  sourcemeta::core::JSON document{sourcemeta::core::JSON{1},
-                                  sourcemeta::core::JSON{2}};
+  auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2}})};
 
   EXPECT_TRUE(document.is_array());
   EXPECT_EQ(document.size(), 2);
@@ -160,9 +222,9 @@ TEST(push_back_json_move) {
 
 TEST(modify_array_after_copy) {
   // Original document
-  sourcemeta::core::JSON document{sourcemeta::core::JSON{1},
-                                  sourcemeta::core::JSON{2},
-                                  sourcemeta::core::JSON{3}};
+  auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
+       sourcemeta::core::JSON{3}})};
   EXPECT_EQ(document.size(), 3);
   EXPECT_EQ(document.array_size(), 3);
   EXPECT_EQ(document.at(0).to_integer(), 1);

--- a/test/json/json_prettify_test.cc
+++ b/test/json/json_prettify_test.cc
@@ -95,20 +95,21 @@ TEST(small_string) {
 }
 
 TEST(array_integers) {
-  const sourcemeta::core::JSON document{
-      sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
-      sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}};
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
+       sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}})};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "[ 1, 2, 3, 4 ]");
 }
 
 TEST(array_strings_almost_long) {
-  const sourcemeta::core::JSON document{sourcemeta::core::JSON{"aaaaaaaaaa"},
-                                        sourcemeta::core::JSON{"bbbbbbbbbb"},
-                                        sourcemeta::core::JSON{"cccccccccc"},
-                                        sourcemeta::core::JSON{"dddddddddd"},
-                                        sourcemeta::core::JSON{"eeeeeeeeee"}};
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{"aaaaaaaaaa"},
+       sourcemeta::core::JSON{"bbbbbbbbbb"},
+       sourcemeta::core::JSON{"cccccccccc"},
+       sourcemeta::core::JSON{"dddddddddd"},
+       sourcemeta::core::JSON{"eeeeeeeeee"}})};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "[ \"aaaaaaaaaa\", \"bbbbbbbbbb\", \"cccccccccc\", "
@@ -192,14 +193,15 @@ TEST(array_strings_almost_long_with_long_property) {
 }
 
 TEST(array_strings_long) {
-  const sourcemeta::core::JSON document{sourcemeta::core::JSON{"aaaaaaaaaa"},
-                                        sourcemeta::core::JSON{"bbbbbbbbbb"},
-                                        sourcemeta::core::JSON{"cccccccccc"},
-                                        sourcemeta::core::JSON{"dddddddddd"},
-                                        sourcemeta::core::JSON{"eeeeeeeeee"},
-                                        sourcemeta::core::JSON{"ffffffffff"},
-                                        sourcemeta::core::JSON{"gggggggggg"},
-                                        sourcemeta::core::JSON{"hhhhhhhhhh"}};
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{"aaaaaaaaaa"},
+       sourcemeta::core::JSON{"bbbbbbbbbb"},
+       sourcemeta::core::JSON{"cccccccccc"},
+       sourcemeta::core::JSON{"dddddddddd"},
+       sourcemeta::core::JSON{"eeeeeeeeee"},
+       sourcemeta::core::JSON{"ffffffffff"},
+       sourcemeta::core::JSON{"gggggggggg"},
+       sourcemeta::core::JSON{"hhhhhhhhhh"}})};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(),
@@ -209,9 +211,9 @@ TEST(array_strings_long) {
 }
 
 TEST(array_nested_1) {
-  sourcemeta::core::JSON array{
-      sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
-      sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}};
+  auto array{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
+       sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}})};
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(std::move(array));
   std::ostringstream stream;
@@ -222,8 +224,8 @@ TEST(array_nested_1) {
 TEST(array_nested_2) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
-  sourcemeta::core::JSON nested{sourcemeta::core::JSON{2},
-                                sourcemeta::core::JSON{3}};
+  auto nested{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{2}, sourcemeta::core::JSON{3}})};
   document.push_back(std::move(nested));
   document.push_back(sourcemeta::core::JSON{4});
   std::ostringstream stream;
@@ -425,8 +427,8 @@ TEST(object_nested_with_4_spaces) {
 TEST(array_nested_with_0_spaces) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
-  sourcemeta::core::JSON nested{sourcemeta::core::JSON{2},
-                                sourcemeta::core::JSON{3}};
+  auto nested{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{2}, sourcemeta::core::JSON{3}})};
   document.push_back(std::move(nested));
   document.push_back(sourcemeta::core::JSON{4});
   std::ostringstream stream;
@@ -437,8 +439,8 @@ TEST(array_nested_with_0_spaces) {
 TEST(array_nested_with_1_space) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
-  sourcemeta::core::JSON nested{sourcemeta::core::JSON{2},
-                                sourcemeta::core::JSON{3}};
+  auto nested{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{2}, sourcemeta::core::JSON{3}})};
   document.push_back(std::move(nested));
   document.push_back(sourcemeta::core::JSON{4});
   std::ostringstream stream;
@@ -449,8 +451,8 @@ TEST(array_nested_with_1_space) {
 TEST(array_nested_with_2_spaces) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
-  sourcemeta::core::JSON nested{sourcemeta::core::JSON{2},
-                                sourcemeta::core::JSON{3}};
+  auto nested{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{2}, sourcemeta::core::JSON{3}})};
   document.push_back(std::move(nested));
   document.push_back(sourcemeta::core::JSON{4});
   std::ostringstream stream;
@@ -461,8 +463,8 @@ TEST(array_nested_with_2_spaces) {
 TEST(array_nested_with_3_spaces) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
-  sourcemeta::core::JSON nested{sourcemeta::core::JSON{2},
-                                sourcemeta::core::JSON{3}};
+  auto nested{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{2}, sourcemeta::core::JSON{3}})};
   document.push_back(std::move(nested));
   document.push_back(sourcemeta::core::JSON{4});
   std::ostringstream stream;
@@ -473,8 +475,8 @@ TEST(array_nested_with_3_spaces) {
 TEST(array_nested_with_4_spaces) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
-  sourcemeta::core::JSON nested{sourcemeta::core::JSON{2},
-                                sourcemeta::core::JSON{3}};
+  auto nested{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{2}, sourcemeta::core::JSON{3}})};
   document.push_back(std::move(nested));
   document.push_back(sourcemeta::core::JSON{4});
   std::ostringstream stream;
@@ -586,9 +588,9 @@ TEST(decimal_in_array) {
   const sourcemeta::core::Decimal value1{100};
   const sourcemeta::core::Decimal value2{"999.999"};
   const sourcemeta::core::Decimal value3{"-42"};
-  const sourcemeta::core::JSON document{sourcemeta::core::JSON{value1},
-                                        sourcemeta::core::JSON{value2},
-                                        sourcemeta::core::JSON{value3}};
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{value1}, sourcemeta::core::JSON{value2},
+       sourcemeta::core::JSON{value3}})};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "[ 1.00e+2, 9.99999e+2, -4.2e+1 ]");
@@ -598,8 +600,8 @@ TEST(decimal_large_numbers_in_array) {
   const sourcemeta::core::Decimal value1{"123456789012345678901234567890"};
   const sourcemeta::core::Decimal value2{
       "98765432109876543210.98765432109876543210"};
-  const sourcemeta::core::JSON document{sourcemeta::core::JSON{value1},
-                                        sourcemeta::core::JSON{value2}};
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{value1}, sourcemeta::core::JSON{value2}})};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "[\n"
@@ -611,8 +613,8 @@ TEST(decimal_large_numbers_in_array) {
 TEST(decimal_nested_in_array) {
   const sourcemeta::core::Decimal value1{"111.111"};
   const sourcemeta::core::Decimal value2{"222.222"};
-  sourcemeta::core::JSON inner_array{sourcemeta::core::JSON{value1},
-                                     sourcemeta::core::JSON{value2}};
+  auto inner_array{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{value1}, sourcemeta::core::JSON{value2}})};
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(std::move(inner_array));
   std::ostringstream stream;

--- a/test/json/json_stringify_test.cc
+++ b/test/json/json_stringify_test.cc
@@ -138,18 +138,18 @@ TEST(small_string) {
 }
 
 TEST(array_integers) {
-  const sourcemeta::core::JSON document{
-      sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
-      sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}};
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
+       sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}})};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "[1,2,3,4]");
 }
 
 TEST(array_nested) {
-  sourcemeta::core::JSON array{
-      sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
-      sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}};
+  auto array{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
+       sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}})};
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(std::move(array));
   std::ostringstream stream;
@@ -611,9 +611,9 @@ TEST(decimal_in_array) {
   const sourcemeta::core::Decimal value1{100};
   const sourcemeta::core::Decimal value2{"999.999"};
   const sourcemeta::core::Decimal value3{"-42"};
-  const sourcemeta::core::JSON document{sourcemeta::core::JSON{value1},
-                                        sourcemeta::core::JSON{value2},
-                                        sourcemeta::core::JSON{value3}};
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{value1}, sourcemeta::core::JSON{value2},
+       sourcemeta::core::JSON{value3}})};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "[1.00e+2,9.99999e+2,-4.2e+1]");
@@ -623,8 +623,8 @@ TEST(decimal_large_numbers_in_array) {
   const sourcemeta::core::Decimal value1{"123456789012345678901234567890"};
   const sourcemeta::core::Decimal value2{
       "98765432109876543210.98765432109876543210"};
-  const sourcemeta::core::JSON document{sourcemeta::core::JSON{value1},
-                                        sourcemeta::core::JSON{value2}};
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{value1}, sourcemeta::core::JSON{value2}})};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "[1.23456789012345678901234567890e+29,9."
@@ -634,8 +634,8 @@ TEST(decimal_large_numbers_in_array) {
 TEST(decimal_nested_in_array) {
   const sourcemeta::core::Decimal value1{"111.111"};
   const sourcemeta::core::Decimal value2{"222.222"};
-  sourcemeta::core::JSON inner_array{sourcemeta::core::JSON{value1},
-                                     sourcemeta::core::JSON{value2}};
+  auto inner_array{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{value1}, sourcemeta::core::JSON{value2}})};
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(std::move(inner_array));
   std::ostringstream stream;

--- a/test/json/json_value_test.cc
+++ b/test/json/json_value_test.cc
@@ -352,9 +352,9 @@ TEST(into_string_from_string) {
 }
 
 TEST(to_ostream) {
-  const sourcemeta::core::JSON document{
-      sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
-      sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}};
+  const auto document{sourcemeta::core::JSON::make_array(
+      {sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
+       sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}})};
   std::ostringstream stream;
   stream << document;
 #ifdef NDEBUG


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

