### PR TITLE
Fix `weakly_canonical` returning relative paths on some platforms

### DIFF
--- a/src/lang/io/include/sourcemeta/core/io.h
+++ b/src/lang/io/include/sourcemeta/core/io.h
@@ -57,7 +57,8 @@ auto canonical(const std::filesystem::path &path) -> std::filesystem::path;
 /// @ingroup io
 ///
 /// A safe variant of `std::filesystem::weakly_canonical` that takes into
-/// account platform-specific oddities like FIFO on GNU/Linux. For example:
+/// account platform-specific oddities like FIFO on GNU/Linux, always resolving
+/// relative paths against the current working directory. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/io.h>

--- a/src/lang/io/io.cc
+++ b/src/lang/io/io.cc
@@ -130,15 +130,25 @@ auto weakly_canonical(const std::filesystem::path &path)
     return path;
   }
 
+  // C++ [fs.op.weakly.canonical] defines the result in terms of "the leading
+  // elements of p that exist, if any", leaving the case where nothing exists
+  // unspecified. Standard libraries disagree there: some resolve against the
+  // current working directory while others hand the input back untouched.
+  // Absolutising first makes the result absolute on every platform, and is a
+  // no-op when any leading element exists, as canonicalising that prefix
+  // already yields an absolute path
+  const auto absolute_path{
+      path.is_absolute() ? path : std::filesystem::absolute(path)};
+
   // On Linux, FIFO files (like /dev/fd/XX due to process substitution)
   // cannot be made canonical
   // See https://github.com/sourcemeta/jsonschema/issues/252
-  if (std::filesystem::is_fifo(path)) {
-    return normalize(path);
+  if (std::filesystem::is_fifo(absolute_path)) {
+    return normalize(absolute_path);
   }
 
   try {
-    return normalize(std::filesystem::weakly_canonical(path));
+    return normalize(std::filesystem::weakly_canonical(absolute_path));
   } catch (const std::filesystem::filesystem_error &error) {
     if (error.code() == std::errc::no_such_file_or_directory) {
       throw IOFileNotFoundError{path};

--- a/test/io/io_weakly_canonical_test.cc
+++ b/test/io/io_weakly_canonical_test.cc
@@ -1,6 +1,12 @@
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/test.h>
 
+#include <filesystem> // std::filesystem
+
+#if !defined(_WIN32)
+#include <sys/stat.h> // mkfifo, S_IRUSR, S_IWUSR
+#endif
+
 TEST(test_txt) {
   const auto path{sourcemeta::core::weakly_canonical(
       std::filesystem::path{STUBS_DIRECTORY} / "test.txt")};
@@ -16,6 +22,43 @@ TEST(not_exists) {
 TEST(empty) {
   EXPECT_EQ(sourcemeta::core::weakly_canonical(std::filesystem::path{}),
             std::filesystem::path{});
+}
+
+TEST(relative_that_does_not_exist) {
+  const auto path{sourcemeta::core::weakly_canonical(
+      std::filesystem::path{"sourcemeta-core-does-not-exist.txt"})};
+  EXPECT_TRUE(path.is_absolute());
+  EXPECT_EQ(path,
+            std::filesystem::current_path() /
+                std::filesystem::path{"sourcemeta-core-does-not-exist.txt"});
+}
+
+TEST(relative_with_missing_leading_component) {
+  const auto path{sourcemeta::core::weakly_canonical(
+      std::filesystem::path{"sourcemeta-core-nope"} /
+      std::filesystem::path{"also-nope.txt"})};
+  EXPECT_TRUE(path.is_absolute());
+  EXPECT_EQ(path, std::filesystem::current_path() /
+                      std::filesystem::path{"sourcemeta-core-nope"} /
+                      std::filesystem::path{"also-nope.txt"});
+}
+
+TEST(relative_with_dot_segments_that_does_not_exist) {
+  const auto path{sourcemeta::core::weakly_canonical(
+      std::filesystem::path{"."} /
+      std::filesystem::path{"sourcemeta-core-nope"} /
+      std::filesystem::path{".."} /
+      std::filesystem::path{"sourcemeta-core-also-nope.txt"})};
+  EXPECT_TRUE(path.is_absolute());
+  EXPECT_EQ(path, std::filesystem::current_path() /
+                      std::filesystem::path{"sourcemeta-core-also-nope.txt"});
+}
+
+TEST(relative_that_exists) {
+  const auto path{sourcemeta::core::weakly_canonical(
+      std::filesystem::path{"."} / std::filesystem::path{"."})};
+  EXPECT_TRUE(path.is_absolute());
+  EXPECT_EQ(path, std::filesystem::current_path());
 }
 
 #ifndef _WIN32
@@ -93,6 +136,17 @@ TEST(posix_no_change_for_clean_path) {
   EXPECT_EQ(
       sourcemeta::core::weakly_canonical(std::filesystem::path{"/foo/bar/baz"}),
       std::filesystem::path{"/foo/bar/baz"});
+}
+
+TEST(posix_relative_fifo) {
+  const std::filesystem::path name{
+      "sourcemeta-core-weakly-canonical-test-fifo"};
+  std::filesystem::remove(name);
+  EXPECT_EQ(::mkfifo(name.c_str(), S_IRUSR | S_IWUSR), 0);
+  const auto path{sourcemeta::core::weakly_canonical(name)};
+  std::filesystem::remove(name);
+  EXPECT_TRUE(path.is_absolute());
+  EXPECT_EQ(path, std::filesystem::current_path() / name);
 }
 
 #endif

--- a/test/io/io_weakly_canonical_test.cc
+++ b/test/io/io_weakly_canonical_test.cc
@@ -139,14 +139,18 @@ TEST(posix_no_change_for_clean_path) {
 }
 
 TEST(posix_relative_fifo) {
-  const std::filesystem::path name{
-      "sourcemeta-core-weakly-canonical-test-fifo"};
-  std::filesystem::remove(name);
-  EXPECT_EQ(::mkfifo(name.c_str(), S_IRUSR | S_IWUSR), 0);
-  const auto path{sourcemeta::core::weakly_canonical(name)};
-  std::filesystem::remove(name);
+  const auto fifo_path{std::filesystem::path{BUILD_DIRECTORY} /
+                       "sourcemeta_core_io_weakly_canonical_fifo"};
+  std::filesystem::remove(fifo_path);
+  EXPECT_EQ(::mkfifo(fifo_path.c_str(), S_IRUSR | S_IWUSR), 0);
+  const auto relative_fifo_path{std::filesystem::relative(fifo_path)};
+  const auto path{sourcemeta::core::weakly_canonical(relative_fifo_path)};
+  const auto expected{sourcemeta::core::weakly_canonical(fifo_path)};
+  std::filesystem::remove(fifo_path);
+
+  EXPECT_TRUE(relative_fifo_path.is_relative());
   EXPECT_TRUE(path.is_absolute());
-  EXPECT_EQ(path, std::filesystem::current_path() / name);
+  EXPECT_EQ(path, expected);
 }
 
 #endif


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

