### PR TITLE
test(ip): expand is_ipv6 coverage across the IPv6address alternatives

### DIFF
--- a/test/ip/ipv6_test.cc
+++ b/test/ip/ipv6_test.cc
@@ -367,3 +367,327 @@ TEST(rejects_leading_single_colon_with_double) {
 TEST(rejects_trailing_single_colon_with_double) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1::2:"));
 }
+
+TEST(valid_no_groups_before_elision_six_groups_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::1:2:3:4:5:6"));
+}
+
+TEST(valid_no_groups_before_elision_five_groups_after_with_ipv4) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::1:2:3:4:1.2.3.4"));
+}
+
+TEST(valid_one_group_before_elision_five_groups_after_with_ipv4) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1::2:3:4:5:1.2.3.4"));
+}
+
+TEST(valid_no_groups_before_elision_five_groups_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::1:2:3:4:5"));
+}
+
+TEST(valid_no_groups_before_elision_four_groups_after_with_ipv4) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::1:2:3:1.2.3.4"));
+}
+
+TEST(valid_one_group_before_elision_five_groups_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1::2:3:4:5:6"));
+}
+
+TEST(valid_two_groups_before_elision_four_groups_after_with_ipv4) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2::3:4:5:1.2.3.4"));
+}
+
+TEST(valid_no_groups_before_elision_four_groups_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::1:2:3:4"));
+}
+
+TEST(valid_one_group_before_elision_four_groups_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1::2:3:4:5"));
+}
+
+TEST(valid_one_group_before_elision_three_groups_after_with_ipv4) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1::2:3:1.2.3.4"));
+}
+
+TEST(valid_two_groups_before_elision_four_groups_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2::3:4:5:6"));
+}
+
+TEST(valid_three_groups_before_elision_three_groups_after_with_ipv4) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3::4:5:1.2.3.4"));
+}
+
+TEST(valid_no_groups_before_elision_three_groups_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::1:2:3"));
+}
+
+TEST(valid_one_group_before_elision_three_groups_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1::2:3:4"));
+}
+
+TEST(valid_one_group_before_elision_two_groups_after_with_ipv4) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1::2:1.2.3.4"));
+}
+
+TEST(valid_two_groups_before_elision_three_groups_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2::3:4:5"));
+}
+
+TEST(valid_two_groups_before_elision_two_groups_after_with_ipv4) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2::3:1.2.3.4"));
+}
+
+TEST(valid_three_groups_before_elision_two_groups_after_with_ipv4) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3::4:1.2.3.4"));
+}
+
+TEST(valid_four_groups_before_elision_two_groups_after_with_ipv4) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4::5:1.2.3.4"));
+}
+
+TEST(valid_no_groups_before_elision_two_groups_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::1:2"));
+}
+
+TEST(valid_one_group_before_elision_two_groups_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1::2:3"));
+}
+
+TEST(valid_three_groups_before_elision_one_group_after_with_ipv4) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3::1.2.3.4"));
+}
+
+TEST(valid_four_groups_before_elision_two_groups_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4::5:6"));
+}
+
+TEST(valid_three_groups_before_elision_one_group_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3::4"));
+}
+
+TEST(valid_five_groups_before_elision_one_group_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4:5::6"));
+}
+
+TEST(valid_two_groups_before_elision_nothing_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2::"));
+}
+
+TEST(valid_three_groups_before_elision_nothing_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3::"));
+}
+
+TEST(valid_four_groups_before_elision_nothing_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4::"));
+}
+
+TEST(valid_five_groups_before_elision_nothing_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4:5::"));
+}
+
+TEST(valid_six_groups_before_elision_nothing_after) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4:5:6::"));
+}
+
+TEST(valid_embedded_ipv4_dec_octet_one_digit) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::ffff:0.0.0.0"));
+}
+
+TEST(valid_embedded_ipv4_dec_octet_two_digit) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::ffff:42.42.42.42"));
+}
+
+TEST(valid_embedded_ipv4_dec_octet_one_hundreds) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::ffff:199.199.199.199"));
+}
+
+TEST(valid_embedded_ipv4_dec_octet_two_hundreds) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::ffff:249.249.249.249"));
+}
+
+TEST(valid_embedded_ipv4_dec_octet_two_five_zero) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::ffff:250.250.250.250"));
+}
+
+TEST(valid_embedded_ipv4_dec_octet_two_five_five) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::ffff:255.255.255.255"));
+}
+
+TEST(invalid_embedded_ipv4_octet_over_255_position_1) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::ffff:256.1.1.1"));
+}
+
+TEST(invalid_embedded_ipv4_leading_zero_position_1) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::ffff:01.1.1.1"));
+}
+
+TEST(invalid_embedded_ipv4_octet_over_255_position_2) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::ffff:1.256.1.1"));
+}
+
+TEST(invalid_embedded_ipv4_leading_zero_position_2) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::ffff:1.01.1.1"));
+}
+
+TEST(invalid_embedded_ipv4_octet_over_255_position_3) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::ffff:1.1.256.1"));
+}
+
+TEST(invalid_embedded_ipv4_leading_zero_position_3) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::ffff:1.1.01.1"));
+}
+
+TEST(invalid_embedded_ipv4_octet_over_255_position_4) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::ffff:1.1.1.256"));
+}
+
+TEST(invalid_embedded_ipv4_leading_zero_position_4) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::ffff:1.1.1.01"));
+}
+
+TEST(valid_compressed_group_one_digit) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::a"));
+}
+
+TEST(valid_compressed_group_two_digits) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::ab"));
+}
+
+TEST(valid_compressed_group_three_digits) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::abc"));
+}
+
+TEST(valid_compressed_group_four_digits) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::abcd"));
+}
+
+TEST(valid_compressed_group_leading_zero_two) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::0a"));
+}
+
+TEST(valid_compressed_group_leading_zero_three) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::00a"));
+}
+
+TEST(valid_compressed_group_leading_zero_four) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::000a"));
+}
+
+TEST(valid_compressed_group_all_zero_four) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("::0000"));
+}
+
+TEST(valid_compressed_uppercase) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("2001:DB8::AB"));
+}
+
+TEST(valid_compressed_mixed_case) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("2001:dB8::aB"));
+}
+
+TEST(valid_uppercase_ls32_hex) {
+  EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:AB:CD"));
+}
+
+TEST(invalid_eight_groups_with_trailing_elision) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7:8::"));
+}
+
+TEST(invalid_ipv4_before_elision) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("1.2.3.4::"));
+}
+
+TEST(invalid_ipv4_before_final_group) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::1.2.3.4:5"));
+}
+
+TEST(invalid_ipv4_in_first_position) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("1.2.3.4:5:6:7:8:9:10"));
+}
+
+TEST(invalid_five_hex_digits_after_elision) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("2001:db8::00001"));
+}
+
+TEST(invalid_five_hex_digits_first_group) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("12345::1"));
+}
+
+TEST(invalid_empty_group_in_middle) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2::3::4"));
+}
+
+TEST(invalid_quadruple_colon) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("1::::8"));
+}
+
+TEST(invalid_only_double_colon_pair) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::::"));
+}
+
+TEST(invalid_trailing_dot_after_ipv4) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::1.2.3.4."));
+}
+
+TEST(invalid_open_bracket_only) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("[::1"));
+}
+
+TEST(invalid_close_bracket_only) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::1]"));
+}
+
+TEST(invalid_zone_identifier_percent_encoded) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("fe80::1%25eth0"));
+}
+
+TEST(invalid_zone_identifier_empty) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("fe80::1%"));
+}
+
+TEST(invalid_prefix_length_zero) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::/0"));
+}
+
+TEST(invalid_prefix_length_empty) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::1/"));
+}
+
+TEST(invalid_trailing_newline) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::1\n"));
+}
+
+TEST(invalid_leading_newline) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("\n::1"));
+}
+
+TEST(invalid_trailing_tab) { EXPECT_FALSE(sourcemeta::core::is_ipv6("::1\t")); }
+
+TEST(invalid_trailing_carriage_return) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::1\r"));
+}
+
+TEST(invalid_embedded_space) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("::1 2"));
+}
+
+TEST(invalid_leading_space) { EXPECT_FALSE(sourcemeta::core::is_ipv6(" ::1")); }
+
+TEST(invalid_fullwidth_hex_digit) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7:Ａ"));
+}
+
+TEST(invalid_fullwidth_digit) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("１２３４::1"));
+}
+
+TEST(invalid_arabic_indic_digit) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7:٤"));
+}
+
+TEST(invalid_bengali_digit_in_embedded_ipv4) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2::192.16৪.0.1"));
+}
+
+TEST(invalid_fullwidth_colon) {
+  EXPECT_FALSE(sourcemeta::core::is_ipv6("1：2:3:4:5:6:7:8"));
+}


### PR DESCRIPTION
I added 82 tests for `sourcemeta::core::is_ipv6`, organised around the nine `IPv6address` alternatives in [RFC 3986 Section 3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2). Core already passes all 82, so this is coverage, not a fix.

## Changes

Everything goes into the existing `test/ip/ipv6_test.cc`, after the current checks - no new file.

## What is new

The grammar admits exactly **59 distinct shapes**, counting each (alternative, groups written before the elision, `ls32` form) triple once. The file covers a valid case for 29 of them. The other 30 are the backbone of this change, named the way the file already names things - how many groups sit either side of the elision, and whether the low 32 bits are written as an embedded IPv4:

- the third through seventh alternatives at every legal prefix length, in both `ls32` forms (`::1:2:3:4:5:6`, `1::2:3:4:5:6`, `1:2::3:4:5:6`, `::1:2:3:1.2.3.4`, `1:2::3:4:5:1.2.3.4`, `1:2:3::4:1.2.3.4`, and the rest)
- the eighth and ninth alternatives at the prefix lengths the file skips (`1:2:3::4`, `1:2:3:4:5::6`, `1:2::`, `1:2:3::`, `1:2:3:4::`, `1:2:3:4:5::`, `1:2:3:4:5:6::`)

On top of the shapes:

- the five `dec-octet` alternatives exercised in the **embedded** position rather than through `is_ipv4` alone (`0`, `42`, `199`, `249`, `250`, `255`), since the interaction is what is untested here - plus an out-of-range and a leading-zero octet at each of the four positions
- hex-digit width and case inside a **compressed** address (`::a`, `::ab`, `::abc`, `::abcd`, `::0a`, `::00a`, `::000a`, `::0000`, `2001:DB8::AB`, `2001:dB8::aB`); the file's existing width and case checks are all on the uncompressed eight-group form
- the boundary neighbours of those shapes: eight groups alongside a `::` at either end, a dotted quad before an elision (`1.2.3.4::`) or before another group (`::1.2.3.4:5`), five hex digits in the first and in a post-elision group, an empty interior group, a quadruple colon, and the three-, five- and trailing-dot embedded IPv4 forms
- the delimiters a delegating parser tends to accept: a half bracket at either end, an [RFC 6874](https://www.rfc-editor.org/rfc/rfc6874) percent-encoded zone identifier (`fe80::1%25eth0`) and an empty one, a prefix length, and the terminator set (`\n`, `\r`, `\t`, leading and embedded space)
- non-ASCII digit look-alikes a folding parser accepts: fullwidth `Ａ`, fullwidth digits, an Arabic-Indic digit, a Bengali digit inside the embedded IPv4, and a fullwidth colon

## How I checked the expected values

I transcribed the grammar into four independent oracles and required all four to agree before any case was written out: a regex over the RFC 3986 ABNF, a generic ABNF interpreter driven by the rules as data, one derived from the RFC 4291 Section 2.2 prose rather than the grammar, and a bit-level parser that builds the 128-bit value and accepts only if the parse consumes the whole input. They agree on 19,319 structured inputs and on 2,000,000 mutations, with no split. Where the bit-level parser and Python's `ipaddress` both accept, they agree on the value and not merely the verdict.

I then ran all 82 inputs through the real `is_ipv6` - a small driver linking the current `ipv6.cc` and `ipv4.cc`, reading hex-encoded bytes so control characters and non-ASCII survive the transport - and got 0 mismatch. The generator refuses to emit any case Core disagrees with, so the block cannot contain a failing test.

The full `ip` unit suite passes: **424 tests, 0 failures**.

Rebased on `main` after #2713, so the two cases it added that overlap with mine (`:1::2` and `1::2:`) are not duplicated here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

