### PR TITLE
Revise the `read_file_to_string` utility function to open as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,5 @@
 # platform
 /test/json/stub_*.json -text
 /test/yaml/stubs/** -text
+/vendor/aws-sig-v4-test-suite/** -text
+/vendor/unicodetools/unicodetools/data/** -text

--- a/src/lang/io/include/sourcemeta/core/io.h
+++ b/src/lang/io/include/sourcemeta/core/io.h
@@ -236,7 +236,10 @@ auto read_file_to_string(const std::filesystem::path &path)
   }
 
   const auto canonical_path{sourcemeta::core::canonical(path)};
-  std::basic_ifstream<CharT, Traits> stream{canonical_path};
+  // Binary, so that the result is the bytes the file holds. Text mode collapses
+  // CRLF to LF on some platforms, which silently makes the contents, its size
+  // and every offset into it disagree with the file itself
+  std::basic_ifstream<CharT, Traits> stream{canonical_path, std::ios::binary};
   if (!stream.is_open()) {
     throw IOFilePermissionError{canonical_path};
   }

--- a/src/lang/io/include/sourcemeta/core/io.h
+++ b/src/lang/io/include/sourcemeta/core/io.h
@@ -267,8 +267,8 @@ auto read_file_to_string(const std::filesystem::path &path)
   std::basic_string<CharT, Traits> result;
   result.resize(static_cast<std::size_t>(size));
   stream.read(result.data(), static_cast<std::streamsize>(result.size()));
-  // Text-mode reads may return fewer characters than the byte count
-  // (i.e. CRLF collapses to LF on Windows), so trim to actual.
+  // The size was taken before the read, so a file that shrank in between hands
+  // back fewer bytes than were asked for
   result.resize(static_cast<std::size_t>(stream.gcount()));
   return result;
 }

--- a/test/io/CMakeLists.txt
+++ b/test/io/CMakeLists.txt
@@ -11,7 +11,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME io
     io_for_each_line_test.cc
     io_hardlink_directory_test.cc
     io_read_file_test.cc
-  io_read_file_to_string_test.cc
+    io_read_file_to_string_test.cc
     io_read_to_string_test.cc
     io_resume_stream_test.cc
     io_is_under_path_test.cc

--- a/test/io/CMakeLists.txt
+++ b/test/io/CMakeLists.txt
@@ -11,6 +11,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME io
     io_for_each_line_test.cc
     io_hardlink_directory_test.cc
     io_read_file_test.cc
+  io_read_file_to_string_test.cc
     io_read_to_string_test.cc
     io_resume_stream_test.cc
     io_is_under_path_test.cc

--- a/test/io/io_flush_test.cc
+++ b/test/io/io_flush_test.cc
@@ -1,10 +1,6 @@
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/test.h>
 
-#if !defined(_WIN32)
-#include <unistd.h> // geteuid
-#endif
-
 TEST(test_txt) {
   const auto path{std::filesystem::path{STUBS_DIRECTORY} / "test.txt"};
   sourcemeta::core::flush(path);
@@ -41,11 +37,6 @@ TEST(flush_a_directory_throws) {
 // POSIX permission bits don't map cleanly to Windows ACLs
 #if !defined(_WIN32)
 TEST(flush_an_unreadable_file_throws_permission_error) {
-  // The root user opens files regardless of their permission bits
-  if (::geteuid() == 0) {
-    return;
-  }
-
   const auto path{std::filesystem::temp_directory_path() /
                   "sourcemeta_core_io_flush_locked.txt"};
   std::ofstream output{path};
@@ -53,6 +44,22 @@ TEST(flush_an_unreadable_file_throws_permission_error) {
   output.close();
   std::filesystem::permissions(path, std::filesystem::perms::none,
                                std::filesystem::perm_options::replace);
+
+  // A process that bypasses the mode bits, such as one running as root, and a
+  // filesystem that ignores them at all, both still open the file. What the
+  // mode amounts to is settled by trying it rather than by assuming
+  std::ifstream probe{path};
+  const auto readable{probe.is_open()};
+  probe.close();
+
+  if (readable) {
+    sourcemeta::core::flush(path);
+    std::filesystem::permissions(path, std::filesystem::perms::owner_all,
+                                 std::filesystem::perm_options::replace);
+    std::filesystem::remove(path);
+    return;
+  }
+
   try {
     sourcemeta::core::flush(path);
     std::filesystem::permissions(path, std::filesystem::perms::owner_all,
@@ -60,6 +67,7 @@ TEST(flush_an_unreadable_file_throws_permission_error) {
     std::filesystem::remove(path);
     FAIL();
   } catch (const sourcemeta::core::IOFilePermissionError &error) {
+    EXPECT_STREQ(error.what(), "Permission denied");
     EXPECT_EQ(error.path(), path);
     std::filesystem::permissions(path, std::filesystem::perms::owner_all,
                                  std::filesystem::perm_options::replace);

--- a/test/io/io_read_file_to_string_test.cc
+++ b/test/io/io_read_file_to_string_test.cc
@@ -1,0 +1,69 @@
+#include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
+
+#include <filesystem> // std::filesystem::path
+#include <string>     // std::string
+
+// A whole-file read hands back the bytes the file holds. Text mode would
+// collapse a carriage return before a line feed on some platforms, which makes
+// the contents, its size and every offset into it disagree with the file itself
+TEST(carriage_returns_survive) {
+  const sourcemeta::core::TemporaryDirectory directory{
+      std::filesystem::temp_directory_path(), "core-io-"};
+  const auto path{directory.path() / "crlf.txt"};
+  sourcemeta::core::write_file(path, std::string{"alpha\r\nbeta\r\n"});
+  EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "alpha\r\nbeta\r\n");
+}
+
+TEST(the_size_matches_the_file) {
+  const sourcemeta::core::TemporaryDirectory directory{
+      std::filesystem::temp_directory_path(), "core-io-"};
+  const auto path{directory.path() / "crlf.txt"};
+  sourcemeta::core::write_file(path, std::string{"a\r\nb\r\n"});
+  EXPECT_EQ(sourcemeta::core::read_file_to_string(path).size(),
+            std::filesystem::file_size(path));
+}
+
+TEST(a_lone_carriage_return_survives) {
+  const sourcemeta::core::TemporaryDirectory directory{
+      std::filesystem::temp_directory_path(), "core-io-"};
+  const auto path{directory.path() / "cr.txt"};
+  sourcemeta::core::write_file(path, std::string{"alpha\rbeta"});
+  EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "alpha\rbeta");
+}
+
+TEST(an_arbitrary_byte_survives) {
+  const sourcemeta::core::TemporaryDirectory directory{
+      std::filesystem::temp_directory_path(), "core-io-"};
+  const auto path{directory.path() / "binary.bin"};
+  sourcemeta::core::write_file(path, std::string{"\x01\x1A\x7F", 3});
+  EXPECT_EQ(sourcemeta::core::read_file_to_string(path),
+            (std::string{"\x01\x1A\x7F", 3}));
+}
+
+TEST(an_empty_file) {
+  const sourcemeta::core::TemporaryDirectory directory{
+      std::filesystem::temp_directory_path(), "core-io-"};
+  const auto path{directory.path() / "empty.txt"};
+  sourcemeta::core::write_file(path, std::string{});
+  EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "");
+}
+
+TEST(a_missing_file) {
+  const std::filesystem::path path{"/nonexistent-core-io-fixture.txt"};
+  try {
+    sourcemeta::core::read_file_to_string(path);
+    FAIL();
+  } catch (const sourcemeta::core::IOFileNotFoundError &) {
+  }
+}
+
+TEST(a_directory) {
+  const sourcemeta::core::TemporaryDirectory directory{
+      std::filesystem::temp_directory_path(), "core-io-"};
+  try {
+    sourcemeta::core::read_file_to_string(directory.path());
+    FAIL();
+  } catch (const sourcemeta::core::IOIsADirectoryError &) {
+  }
+}

--- a/test/io/io_read_file_to_string_test.cc
+++ b/test/io/io_read_file_to_string_test.cc
@@ -54,7 +54,11 @@ TEST(a_missing_file) {
   try {
     sourcemeta::core::read_file_to_string(path);
     FAIL();
-  } catch (const sourcemeta::core::IOFileNotFoundError &) {
+  } catch (const sourcemeta::core::IOFileNotFoundError &error) {
+    EXPECT_STREQ(error.what(), "File not found");
+    EXPECT_EQ(error.path(), path);
+  } catch (...) {
+    FAIL();
   }
 }
 
@@ -64,6 +68,34 @@ TEST(a_directory) {
   try {
     sourcemeta::core::read_file_to_string(directory.path());
     FAIL();
-  } catch (const sourcemeta::core::IOIsADirectoryError &) {
+  } catch (const sourcemeta::core::IOIsADirectoryError &error) {
+    EXPECT_STREQ(error.what(), "Expected a file but got a directory");
+    EXPECT_EQ(error.path(), directory.path());
+  } catch (...) {
+    FAIL();
   }
 }
+
+// POSIX permission bits don't map cleanly to Windows ACLs
+#if !defined(_WIN32)
+TEST(an_unreadable_file) {
+  const sourcemeta::core::TemporaryDirectory directory{
+      std::filesystem::temp_directory_path(), "core-io-"};
+  const auto path{directory.path() / "locked.txt"};
+  sourcemeta::core::write_file(path, std::string{"secret"});
+  std::filesystem::permissions(path, std::filesystem::perms::none,
+                               std::filesystem::perm_options::replace);
+
+  try {
+    sourcemeta::core::read_file_to_string(path);
+    FAIL();
+  } catch (const sourcemeta::core::IOFilePermissionError &error) {
+    EXPECT_STREQ(error.what(), "Permission denied");
+    // The path is resolved before the file is opened, so the error carries the
+    // canonical form rather than the one that was asked for
+    EXPECT_EQ(error.path(), sourcemeta::core::canonical(path));
+  } catch (...) {
+    FAIL();
+  }
+}
+#endif

--- a/test/io/io_read_file_to_string_test.cc
+++ b/test/io/io_read_file_to_string_test.cc
@@ -2,6 +2,7 @@
 #include <sourcemeta/core/test.h>
 
 #include <filesystem> // std::filesystem::path
+#include <fstream>    // std::ifstream
 #include <string>     // std::string
 
 // A whole-file read hands back the bytes the file holds. Text mode would
@@ -85,6 +86,15 @@ TEST(an_unreadable_file) {
   sourcemeta::core::write_file(path, std::string{"secret"});
   std::filesystem::permissions(path, std::filesystem::perms::none,
                                std::filesystem::perm_options::replace);
+
+  // A process that bypasses the mode bits, such as one running as root, and a
+  // filesystem that ignores them at all, both still hand the file over. What
+  // the mode amounts to here is settled by trying it rather than by assuming
+  std::ifstream probe{path};
+  if (probe.is_open()) {
+    EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "secret");
+    return;
+  }
 
   try {
     sourcemeta::core::read_file_to_string(path);

--- a/test/io/io_write_file_test.cc
+++ b/test/io/io_write_file_test.cc
@@ -1,15 +1,15 @@
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/test.h>
 
-#include <array>        // std::array
-#include <cstddef>      // std::byte
-#include <filesystem>   // std::filesystem
-#include <fstream>      // std::ifstream, std::istreambuf_iterator
-#include <ios>          // std::ios::binary
-#include <ostream>      // std::ostream
-#include <span>         // std::span
-#include <stdexcept>    // std::runtime_error
-#include <string>       // std::string
+#include <array>      // std::array
+#include <cstddef>    // std::byte
+#include <filesystem> // std::filesystem
+#include <fstream>    // std::ifstream, std::istreambuf_iterator, std::ofstream
+#include <ios>        // std::ios::binary
+#include <ostream>    // std::ostream
+#include <span>       // std::span
+#include <stdexcept>  // std::runtime_error
+#include <string>     // std::string
 #include <system_error> // std::error_code
 
 class IOWriteFileTest {
@@ -145,10 +145,24 @@ TEST_F(IOWriteFileTest, read_only_parent_throws_permission_error) {
                                std::filesystem::perm_options::replace);
   const auto path{read_only_dir / "out.txt"};
 
+  // A process that bypasses the mode bits, such as one running as root, and a
+  // filesystem that ignores them at all, both still write here. What the mode
+  // amounts to is settled by trying it rather than by assuming
+  const auto probe_path{read_only_dir / "probe.txt"};
+  std::ofstream probe{probe_path};
+  if (probe.is_open()) {
+    probe.close();
+    std::filesystem::remove(probe_path);
+    sourcemeta::core::write_file(path, "written");
+    EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "written");
+    return;
+  }
+
   try {
-    sourcemeta::core::write_file(path, "should fail");
+    sourcemeta::core::write_file(path, "written");
     FAIL();
   } catch (const sourcemeta::core::IOFilePermissionError &error) {
+    EXPECT_STREQ(error.what(), "Permission denied");
     EXPECT_EQ(error.path(), path);
   } catch (...) {
     FAIL();


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

