### PR TITLE
Unify project codebase in preparation for `clang-tidy`

### DIFF
--- a/src/core/crypto/crypto_aes_cbc_hmac.cc
+++ b/src/core/crypto/crypto_aes_cbc_hmac.cc
@@ -35,7 +35,7 @@ auto associated_data_length_block(const std::size_t associated_data_size)
   std::string block(8, '\x00');
   const auto bits{static_cast<std::uint64_t>(associated_data_size) * 8};
   for (std::size_t index = 0; index < 8; ++index) {
-    block[7 - index] = static_cast<char>((bits >> (8 * index)) & 0xffu);
+    block[7 - index] = static_cast<char>((bits >> (8 * index)) & 0xffU);
   }
 
   return block;

--- a/src/core/crypto/crypto_apple.h
+++ b/src/core/crypto/crypto_apple.h
@@ -43,7 +43,7 @@ struct PrivateKey::Internal {
 inline auto copy_external_representation(SecKeyRef key)
     -> std::optional<std::string> {
   CFErrorRef error{nullptr};
-  auto data{SecKeyCopyExternalRepresentation(key, &error)};
+  const auto *data{SecKeyCopyExternalRepresentation(key, &error)};
   if (data == nullptr) {
     if (error != nullptr) {
       CFRelease(error);

--- a/src/core/crypto/crypto_base64.cc
+++ b/src/core/crypto/crypto_base64.cc
@@ -45,18 +45,18 @@ auto encode(const std::string_view input, const std::string_view alphabet,
     const std::uint32_t first{static_cast<std::uint8_t>(input[index])};
     const std::uint32_t second{static_cast<std::uint8_t>(input[index + 1])};
     const std::uint32_t third{static_cast<std::uint8_t>(input[index + 2])};
-    output.push_back(alphabet[first >> 2u]);
-    output.push_back(alphabet[((first & 0x03u) << 4u) | (second >> 4u)]);
-    output.push_back(alphabet[((second & 0x0Fu) << 2u) | (third >> 6u)]);
-    output.push_back(alphabet[third & 0x3Fu]);
+    output.push_back(alphabet[first >> 2U]);
+    output.push_back(alphabet[((first & 0x03U) << 4U) | (second >> 4U)]);
+    output.push_back(alphabet[((second & 0x0FU) << 2U) | (third >> 6U)]);
+    output.push_back(alphabet[third & 0x3FU]);
     index += 3;
   }
 
   const auto remaining{input.size() - index};
   if (remaining == 1) {
     const std::uint32_t first{static_cast<std::uint8_t>(input[index])};
-    output.push_back(alphabet[first >> 2u]);
-    output.push_back(alphabet[(first & 0x03u) << 4u]);
+    output.push_back(alphabet[first >> 2U]);
+    output.push_back(alphabet[(first & 0x03U) << 4U]);
     if (padding) {
       output.push_back('=');
       output.push_back('=');
@@ -64,9 +64,9 @@ auto encode(const std::string_view input, const std::string_view alphabet,
   } else if (remaining == 2) {
     const std::uint32_t first{static_cast<std::uint8_t>(input[index])};
     const std::uint32_t second{static_cast<std::uint8_t>(input[index + 1])};
-    output.push_back(alphabet[first >> 2u]);
-    output.push_back(alphabet[((first & 0x03u) << 4u) | (second >> 4u)]);
-    output.push_back(alphabet[(second & 0x0Fu) << 2u]);
+    output.push_back(alphabet[first >> 2U]);
+    output.push_back(alphabet[((first & 0x03U) << 4U) | (second >> 4U)]);
+    output.push_back(alphabet[(second & 0x0FU) << 2U]);
     if (padding) {
       output.push_back('=');
     }
@@ -121,11 +121,11 @@ auto decode_into(const std::string_view input,
       return false;
     }
 
-    const std::uint32_t group{(first << 18u) | (second << 12u) | (third << 6u) |
+    const std::uint32_t group{(first << 18U) | (second << 12U) | (third << 6U) |
                               fourth};
-    output.push_back(static_cast<char>((group >> 16u) & 0xFFu));
-    output.push_back(static_cast<char>((group >> 8u) & 0xFFu));
-    output.push_back(static_cast<char>(group & 0xFFu));
+    output.push_back(static_cast<char>((group >> 16U) & 0xFFU));
+    output.push_back(static_cast<char>((group >> 8U) & 0xFFU));
+    output.push_back(static_cast<char>(group & 0xFFU));
     index += 4;
   }
 
@@ -138,12 +138,12 @@ auto decode_into(const std::string_view input,
     const std::uint32_t second{
         table[static_cast<std::uint8_t>(data[index + 1])]};
     if (first == INVALID_SEXTET || second == INVALID_SEXTET ||
-        (second & 0x0Fu) != 0) {
+        (second & 0x0FU) != 0) {
       output.resize(base, '\0');
       return false;
     }
 
-    output.push_back(static_cast<char>((first << 2u) | (second >> 4u)));
+    output.push_back(static_cast<char>((first << 2U) | (second >> 4U)));
   } else if (remaining == 3) {
     const std::uint32_t first{table[static_cast<std::uint8_t>(data[index])]};
     const std::uint32_t second{
@@ -151,14 +151,14 @@ auto decode_into(const std::string_view input,
     const std::uint32_t third{
         table[static_cast<std::uint8_t>(data[index + 2])]};
     if (first == INVALID_SEXTET || second == INVALID_SEXTET ||
-        third == INVALID_SEXTET || (third & 0x03u) != 0) {
+        third == INVALID_SEXTET || (third & 0x03U) != 0) {
       output.resize(base, '\0');
       return false;
     }
 
-    output.push_back(static_cast<char>((first << 2u) | (second >> 4u)));
+    output.push_back(static_cast<char>((first << 2U) | (second >> 4U)));
     output.push_back(
-        static_cast<char>(((second & 0x0Fu) << 4u) | (third >> 2u)));
+        static_cast<char>(((second & 0x0FU) << 4U) | (third >> 2U)));
   }
 
   return true;
@@ -183,7 +183,7 @@ auto base64_encode(const std::string_view input, SecureString &output) -> void {
   // The input is copied first so that growing the output cannot invalidate it
   // when the two alias the same storage
   const SecureString input_copy{input};
-  output.reserve(output.size() + ((input_copy.size() + 2) / 3) * 4);
+  output.reserve(output.size() + (((input_copy.size() + 2) / 3) * 4));
   encode(std::string_view{input_copy}, BASE64_ALPHABET, true, output);
 }
 
@@ -233,7 +233,7 @@ auto base64url_encode(const std::string_view input, SecureString &output)
   // The input is copied first so that growing the output cannot invalidate it
   // when the two alias the same storage
   const SecureString input_copy{input};
-  output.reserve(output.size() + ((input_copy.size() + 2) / 3) * 4);
+  output.reserve(output.size() + (((input_copy.size() + 2) / 3) * 4));
   encode(std::string_view{input_copy}, BASE64URL_ALPHABET, false, output);
 }
 

--- a/src/core/crypto/crypto_bignum.h
+++ b/src/core/crypto/crypto_bignum.h
@@ -12,6 +12,7 @@
 #include <sourcemeta/core/numeric.h>
 #include <sourcemeta/core/text.h>
 
+#include <algorithm>   // std::max, std::min
 #include <array>       // std::array
 #include <cstddef>     // std::size_t
 #include <cstdint>     // std::uint8_t, std::uint64_t
@@ -25,8 +26,8 @@ using BignumDoubleWord = uint128_t;
 
 struct Bignum {
   // Enough words for an 8192-bit product plus shifting headroom
-  static constexpr std::size_t capacity{130};
-  std::array<std::uint64_t, capacity> words{};
+  static constexpr std::size_t CAPACITY{130};
+  std::array<std::uint64_t, CAPACITY> words{};
   std::size_t size{0};
 };
 
@@ -68,7 +69,7 @@ inline auto bignum_from_bytes(const std::string_view input) noexcept -> Bignum {
   for (std::size_t index = input.size(); index > 0; --index) {
     const auto byte{static_cast<std::uint8_t>(input[index - 1])};
     const auto word_index{bytes_consumed / 8};
-    if (word_index >= Bignum::capacity) {
+    if (word_index >= Bignum::CAPACITY) {
       break;
     }
 
@@ -129,7 +130,7 @@ inline auto bignum_bit_length(const Bignum &value) noexcept -> std::size_t {
   auto top_word{value.words[value.size - 1]};
   std::size_t top_bits{0};
   while (top_word > 0) {
-    top_word >>= 1u;
+    top_word >>= 1U;
     top_bits += 1;
   }
 
@@ -143,7 +144,7 @@ inline auto bignum_get_bit(const Bignum &value, const std::size_t bit) noexcept
     return false;
   }
 
-  return ((value.words[word] >> (bit % 64)) & 1u) != 0;
+  return ((value.words[word] >> (bit % 64)) & 1U) != 0;
 }
 
 // The same read without the size-dependent early return, so the signing ladders
@@ -152,8 +153,8 @@ inline auto bignum_get_bit(const Bignum &value, const std::size_t bit) noexcept
 inline auto bignum_get_bit_fixed(const Bignum &value,
                                  const std::size_t bit) noexcept -> bool {
   const auto word{bit / 64};
-  return word < Bignum::capacity &&
-         ((value.words[word] >> (bit % 64)) & 1u) != 0;
+  return word < Bignum::CAPACITY &&
+         ((value.words[word] >> (bit % 64)) & 1U) != 0;
 }
 
 // Assumes the result fits in the capacity
@@ -163,19 +164,17 @@ inline auto bignum_shift_left(const Bignum &value,
   const auto word_shift{bits / 64};
   const auto bit_shift{bits % 64};
   result.size = value.size + word_shift + 1;
-  if (result.size > Bignum::capacity) {
-    result.size = Bignum::capacity;
-  }
+  result.size = std::min(result.size, Bignum::CAPACITY);
 
   for (std::size_t index = 0; index < value.size; ++index) {
     const auto destination{index + word_shift};
-    if (destination >= Bignum::capacity) {
+    if (destination >= Bignum::CAPACITY) {
       break;
     }
 
     result.words[destination] |= value.words[index] << bit_shift;
-    if (bit_shift > 0 && destination + 1 < Bignum::capacity) {
-      result.words[destination + 1] |= value.words[index] >> (64u - bit_shift);
+    if (bit_shift > 0 && destination + 1 < Bignum::CAPACITY) {
+      result.words[destination + 1] |= value.words[index] >> (64U - bit_shift);
     }
   }
 
@@ -219,7 +218,7 @@ inline auto bignum_reduce(Bignum &value, const Bignum &modulus) noexcept
     const auto divisor{modulus.words[0]};
     BignumDoubleWord remainder{0};
     for (std::size_t index = value.size; index > 0; --index) {
-      remainder = (remainder << 64u) | value.words[index - 1];
+      remainder = (remainder << 64U) | value.words[index - 1];
       remainder %= divisor;
     }
 
@@ -230,14 +229,14 @@ inline auto bignum_reduce(Bignum &value, const Bignum &modulus) noexcept
   // Normalize so the divisor's top word has its high bit set, which bounds the
   // error of each quotient word estimate to at most two
   const auto shift{static_cast<std::size_t>(
-      (64u - (bignum_bit_length(modulus) % 64u)) % 64u)};
+      (64U - (bignum_bit_length(modulus) % 64U)) % 64U)};
   const auto divisor{shift > 0 ? bignum_shift_left(modulus, shift) : modulus};
   auto dividend{shift > 0 ? bignum_shift_left(value, shift) : value};
   const auto dividend_words{dividend.size};
   const auto quotient_words{dividend_words - divisor_words};
   const auto top{divisor.words[divisor_words - 1]};
   const auto next{divisor.words[divisor_words - 2]};
-  const BignumDoubleWord base{static_cast<BignumDoubleWord>(1) << 64u};
+  const BignumDoubleWord base{static_cast<BignumDoubleWord>(1) << 64U};
 
   for (std::size_t step = quotient_words + 1; step > 0; --step) {
     const auto offset{step - 1};
@@ -245,12 +244,12 @@ inline auto bignum_reduce(Bignum &value, const Bignum &modulus) noexcept
     // Estimate the quotient word from the top two words of the running value
     const auto numerator{
         (static_cast<BignumDoubleWord>(dividend.words[offset + divisor_words])
-         << 64u) |
+         << 64U) |
         dividend.words[offset + divisor_words - 1]};
     auto estimate{numerator / top};
     auto estimate_remainder{numerator % top};
     while (estimate >= base ||
-           estimate * next > (estimate_remainder << 64u) +
+           estimate * next > (estimate_remainder << 64U) +
                                  dividend.words[offset + divisor_words - 2]) {
       estimate -= 1;
       estimate_remainder += top;
@@ -264,17 +263,17 @@ inline auto bignum_reduce(Bignum &value, const Bignum &modulus) noexcept
     BignumDoubleWord carry{0};
     std::uint64_t borrow{0};
     for (std::size_t index = 0; index < divisor_words; ++index) {
-      const auto product{static_cast<BignumDoubleWord>(quotient_word) *
-                             divisor.words[index] +
+      const auto product{(static_cast<BignumDoubleWord>(quotient_word) *
+                          divisor.words[index]) +
                          carry};
-      carry = product >> 64u;
+      carry = product >> 64U;
       const auto subtrahend{static_cast<std::uint64_t>(product)};
       const auto current{dividend.words[offset + index]};
       const auto without_subtrahend{current - subtrahend};
-      auto next_borrow{current < subtrahend ? 1u : 0u};
+      auto next_borrow{current < subtrahend ? 1U : 0U};
       const auto result_word{without_subtrahend - borrow};
       if (without_subtrahend < borrow) {
-        next_borrow += 1u;
+        next_borrow += 1U;
       }
 
       dividend.words[offset + index] = result_word;
@@ -284,10 +283,10 @@ inline auto bignum_reduce(Bignum &value, const Bignum &modulus) noexcept
     const auto current{dividend.words[offset + divisor_words]};
     const auto subtrahend{static_cast<std::uint64_t>(carry)};
     const auto without_subtrahend{current - subtrahend};
-    auto next_borrow{current < subtrahend ? 1u : 0u};
+    auto next_borrow{current < subtrahend ? 1U : 0U};
     dividend.words[offset + divisor_words] = without_subtrahend - borrow;
     if (without_subtrahend < borrow) {
-      next_borrow += 1u;
+      next_borrow += 1U;
     }
 
     // The estimate was at most one too large, so add the divisor back when the
@@ -299,7 +298,7 @@ inline auto bignum_reduce(Bignum &value, const Bignum &modulus) noexcept
             static_cast<BignumDoubleWord>(dividend.words[offset + index]) +
             divisor.words[index] + add_carry};
         dividend.words[offset + index] = static_cast<std::uint64_t>(sum);
-        add_carry = sum >> 64u;
+        add_carry = sum >> 64U;
       }
 
       dividend.words[offset + divisor_words] +=
@@ -318,27 +317,26 @@ inline auto bignum_multiply(const Bignum &left, const Bignum &right) noexcept
     -> Bignum {
   Bignum result;
   result.size = left.size + right.size;
-  if (result.size > Bignum::capacity) {
-    result.size = Bignum::capacity;
-  }
+  result.size = std::min(result.size, Bignum::CAPACITY);
 
   for (std::size_t left_index = 0; left_index < left.size; ++left_index) {
     std::uint64_t carry{0};
     for (std::size_t right_index = 0; right_index < right.size; ++right_index) {
       const auto destination{left_index + right_index};
-      if (destination >= Bignum::capacity) {
+      if (destination >= Bignum::CAPACITY) {
         break;
       }
 
-      const auto product{static_cast<BignumDoubleWord>(left.words[left_index]) *
-                             right.words[right_index] +
-                         result.words[destination] + carry};
+      const auto product{
+          (static_cast<BignumDoubleWord>(left.words[left_index]) *
+           right.words[right_index]) +
+          result.words[destination] + carry};
       result.words[destination] = static_cast<std::uint64_t>(product);
-      carry = static_cast<std::uint64_t>(product >> 64u);
+      carry = static_cast<std::uint64_t>(product >> 64U);
     }
 
     const auto carry_destination{left_index + right.size};
-    if (carry_destination < Bignum::capacity) {
+    if (carry_destination < Bignum::CAPACITY) {
       result.words[carry_destination] += carry;
     }
   }
@@ -379,11 +377,11 @@ inline auto bignum_add(const Bignum &left, const Bignum &right) noexcept
     const auto second{index < right.size ? right.words[index] : 0};
     const auto sum{static_cast<BignumDoubleWord>(first) + second + carry};
     result.words[index] = static_cast<std::uint64_t>(sum);
-    carry = static_cast<std::uint64_t>(sum >> 64u);
+    carry = static_cast<std::uint64_t>(sum >> 64U);
   }
 
   result.size = larger;
-  if (carry > 0 && larger < Bignum::capacity) {
+  if (carry > 0 && larger < Bignum::CAPACITY) {
     result.words[larger] = carry;
     result.size = larger + 1;
   }
@@ -405,7 +403,7 @@ inline auto bignum_shift_right(const Bignum &value,
   for (std::size_t index = 0; index < result.size; ++index) {
     auto word{value.words[index + word_shift] >> bit_shift};
     if (bit_shift > 0 && index + word_shift + 1 < value.size) {
-      word |= value.words[index + word_shift + 1] << (64u - bit_shift);
+      word |= value.words[index + word_shift + 1] << (64U - bit_shift);
     }
 
     result.words[index] = word;
@@ -452,7 +450,7 @@ inline auto bignum_mod_multiply(const Bignum &left, const Bignum &right,
 // becomes even by adding the modulus first, so the result stays an integer
 inline auto bignum_mod_halve(const Bignum &value,
                              const Bignum &modulus) noexcept -> Bignum {
-  if ((value.words[0] & 1u) == 0) {
+  if ((value.words[0] & 1U) == 0) {
     return bignum_shift_right(value, 1);
   }
 
@@ -481,12 +479,12 @@ inline auto bignum_mod_inverse(const Bignum &value,
       return {};
     }
 
-    while ((first.words[0] & 1u) == 0) {
+    while ((first.words[0] & 1U) == 0) {
       first = bignum_shift_right(first, 1);
       first_coefficient = bignum_mod_halve(first_coefficient, modulus);
     }
 
-    while ((second.words[0] & 1u) == 0) {
+    while ((second.words[0] & 1U) == 0) {
       second = bignum_shift_right(second, 1);
       second_coefficient = bignum_mod_halve(second_coefficient, modulus);
     }
@@ -515,7 +513,7 @@ inline auto bignum_conditional_select(const bool condition,
   const std::uint64_t mask{std::uint64_t{0} -
                            static_cast<std::uint64_t>(condition)};
   Bignum result;
-  for (std::size_t index = 0; index < Bignum::capacity; ++index) {
+  for (std::size_t index = 0; index < Bignum::CAPACITY; ++index) {
     result.words[index] =
         (when_true.words[index] & mask) | (when_false.words[index] & ~mask);
   }
@@ -538,9 +536,9 @@ inline auto bignum_subtract_fixed(const Bignum &left, const Bignum &right,
     const auto left_word{left.words[index]};
     const auto right_word{right.words[index]};
     const auto without_right{left_word - right_word};
-    const std::uint64_t borrow_from_right{left_word < right_word ? 1u : 0u};
+    const std::uint64_t borrow_from_right{left_word < right_word ? 1U : 0U};
     const auto result_word{without_right - borrow};
-    const std::uint64_t borrow_from_previous{without_right < borrow ? 1u : 0u};
+    const std::uint64_t borrow_from_previous{without_right < borrow ? 1U : 0U};
     out.words[index] = result_word;
     borrow = borrow_from_right | borrow_from_previous;
   }
@@ -561,11 +559,12 @@ inline auto bignum_multiply_fixed(const Bignum &left, const Bignum &right,
     for (std::size_t right_index = 0; right_index < right_words;
          ++right_index) {
       const auto destination{left_index + right_index};
-      const auto product{static_cast<BignumDoubleWord>(left.words[left_index]) *
-                             right.words[right_index] +
-                         result.words[destination] + carry};
+      const auto product{
+          (static_cast<BignumDoubleWord>(left.words[left_index]) *
+           right.words[right_index]) +
+          result.words[destination] + carry};
       result.words[destination] = static_cast<std::uint64_t>(product);
-      carry = static_cast<std::uint64_t>(product >> 64u);
+      carry = static_cast<std::uint64_t>(product >> 64U);
     }
 
     result.words[left_index + right_words] = carry;
@@ -580,7 +579,7 @@ inline auto bignum_multiply_fixed(const Bignum &left, const Bignum &right,
 inline auto bignum_drop_low_words(const Bignum &value,
                                   const std::size_t words) noexcept -> Bignum {
   Bignum result;
-  for (std::size_t index = 0; index + words < Bignum::capacity; ++index) {
+  for (std::size_t index = 0; index + words < Bignum::CAPACITY; ++index) {
     result.words[index] = value.words[index + words];
   }
 
@@ -609,7 +608,7 @@ inline auto bignum_divide(const Bignum &numerator,
   for (std::size_t index = bits; index > 0; --index) {
     remainder = bignum_shift_left(remainder, 1);
     if (bignum_get_bit(numerator, index - 1)) {
-      remainder.words[0] |= 1u;
+      remainder.words[0] |= 1U;
       if (remainder.size == 0) {
         remainder.size = 1;
       }
@@ -619,9 +618,7 @@ inline auto bignum_divide(const Bignum &numerator,
       bignum_subtract_in_place(remainder, denominator);
       quotient.words[(index - 1) / 64] |= std::uint64_t{1}
                                           << ((index - 1) % 64);
-      if (quotient.size < ((index - 1) / 64) + 1) {
-        quotient.size = ((index - 1) / 64) + 1;
-      }
+      quotient.size = std::max(quotient.size, ((index - 1) / 64) + 1);
     }
   }
 
@@ -700,7 +697,7 @@ inline auto field_add_ct(const Bignum &left, const Bignum &right,
     const auto total{static_cast<BignumDoubleWord>(left.words[index]) +
                      right.words[index] + carry};
     sum.words[index] = static_cast<std::uint64_t>(total);
-    carry = static_cast<std::uint64_t>(total >> 64u);
+    carry = static_cast<std::uint64_t>(total >> 64U);
   }
 
   sum.words[width] = carry;
@@ -722,7 +719,7 @@ inline auto field_subtract_ct(const Bignum &left, const Bignum &right,
     const auto total{static_cast<BignumDoubleWord>(difference.words[index]) +
                      context.modulus.words[index] + carry};
     wrapped.words[index] = static_cast<std::uint64_t>(total);
-    carry = static_cast<std::uint64_t>(total >> 64u);
+    carry = static_cast<std::uint64_t>(total >> 64U);
   }
 
   wrapped.size = width;
@@ -787,7 +784,7 @@ inline auto bignum_to_bytes(const Bignum &value, const std::size_t length)
     }
 
     const auto byte{static_cast<std::uint8_t>(
-        (value.words[word_index] >> (8 * (index % 8))) & 0xffu)};
+        (value.words[word_index] >> (8 * (index % 8))) & 0xffU)};
     result[length - 1 - index] = static_cast<char>(byte);
   }
 

--- a/src/core/crypto/crypto_crc32.cc
+++ b/src/core/crypto/crypto_crc32.cc
@@ -82,12 +82,12 @@ constexpr std::array<std::array<std::uint32_t, 256>, 8> CRC32_TABLES{
 namespace sourcemeta::core {
 
 auto crc32(const std::string_view input) -> std::uint32_t {
-  return crc32_update(0u, input);
+  return crc32_update(0U, input);
 }
 
 auto crc32_update(const std::uint32_t previous, const std::string_view input)
     -> std::uint32_t {
-  auto checksum{previous ^ 0xFFFFFFFFu};
+  auto checksum{previous ^ 0xFFFFFFFFU};
   const auto *data{reinterpret_cast<const std::uint8_t *>(input.data())};
   auto remaining{input.size()};
 
@@ -104,7 +104,7 @@ auto crc32_update(const std::uint32_t previous, const std::string_view input)
     checksum = crc32_hardware_byte(checksum, *data++);
     --remaining;
   }
-  return checksum ^ 0xFFFFFFFFu;
+  return checksum ^ 0xFFFFFFFFU;
 #else
   // Slice-by-8 software fallback: consume 8 bytes per iteration
   while (remaining >= 8) {

--- a/src/core/crypto/crypto_der.h
+++ b/src/core/crypto/crypto_der.h
@@ -36,7 +36,7 @@ inline auto der_read(const std::string_view input)
   if (first < 0x80) {
     length = first;
   } else {
-    const std::size_t count{first & 0x7fu};
+    const std::size_t count{first & 0x7fU};
     if (count == 0 || count > 4 || position + count > input.size()) {
       return std::nullopt;
     }
@@ -49,7 +49,7 @@ inline auto der_read(const std::string_view input)
     }
 
     for (std::size_t index{0}; index < count; ++index) {
-      length = (length << 8u) | static_cast<unsigned char>(input[position]);
+      length = (length << 8U) | static_cast<unsigned char>(input[position]);
       position += 1;
     }
 
@@ -80,11 +80,11 @@ inline auto der_append_length(std::string &output, const std::size_t length)
   }
 
   std::string octets;
-  for (std::size_t remaining{length}; remaining > 0; remaining >>= 8u) {
-    octets.insert(octets.begin(), static_cast<char>(remaining & 0xffu));
+  for (std::size_t remaining{length}; remaining > 0; remaining >>= 8U) {
+    octets.insert(octets.begin(), static_cast<char>(remaining & 0xffU));
   }
 
-  output.push_back(static_cast<char>(0x80u | octets.size()));
+  output.push_back(static_cast<char>(0x80U | octets.size()));
   output.append(octets);
 }
 
@@ -107,7 +107,7 @@ inline auto der_append_unsigned_integer(std::string &output,
   // and represents the value zero when nothing remains
   const auto needs_zero_prefix{
       value.empty() ||
-      (static_cast<unsigned char>(value.front()) & 0x80u) != 0};
+      (static_cast<unsigned char>(value.front()) & 0x80U) != 0};
   output.push_back('\x02');
   der_append_length(output, value.size() + (needs_zero_prefix ? 1 : 0));
   if (needs_zero_prefix) {

--- a/src/core/crypto/crypto_ecdh.cc
+++ b/src/core/crypto/crypto_ecdh.cc
@@ -31,12 +31,12 @@ auto kdf_concat(const std::string_view shared_secret,
     -> std::optional<std::string> {
   // The construction encodes each length and the key length in bits as a 32-bit
   // field, so an input that would not fit cannot be represented
-  constexpr std::size_t maximum_field{
+  constexpr std::size_t MAXIMUM_FIELD{
       std::numeric_limits<std::uint32_t>::max()};
-  if (algorithm_id.size() > maximum_field ||
-      party_u_info.size() > maximum_field ||
-      party_v_info.size() > maximum_field ||
-      derived_key_bytes > maximum_field / 8u) {
+  if (algorithm_id.size() > MAXIMUM_FIELD ||
+      party_u_info.size() > MAXIMUM_FIELD ||
+      party_v_info.size() > MAXIMUM_FIELD ||
+      derived_key_bytes > MAXIMUM_FIELD / 8U) {
     return std::nullopt;
   }
 
@@ -49,7 +49,7 @@ auto kdf_concat(const std::string_view shared_secret,
   append_length_prefixed(other_info, party_u_info);
   append_length_prefixed(other_info, party_v_info);
   append_big_endian_uint32(other_info,
-                           static_cast<std::uint32_t>(derived_key_bytes * 8u));
+                           static_cast<std::uint32_t>(derived_key_bytes * 8U));
 
   // Each round hashes the big-endian round counter, the shared secret, and
   // OtherInfo, taking blocks until the requested length is reached

--- a/src/core/crypto/crypto_ecdh_apple.cc
+++ b/src/core/crypto/crypto_ecdh_apple.cc
@@ -22,16 +22,16 @@ auto ecdh_derive(const PrivateKey &private_key, const PublicKey &public_key)
     return std::nullopt;
   }
 
-  auto parameters{CFDictionaryCreate(kCFAllocatorDefault, nullptr, nullptr, 0,
-                                     &kCFTypeDictionaryKeyCallBacks,
-                                     &kCFTypeDictionaryValueCallBacks)};
+  const auto *parameters{CFDictionaryCreate(
+      kCFAllocatorDefault, nullptr, nullptr, 0, &kCFTypeDictionaryKeyCallBacks,
+      &kCFTypeDictionaryValueCallBacks)};
   if (parameters == nullptr) {
     return std::nullopt;
   }
 
   // The standard exchange returns the agreed point x coordinate, and the peer
   // key was validated on the curve when it was parsed
-  auto shared{SecKeyCopyKeyExchangeResult(
+  const auto *shared{SecKeyCopyKeyExchangeResult(
       private_internal->key, kSecKeyAlgorithmECDHKeyExchangeStandard,
       public_internal->key, parameters, nullptr)};
   CFRelease(parameters);

--- a/src/core/crypto/crypto_eddsa.h
+++ b/src/core/crypto/crypto_eddsa.h
@@ -183,7 +183,7 @@ inline auto edwards_point_encode(const EdwardsPoint &point, const Bignum &prime,
   std::string encoding{big_endian.rbegin(), big_endian.rend()};
   if (bignum_get_bit(x, 0)) {
     encoding.back() =
-        static_cast<char>(static_cast<std::uint8_t>(encoding.back()) | 0x80u);
+        static_cast<char>(static_cast<std::uint8_t>(encoding.back()) | 0x80U);
   }
 
   return encoding;
@@ -215,9 +215,9 @@ inline auto edwards25519_decode_point(const std::string_view encoding,
   // The final bit holds the sign of x, the remaining bits the little-endian y
   std::string bytes{encoding};
   const auto sign_bit{
-      static_cast<unsigned>(static_cast<std::uint8_t>(bytes.back()) >> 7) & 1u};
+      static_cast<unsigned>(static_cast<std::uint8_t>(bytes.back()) >> 7) & 1U};
   bytes.back() =
-      static_cast<char>(static_cast<std::uint8_t>(bytes.back()) & 0x7fu);
+      static_cast<char>(static_cast<std::uint8_t>(bytes.back()) & 0x7fU);
   const auto y{bignum_from_bytes_little_endian(bytes)};
 
   // A y coordinate at or beyond the field prime is not a canonical encoding
@@ -388,9 +388,9 @@ inline auto edwards25519_verify(const std::string_view public_key,
 inline auto edwards25519_prune_scalar(std::string &scalar_bytes) noexcept
     -> void {
   scalar_bytes.front() = static_cast<char>(
-      static_cast<std::uint8_t>(scalar_bytes.front()) & 0xf8u);
+      static_cast<std::uint8_t>(scalar_bytes.front()) & 0xf8U);
   scalar_bytes.back() = static_cast<char>(
-      (static_cast<std::uint8_t>(scalar_bytes.back()) & 0x7fu) | 0x40u);
+      (static_cast<std::uint8_t>(scalar_bytes.back()) & 0x7fU) | 0x40U);
 }
 
 // The Ed25519 public key derived from the 32-byte private seed, the encoded
@@ -501,9 +501,9 @@ inline auto edwards448_decode_point(const std::string_view encoding,
   // The final bit holds the sign of x, the remaining bits the little-endian y
   std::string bytes{encoding};
   const auto sign_bit{
-      static_cast<unsigned>(static_cast<std::uint8_t>(bytes.back()) >> 7) & 1u};
+      static_cast<unsigned>(static_cast<std::uint8_t>(bytes.back()) >> 7) & 1U};
   bytes.back() =
-      static_cast<char>(static_cast<std::uint8_t>(bytes.back()) & 0x7fu);
+      static_cast<char>(static_cast<std::uint8_t>(bytes.back()) & 0x7fU);
   const auto y{bignum_from_bytes_little_endian(bytes)};
 
   // A y coordinate at or beyond the field prime is not a canonical encoding
@@ -651,9 +651,9 @@ inline auto edwards448_verify(const std::string_view public_key,
 inline auto edwards448_prune_scalar(std::string &scalar_bytes) noexcept
     -> void {
   scalar_bytes.front() = static_cast<char>(
-      static_cast<std::uint8_t>(scalar_bytes.front()) & 0xfcu);
+      static_cast<std::uint8_t>(scalar_bytes.front()) & 0xfcU);
   scalar_bytes[55] =
-      static_cast<char>(static_cast<std::uint8_t>(scalar_bytes[55]) | 0x80u);
+      static_cast<char>(static_cast<std::uint8_t>(scalar_bytes[55]) | 0x80U);
   scalar_bytes[56] = '\x00';
 }
 

--- a/src/core/crypto/crypto_fnv128.cc
+++ b/src/core/crypto/crypto_fnv128.cc
@@ -14,22 +14,22 @@ constexpr std::uint64_t OFFSET_BASIS_LOW{0x62b821756295c58dULL};
 // The 128-bit FNV prime is 2^88 + 2^8 + 0x3b (draft-eastlake-fnv Section 4),
 // so multiplying by it reduces to (value << 88) + (value << 8) + value * 0x3b
 // modulo 2^128, computed here over two 64-bit limbs
-inline constexpr auto multiply_by_prime(std::uint64_t &high,
-                                        std::uint64_t &low) noexcept -> void {
+constexpr auto multiply_by_prime(std::uint64_t &high,
+                                 std::uint64_t &low) noexcept -> void {
   // value << 88, whose low limb is always zero
-  const auto shift_88_high = low << 24u;
+  const auto shift_88_high = low << 24U;
 
   // value << 8
-  const auto shift_8_high = (high << 8u) | (low >> 56u);
-  const auto shift_8_low = low << 8u;
+  const auto shift_8_high = (high << 8U) | (low >> 56U);
+  const auto shift_8_low = low << 8U;
 
   // value * 0x3b, multiplying the low limb in 32-bit halves to portably
   // capture the carry into the high limb
   const auto low_half_product = (low & 0xffffffffULL) * 0x3bULL;
-  const auto high_half_product = (low >> 32u) * 0x3bULL;
-  const auto small_low = low_half_product + (high_half_product << 32u);
+  const auto high_half_product = (low >> 32U) * 0x3bULL;
+  const auto small_low = low_half_product + (high_half_product << 32U);
   const auto small_carry =
-      (high_half_product + (low_half_product >> 32u)) >> 32u;
+      (high_half_product + (low_half_product >> 32U)) >> 32U;
   const auto small_high = (high * 0x3bULL) + small_carry;
 
   const auto result_low = shift_8_low + small_low;
@@ -54,10 +54,10 @@ auto fnv128_digest(const std::string_view input)
   }
 
   std::array<std::uint8_t, 16> result{};
-  for (std::uint64_t index = 0u; index < 8u; ++index) {
-    const auto shift = 8u * (7u - index);
-    result[index] = static_cast<std::uint8_t>((high >> shift) & 0xffu);
-    result[8u + index] = static_cast<std::uint8_t>((low >> shift) & 0xffu);
+  for (std::uint64_t index = 0U; index < 8U; ++index) {
+    const auto shift = 8U * (7U - index);
+    result[index] = static_cast<std::uint8_t>((high >> shift) & 0xffU);
+    result[8U + index] = static_cast<std::uint8_t>((low >> shift) & 0xffU);
   }
 
   return result;

--- a/src/core/crypto/crypto_helpers.h
+++ b/src/core/crypto/crypto_helpers.h
@@ -26,10 +26,10 @@ inline constexpr std::size_t MAXIMUM_KEY_BYTES{512};
 // their counters and length fields
 inline auto append_big_endian_uint32(std::string &target,
                                      const std::uint32_t value) -> void {
-  target.push_back(static_cast<char>((value >> 24u) & 0xffu));
-  target.push_back(static_cast<char>((value >> 16u) & 0xffu));
-  target.push_back(static_cast<char>((value >> 8u) & 0xffu));
-  target.push_back(static_cast<char>(value & 0xffu));
+  target.push_back(static_cast<char>((value >> 24U) & 0xffU));
+  target.push_back(static_cast<char>((value >> 16U) & 0xffU));
+  target.push_back(static_cast<char>((value >> 8U) & 0xffU));
+  target.push_back(static_cast<char>(value & 0xffU));
 }
 
 // The same guard for a raw buffer, so a secret that a fixed-size digest array

--- a/src/core/crypto/crypto_pkcs8.h
+++ b/src/core/crypto/crypto_pkcs8.h
@@ -152,14 +152,14 @@ inline auto parse_pkcs8(const std::string_view der) -> std::optional<PKCS8Key> {
 
   // The object identifiers are raw DER content bytes, kept as escaped literals
   // NOLINTBEGIN(modernize-raw-string-literal)
-  constexpr std::string_view rsa{"\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01", 9};
-  constexpr std::string_view rsa_pss{"\x2a\x86\x48\x86\xf7\x0d\x01\x01\x0a", 9};
-  constexpr std::string_view elliptic_curve{"\x2a\x86\x48\xce\x3d\x02\x01", 7};
-  constexpr std::string_view ed25519{"\x2b\x65\x70", 3};
-  constexpr std::string_view ed448{"\x2b\x65\x71", 3};
+  constexpr std::string_view RSA{"\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01", 9};
+  constexpr std::string_view RSA_PSS{"\x2a\x86\x48\x86\xf7\x0d\x01\x01\x0a", 9};
+  constexpr std::string_view ELLIPTIC_CURVE{"\x2a\x86\x48\xce\x3d\x02\x01", 7};
+  constexpr std::string_view ED25519{"\x2b\x65\x70", 3};
+  constexpr std::string_view ED448{"\x2b\x65\x71", 3};
   // NOLINTEND(modernize-raw-string-literal)
 
-  if (oid->content == rsa || oid->content == rsa_pss) {
+  if (oid->content == RSA || oid->content == RSA_PSS) {
     if (!rsa_private_key_acceptable(private_key->content)) {
       return std::nullopt;
     }
@@ -168,35 +168,35 @@ inline auto parse_pkcs8(const std::string_view der) -> std::optional<PKCS8Key> {
                     .curve = {},
                     .edwards_curve = {},
                     .key = private_key->content,
-                    .rsa_pss_restricted = oid->content == rsa_pss};
+                    .rsa_pss_restricted = oid->content == RSA_PSS};
   }
 
-  if (oid->content == ed25519 || oid->content == ed448) {
+  if (oid->content == ED25519 || oid->content == ED448) {
     return PKCS8Key{.kind = PKCS8KeyKind::Edwards,
                     .curve = {},
-                    .edwards_curve = oid->content == ed25519
+                    .edwards_curve = oid->content == ED25519
                                          ? EdwardsCurve::Ed25519
                                          : EdwardsCurve::Ed448,
                     .key = private_key->content};
   }
 
-  if (oid->content == elliptic_curve) {
+  if (oid->content == ELLIPTIC_CURVE) {
     const auto curve_oid{der_read(oid->rest)};
     if (!curve_oid.has_value() || curve_oid->tag != 0x06) {
       return std::nullopt;
     }
 
     // NOLINTBEGIN(modernize-raw-string-literal)
-    constexpr std::string_view p256{"\x2a\x86\x48\xce\x3d\x03\x01\x07", 8};
-    constexpr std::string_view p384{"\x2b\x81\x04\x00\x22", 5};
-    constexpr std::string_view p521{"\x2b\x81\x04\x00\x23", 5};
+    constexpr std::string_view P256{"\x2a\x86\x48\xce\x3d\x03\x01\x07", 8};
+    constexpr std::string_view P384{"\x2b\x81\x04\x00\x22", 5};
+    constexpr std::string_view P521{"\x2b\x81\x04\x00\x23", 5};
     // NOLINTEND(modernize-raw-string-literal)
     EllipticCurve curve{};
-    if (curve_oid->content == p256) {
+    if (curve_oid->content == P256) {
       curve = EllipticCurve::P256;
-    } else if (curve_oid->content == p384) {
+    } else if (curve_oid->content == P384) {
       curve = EllipticCurve::P384;
-    } else if (curve_oid->content == p521) {
+    } else if (curve_oid->content == P521) {
       curve = EllipticCurve::P521;
     } else {
       return std::nullopt;

--- a/src/core/crypto/crypto_rsa_oaep_apple.cc
+++ b/src/core/crypto/crypto_rsa_oaep_apple.cc
@@ -41,12 +41,12 @@ auto rsa_oaep_encrypt(const PublicKey &key, const RSAOAEPHash hash,
     return std::nullopt;
   }
 
-  auto plaintext_data{make_data(plaintext)};
+  const auto *plaintext_data{make_data(plaintext)};
   if (plaintext_data == nullptr) {
     return std::nullopt;
   }
 
-  auto ciphertext{SecKeyCreateEncryptedData(
+  const auto *ciphertext{SecKeyCreateEncryptedData(
       internal->key, to_oaep_algorithm(hash), plaintext_data, nullptr)};
   CFRelease(plaintext_data);
   if (ciphertext == nullptr) {
@@ -77,12 +77,12 @@ auto rsa_oaep_decrypt(const PrivateKey &key, const RSAOAEPHash hash,
     return std::nullopt;
   }
 
-  auto ciphertext_data{make_data(ciphertext)};
+  const auto *ciphertext_data{make_data(ciphertext)};
   if (ciphertext_data == nullptr) {
     return std::nullopt;
   }
 
-  auto plaintext{SecKeyCreateDecryptedData(
+  const auto *plaintext{SecKeyCreateDecryptedData(
       internal->key, to_oaep_algorithm(hash), ciphertext_data, nullptr)};
   CFRelease(ciphertext_data);
   if (plaintext == nullptr) {

--- a/src/core/crypto/crypto_sha1_apple.cc
+++ b/src/core/crypto/crypto_sha1_apple.cc
@@ -22,9 +22,9 @@ auto sha1(const std::string_view input) -> std::string {
   // inputs must be fed in chunks
   const auto *remaining_data{input.data()};
   auto remaining_size{input.size()};
-  constexpr std::size_t maximum_chunk{std::numeric_limits<CC_LONG>::max()};
+  constexpr std::size_t MAXIMUM_CHUNK{std::numeric_limits<CC_LONG>::max()};
   while (remaining_size > 0) {
-    const auto chunk_size{remaining_size > maximum_chunk ? maximum_chunk
+    const auto chunk_size{remaining_size > MAXIMUM_CHUNK ? MAXIMUM_CHUNK
                                                          : remaining_size};
     CC_SHA1_Update(&context, remaining_data, static_cast<CC_LONG>(chunk_size));
     remaining_data += chunk_size;

--- a/src/core/crypto/crypto_sha256_apple.cc
+++ b/src/core/crypto/crypto_sha256_apple.cc
@@ -17,9 +17,9 @@ auto sha256_update(CC_SHA256_CTX &context, const std::string_view input)
   // inputs must be fed in chunks
   const auto *remaining_data{input.data()};
   auto remaining_size{input.size()};
-  constexpr std::size_t maximum_chunk{std::numeric_limits<CC_LONG>::max()};
+  constexpr std::size_t MAXIMUM_CHUNK{std::numeric_limits<CC_LONG>::max()};
   while (remaining_size > 0) {
-    const auto chunk_size{remaining_size > maximum_chunk ? maximum_chunk
+    const auto chunk_size{remaining_size > MAXIMUM_CHUNK ? MAXIMUM_CHUNK
                                                          : remaining_size};
     CC_SHA256_Update(&context, remaining_data,
                      static_cast<CC_LONG>(chunk_size));

--- a/src/core/crypto/crypto_sha384_apple.cc
+++ b/src/core/crypto/crypto_sha384_apple.cc
@@ -18,9 +18,9 @@ auto sha384_digest(const std::string_view input)
   // inputs must be fed in chunks
   const auto *remaining_data{input.data()};
   auto remaining_size{input.size()};
-  constexpr std::size_t maximum_chunk{std::numeric_limits<CC_LONG>::max()};
+  constexpr std::size_t MAXIMUM_CHUNK{std::numeric_limits<CC_LONG>::max()};
   while (remaining_size > 0) {
-    const auto chunk_size{remaining_size > maximum_chunk ? maximum_chunk
+    const auto chunk_size{remaining_size > MAXIMUM_CHUNK ? MAXIMUM_CHUNK
                                                          : remaining_size};
     CC_SHA384_Update(&context, remaining_data,
                      static_cast<CC_LONG>(chunk_size));

--- a/src/core/crypto/crypto_sha512_apple.cc
+++ b/src/core/crypto/crypto_sha512_apple.cc
@@ -18,9 +18,9 @@ auto sha512_digest(const std::string_view input)
   // inputs must be fed in chunks
   const auto *remaining_data{input.data()};
   auto remaining_size{input.size()};
-  constexpr std::size_t maximum_chunk{std::numeric_limits<CC_LONG>::max()};
+  constexpr std::size_t MAXIMUM_CHUNK{std::numeric_limits<CC_LONG>::max()};
   while (remaining_size > 0) {
-    const auto chunk_size{remaining_size > maximum_chunk ? maximum_chunk
+    const auto chunk_size{remaining_size > MAXIMUM_CHUNK ? MAXIMUM_CHUNK
                                                          : remaining_size};
     CC_SHA512_Update(&context, remaining_data,
                      static_cast<CC_LONG>(chunk_size));

--- a/src/core/crypto/crypto_shake256.h
+++ b/src/core/crypto/crypto_shake256.h
@@ -12,7 +12,7 @@
 
 namespace sourcemeta::core {
 
-inline constexpr std::array<std::uint64_t, 24> keccak_round_constants{
+inline constexpr std::array<std::uint64_t, 24> KECCAK_ROUND_CONSTANTS{
     {0x0000000000000001ULL, 0x0000000000008082ULL, 0x800000000000808aULL,
      0x8000000080008000ULL, 0x000000000000808bULL, 0x0000000080000001ULL,
      0x8000000080008081ULL, 0x8000000000008009ULL, 0x000000000000008aULL,
@@ -24,18 +24,18 @@ inline constexpr std::array<std::uint64_t, 24> keccak_round_constants{
 
 // The rotation offsets and destination lanes of the combined rho and pi steps,
 // walking the lanes starting from lane 1
-inline constexpr std::array<unsigned, 24> keccak_rho_offsets{
+inline constexpr std::array<unsigned, 24> KECCAK_RHO_OFFSETS{
     {1,  3,  6,  10, 15, 21, 28, 36, 45, 55, 2,  14,
      27, 41, 56, 8,  25, 43, 62, 18, 39, 61, 20, 44}};
 
-inline constexpr std::array<unsigned, 24> keccak_pi_lanes{
+inline constexpr std::array<unsigned, 24> KECCAK_PI_LANES{
     {10, 7,  11, 17, 18, 3, 5,  16, 8,  21, 24, 4,
      15, 23, 19, 13, 12, 2, 20, 14, 22, 9,  6,  1}};
 
-inline constexpr auto keccak_rotate_left(const std::uint64_t value,
-                                         const unsigned offset) noexcept
+constexpr auto keccak_rotate_left(const std::uint64_t value,
+                                  const unsigned offset) noexcept
     -> std::uint64_t {
-  return (value << offset) | (value >> (64u - offset));
+  return (value << offset) | (value >> (64U - offset));
 }
 
 inline auto keccak_permute(std::array<std::uint64_t, 25> &state) noexcept
@@ -60,9 +60,9 @@ inline auto keccak_permute(std::array<std::uint64_t, 25> &state) noexcept
     // Rho and pi
     auto current{state[1]};
     for (std::size_t index = 0; index < 24; ++index) {
-      const auto lane{keccak_pi_lanes[index]};
+      const auto lane{KECCAK_PI_LANES[index]};
       const auto moved{state[lane]};
-      state[lane] = keccak_rotate_left(current, keccak_rho_offsets[index]);
+      state[lane] = keccak_rotate_left(current, KECCAK_RHO_OFFSETS[index]);
       current = moved;
     }
 
@@ -80,7 +80,7 @@ inline auto keccak_permute(std::array<std::uint64_t, 25> &state) noexcept
     }
 
     // Iota
-    state[0] ^= keccak_round_constants[round];
+    state[0] ^= KECCAK_ROUND_CONSTANTS[round];
   }
 }
 
@@ -88,7 +88,7 @@ inline auto keccak_permute(std::array<std::uint64_t, 25> &state) noexcept
 inline auto shake256(const std::string_view input,
                      const std::size_t output_length) -> std::string {
   // The bitrate is 1600 - 2 * 256 = 1088 bits, that is 136 octets
-  constexpr std::size_t rate{136};
+  constexpr std::size_t RATE{136};
   std::array<std::uint64_t, 25> state{};
 
   std::size_t pointer{0};
@@ -97,7 +97,7 @@ inline auto shake256(const std::string_view input,
         static_cast<std::uint64_t>(static_cast<std::uint8_t>(character))
         << (8 * (pointer % 8));
     pointer += 1;
-    if (pointer == rate) {
+    if (pointer == RATE) {
       keccak_permute(state);
       pointer = 0;
     }
@@ -106,8 +106,8 @@ inline auto shake256(const std::string_view input,
   // The SHAKE domain separation suffix is the bits 1111, padded to the rate
   // with the pad10*1 rule
   state[pointer / 8] ^= static_cast<std::uint64_t>(0x1f) << (8 * (pointer % 8));
-  state[(rate - 1) / 8] ^= static_cast<std::uint64_t>(0x80)
-                           << (8 * ((rate - 1) % 8));
+  state[(RATE - 1) / 8] ^= static_cast<std::uint64_t>(0x80)
+                           << (8 * ((RATE - 1) % 8));
   keccak_permute(state);
 
   std::string output;
@@ -115,9 +115,9 @@ inline auto shake256(const std::string_view input,
   std::size_t squeeze_pointer{0};
   while (output.size() < output_length) {
     output.push_back(static_cast<char>(
-        (state[squeeze_pointer / 8] >> (8 * (squeeze_pointer % 8))) & 0xffu));
+        (state[squeeze_pointer / 8] >> (8 * (squeeze_pointer % 8))) & 0xffU));
     squeeze_pointer += 1;
-    if (squeeze_pointer == rate) {
+    if (squeeze_pointer == RATE) {
       keccak_permute(state);
       squeeze_pointer = 0;
     }

--- a/src/core/crypto/crypto_sign_apple.cc
+++ b/src/core/crypto/crypto_sign_apple.cc
@@ -76,7 +76,7 @@ auto make_data(const std::string_view value) -> CFDataRef {
 
 auto native_private_key(const void *type, const std::string_view key)
     -> SecKeyRef {
-  auto key_data{make_data(key)};
+  const auto *key_data{make_data(key)};
   if (key_data == nullptr) {
     return nullptr;
   }
@@ -84,7 +84,7 @@ auto native_private_key(const void *type, const std::string_view key)
   std::array<const void *, 2> attribute_keys{
       {kSecAttrKeyType, kSecAttrKeyClass}};
   std::array<const void *, 2> attribute_values{{type, kSecAttrKeyClassPrivate}};
-  auto attributes{CFDictionaryCreate(
+  const auto *attributes{CFDictionaryCreate(
       kCFAllocatorDefault, attribute_keys.data(), attribute_values.data(),
       static_cast<CFIndex>(attribute_keys.size()),
       &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks)};
@@ -93,7 +93,7 @@ auto native_private_key(const void *type, const std::string_view key)
     return nullptr;
   }
 
-  auto key_reference{SecKeyCreateWithData(key_data, attributes, nullptr)};
+  auto *key_reference{SecKeyCreateWithData(key_data, attributes, nullptr)};
   CFRelease(attributes);
   CFRelease(key_data);
   return key_reference;
@@ -179,12 +179,13 @@ auto native_ec_private_key_components(const std::size_t field_bytes,
 auto sign_with_algorithm(SecKeyRef key, const SecKeyAlgorithm algorithm,
                          const std::string_view message)
     -> std::optional<std::string> {
-  auto message_data{make_data(message)};
+  const auto *message_data{make_data(message)};
   if (message_data == nullptr) {
     return std::nullopt;
   }
 
-  auto signature{SecKeyCreateSignature(key, algorithm, message_data, nullptr)};
+  const auto *signature{
+      SecKeyCreateSignature(key, algorithm, message_data, nullptr)};
   CFRelease(message_data);
   if (signature == nullptr) {
     return std::nullopt;
@@ -360,7 +361,8 @@ auto make_ec_private_key(const EllipticCurve curve,
 auto generate_ec_private_key(const EllipticCurve curve)
     -> std::optional<PrivateKey> {
   const int bits{static_cast<int>(curve_bit_length(curve))};
-  auto size{CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &bits)};
+  const auto *size{
+      CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &bits)};
   if (size == nullptr) {
     return std::nullopt;
   }
@@ -369,7 +371,7 @@ auto generate_ec_private_key(const EllipticCurve curve)
       {kSecAttrKeyType, kSecAttrKeySizeInBits}};
   std::array<const void *, 2> attribute_values{
       {kSecAttrKeyTypeECSECPrimeRandom, size}};
-  auto attributes{CFDictionaryCreate(
+  const auto *attributes{CFDictionaryCreate(
       kCFAllocatorDefault, attribute_keys.data(), attribute_values.data(),
       static_cast<CFIndex>(attribute_keys.size()),
       &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks)};

--- a/src/core/crypto/crypto_uuid.cc
+++ b/src/core/crypto/crypto_uuid.cc
@@ -15,9 +15,9 @@ namespace sourcemeta::core {
 // Format: xxxxxxxx-xxxx-4xxx-Nxxx-xxxxxxxxxxxx
 // where 4 is the version and N is the variant (8, 9, a, or b)
 auto uuidv4() -> std::string {
-  static constexpr std::string_view digits = "0123456789abcdef";
-  static constexpr std::string_view variant_digits = "89ab";
-  static constexpr std::array<bool, 16> dash = {
+  static constexpr std::string_view DIGITS = "0123456789abcdef";
+  static constexpr std::string_view VARIANT_DIGITS = "89ab";
+  static constexpr std::array<bool, 16> DASH = {
       {false, false, false, false, true, false, true, false, true, false, true,
        false, false, false, false, false}};
 
@@ -26,25 +26,25 @@ auto uuidv4() -> std::string {
 
   std::string result;
   result.reserve(36);
-  for (std::size_t index = 0; index < dash.size(); ++index) {
-    if (dash[index]) {
+  for (std::size_t index = 0; index < DASH.size(); ++index) {
+    if (DASH[index]) {
       result += '-';
     }
 
-    const auto high_nibble = (bytes[index] >> 4u) & 0x0fu;
-    const auto low_nibble = bytes[index] & 0x0fu;
+    const auto high_nibble = (bytes[index] >> 4U) & 0x0fU;
+    const auto low_nibble = bytes[index] & 0x0fU;
 
     // RFC 9562 Section 5.4: version bits (48-51) must be 0b0100
     if (index == 6) {
       result += '4';
       // RFC 9562 Section 5.4: variant bits (64-65) must be 0b10
     } else if (index == 8) {
-      result += variant_digits[high_nibble & 0x03u];
+      result += VARIANT_DIGITS[high_nibble & 0x03U];
     } else {
-      result += digits[high_nibble];
+      result += DIGITS[high_nibble];
     }
 
-    result += digits[low_nibble];
+    result += DIGITS[low_nibble];
   }
 
   return result;

--- a/src/core/crypto/crypto_verify_apple.cc
+++ b/src/core/crypto/crypto_verify_apple.cc
@@ -85,7 +85,7 @@ auto native_rsa_key(const std::string_view modulus,
   sourcemeta::core::der_append_length(der, body.size());
   der.append(body);
 
-  auto key_data{make_data(der)};
+  const auto *key_data{make_data(der)};
   if (key_data == nullptr) {
     return nullptr;
   }
@@ -94,7 +94,7 @@ auto native_rsa_key(const std::string_view modulus,
       {kSecAttrKeyType, kSecAttrKeyClass}};
   std::array<const void *, 2> attribute_values{
       {kSecAttrKeyTypeRSA, kSecAttrKeyClassPublic}};
-  auto attributes{CFDictionaryCreate(
+  const auto *attributes{CFDictionaryCreate(
       kCFAllocatorDefault, attribute_keys.data(), attribute_values.data(),
       static_cast<CFIndex>(attribute_keys.size()),
       &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks)};
@@ -103,7 +103,7 @@ auto native_rsa_key(const std::string_view modulus,
     return nullptr;
   }
 
-  auto key{SecKeyCreateWithData(key_data, attributes, nullptr)};
+  auto *key{SecKeyCreateWithData(key_data, attributes, nullptr)};
   CFRelease(attributes);
   CFRelease(key_data);
   return key;
@@ -126,7 +126,7 @@ auto native_ec_key(const sourcemeta::core::EllipticCurve curve,
   point.append(sourcemeta::core::pad_left(stripped_x, width, '\x00'));
   point.append(sourcemeta::core::pad_left(stripped_y, width, '\x00'));
 
-  auto key_data{make_data(point)};
+  const auto *key_data{make_data(point)};
   if (key_data == nullptr) {
     return nullptr;
   }
@@ -135,7 +135,7 @@ auto native_ec_key(const sourcemeta::core::EllipticCurve curve,
       {kSecAttrKeyType, kSecAttrKeyClass}};
   std::array<const void *, 2> attribute_values{
       {kSecAttrKeyTypeECSECPrimeRandom, kSecAttrKeyClassPublic}};
-  auto attributes{CFDictionaryCreate(
+  const auto *attributes{CFDictionaryCreate(
       kCFAllocatorDefault, attribute_keys.data(), attribute_values.data(),
       static_cast<CFIndex>(attribute_keys.size()),
       &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks)};
@@ -144,7 +144,7 @@ auto native_ec_key(const sourcemeta::core::EllipticCurve curve,
     return nullptr;
   }
 
-  auto key{SecKeyCreateWithData(key_data, attributes, nullptr)};
+  auto *key{SecKeyCreateWithData(key_data, attributes, nullptr)};
   CFRelease(attributes);
   CFRelease(key_data);
   return key;
@@ -170,12 +170,12 @@ auto encode_ecdsa_signature(const std::string_view raw_signature)
 auto verify_with_algorithm(SecKeyRef key, const SecKeyAlgorithm algorithm,
                            const std::string_view message,
                            const std::string_view signature) -> bool {
-  auto message_data{make_data(message)};
-  auto signature_data{make_data(signature)};
+  const auto *message_data{make_data(message)};
+  const auto *signature_data{make_data(signature)};
   auto result{false};
   if (message_data != nullptr && signature_data != nullptr) {
     result = SecKeyVerifySignature(key, algorithm, message_data, signature_data,
-                                   nullptr) == true;
+                                   nullptr) == 1;
   }
 
   if (signature_data != nullptr) {

--- a/src/core/crypto/crypto_verify_other.cc
+++ b/src/core/crypto/crypto_verify_other.cc
@@ -21,7 +21,7 @@ namespace sourcemeta::core {
 // The big integer capacity must hold the product of two maximum-size operands
 // plus a normalisation limb and Knuth's implicit leading-zero digit, otherwise
 // the modular reduction would index past the fixed-capacity word array
-static_assert(Bignum::capacity >= 2 * ((MAXIMUM_KEY_BYTES + 7) / 8) + 2);
+static_assert(Bignum::CAPACITY >= 2 * ((MAXIMUM_KEY_BYTES + 7) / 8) + 2);
 
 namespace {
 

--- a/src/core/crypto/include/sourcemeta/core/crypto_secure.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_secure.h
@@ -114,7 +114,8 @@ template <typename T> struct SecureAllocator {
 
   /// Construct from an allocator for another type, as the containers require.
   template <typename Other>
-  constexpr SecureAllocator(const SecureAllocator<Other> &) noexcept {}
+  constexpr SecureAllocator(
+      [[maybe_unused]] const SecureAllocator<Other> &other) noexcept {}
 
   /// Allocate storage for the given number of objects.
   [[nodiscard]] auto allocate(const std::size_t count) -> T * {
@@ -134,13 +135,15 @@ template <typename T> struct SecureAllocator {
 
   /// Every instance is interchangeable, since the allocator holds no state.
   template <typename Other>
-  auto operator==(const SecureAllocator<Other> &) const noexcept -> bool {
+  auto operator==([[maybe_unused]] const SecureAllocator<Other> &other)
+      const noexcept -> bool {
     return true;
   }
 
   /// Every instance is interchangeable, since the allocator holds no state.
   template <typename Other>
-  auto operator!=(const SecureAllocator<Other> &) const noexcept -> bool {
+  auto operator!=([[maybe_unused]] const SecureAllocator<Other> &other)
+      const noexcept -> bool {
     return false;
   }
 };

--- a/src/core/email/email.cc
+++ b/src/core/email/email.cc
@@ -179,7 +179,7 @@ auto mailto_iri(const std::string_view value) -> std::optional<std::string> {
   }
 
   std::string result;
-  result.reserve(value.size() * 3 + 7);
+  result.reserve((value.size() * 3) + 7);
   result.append("mailto:");
   for (const auto character : value.substr(0, separator.value())) {
     if (is_mailto_verbatim(character)) {
@@ -231,7 +231,7 @@ auto acct_iri(const std::string_view value) -> std::optional<std::string> {
   }
 
   std::string result;
-  result.reserve(value.size() * 3 + 5);
+  result.reserve((value.size() * 3) + 5);
   result.append("acct:");
   for (const auto character : parts->first) {
     if (is_acct_userpart_verbatim(character)) {

--- a/src/core/email/helpers.h
+++ b/src/core/email/helpers.h
@@ -13,7 +13,7 @@ namespace {
 // RFC 5321 §4.1.2: atext = ALPHA / DIGIT / "!" / "#" / "$" / "%" /
 // "&" / "'" / "*" / "+" / "-" / "/" / "=" / "?" / "^" / "_" / "`" /
 // "{" / "|" / "}" / "~"
-inline constexpr auto is_atext(const char character) -> bool {
+constexpr auto is_atext(const char character) -> bool {
   switch (character) {
     case '!':
     case '#':
@@ -41,21 +41,21 @@ inline constexpr auto is_atext(const char character) -> bool {
 }
 
 // RFC 5321 §4.1.2: qtextSMTP = %d32-33 / %d35-91 / %d93-126
-inline constexpr auto is_qtext_smtp(const unsigned char character) -> bool {
+constexpr auto is_qtext_smtp(const unsigned char character) -> bool {
   return (character >= 32 && character <= 33) ||
          (character >= 35 && character <= 91) ||
          (character >= 93 && character <= 126);
 }
 
 // RFC 5321 §4.1.3: dcontent = %d33-90 / %d94-126
-inline constexpr auto is_dcontent(const unsigned char character) -> bool {
+constexpr auto is_dcontent(const unsigned char character) -> bool {
   return (character >= 33 && character <= 90) ||
          (character >= 94 && character <= 126);
 }
 
 // RFC 5321 §4.1.2: Ldh-str = *( ALPHA / DIGIT / "-" ) Let-dig
 // RFC 5321 §4.1.3: Standardized-tag = Ldh-str
-inline constexpr auto is_ldh_str(const std::string_view value) -> bool {
+constexpr auto is_ldh_str(const std::string_view value) -> bool {
   if (value.empty() || !sourcemeta::core::is_alphanum(value.back())) {
     return false;
   }
@@ -72,7 +72,7 @@ inline constexpr auto is_ldh_str(const std::string_view value) -> bool {
 // RFC 5321 §4.1.3: Snum = 1*3DIGIT ; representing a decimal integer
 // value in the range 0 through 255. Leading zeros are permitted, unlike
 // the RFC 3986 dec-octet that backs is_ipv4
-inline constexpr auto is_snum(const std::string_view value) -> bool {
+constexpr auto is_snum(const std::string_view value) -> bool {
   if (value.empty() || value.size() > 3) {
     return false;
   }
@@ -82,14 +82,13 @@ inline constexpr auto is_snum(const std::string_view value) -> bool {
       return false;
     }
     result = static_cast<std::uint16_t>(
-        result * 10 + static_cast<std::uint16_t>(character - '0'));
+        (result * 10) + static_cast<std::uint16_t>(character - '0'));
   }
   return result <= 255;
 }
 
 // RFC 5321 §4.1.3: IPv4-address-literal = Snum 3("." Snum)
-inline constexpr auto is_ipv4_address_literal(const std::string_view value)
-    -> bool {
+constexpr auto is_ipv4_address_literal(const std::string_view value) -> bool {
   std::string_view::size_type start{0};
   std::uint8_t octets{0};
   while (true) {
@@ -116,7 +115,7 @@ inline constexpr auto is_ipv4_address_literal(const std::string_view value)
 
 // RFC 5234 §2.3: ABNF literal strings are case-insensitive by default
 // RFC 5321 §4.1.3: IPv6-address-literal prefix is the literal "IPv6:"
-inline constexpr auto matches_ipv6_tag(const std::string_view value) -> bool {
+constexpr auto matches_ipv6_tag(const std::string_view value) -> bool {
   return value.size() >= 5 && (value[0] == 'I' || value[0] == 'i') &&
          (value[1] == 'P' || value[1] == 'p') &&
          (value[2] == 'v' || value[2] == 'V') && value[3] == '6' &&
@@ -124,7 +123,7 @@ inline constexpr auto matches_ipv6_tag(const std::string_view value) -> bool {
 }
 
 // RFC 5321 §4.1.3: General-address-literal = Standardized-tag ":" 1*dcontent
-inline constexpr auto is_general_address_literal(const std::string_view value)
+constexpr auto is_general_address_literal(const std::string_view value)
     -> bool {
   const auto colon_position{value.find(':')};
   if (colon_position == std::string_view::npos) {
@@ -164,7 +163,7 @@ inline auto is_address_literal(const std::string_view domain) -> bool {
   // falls through to IPv4 or General-address-literal.
   // RFC 5321 §4.1.3: IPv4-address-literal has no ":";
   // General-address-literal requires ":"
-  if (inner.find(':') == std::string_view::npos) {
+  if (!inner.contains(':')) {
     return is_ipv4_address_literal(inner);
   }
   return is_general_address_literal(inner);
@@ -174,10 +173,10 @@ inline auto is_address_literal(const std::string_view domain) -> bool {
 // uppercase hexadecimal digits for all percent-encodings"
 inline auto percent_encode(const unsigned char byte, std::string &output)
     -> void {
-  constexpr std::string_view hexadecimal{"0123456789ABCDEF"};
+  constexpr std::string_view HEXADECIMAL{"0123456789ABCDEF"};
   output.push_back('%');
-  output.push_back(hexadecimal[byte >> 4U]);
-  output.push_back(hexadecimal[byte & 0x0FU]);
+  output.push_back(HEXADECIMAL[byte >> 4U]);
+  output.push_back(HEXADECIMAL[byte & 0x0FU]);
 }
 
 // RFC 6068 §2: within addr-spec, the characters that cannot appear in a URI,
@@ -188,7 +187,7 @@ inline auto percent_encode(const unsigned char byte, std::string &output)
 // encoded as well because the "to" production takes it as the address list
 // separator, and "@" inside quoted content is encoded following the §6.2
 // example "%22not%40me%22"
-inline constexpr auto is_mailto_verbatim(const char character) -> bool {
+constexpr auto is_mailto_verbatim(const char character) -> bool {
   switch (character) {
     case '!':
     case '$':
@@ -211,7 +210,7 @@ inline constexpr auto is_mailto_verbatim(const char character) -> bool {
 // RFC 7565 §7: userpart consists of unreserved, sub-delims, and pct-encoded,
 // so those two literal sets pass through and every other octet is
 // percent-encoded, as the §4 example does for "juliet@capulet.example"
-inline constexpr auto is_acct_userpart_verbatim(const char character) -> bool {
+constexpr auto is_acct_userpart_verbatim(const char character) -> bool {
   switch (character) {
     case '!':
     case '$':

--- a/src/core/gzip/huffman.h
+++ b/src/core/gzip/huffman.h
@@ -25,7 +25,7 @@ public:
   // Primary lookup table covering all codes of length <= LUT_BITS. Misses
   // fall back to the canonical-puff traversal for codes of length 10..15
   static constexpr unsigned int LUT_BITS{9};
-  static constexpr std::size_t LUT_SIZE{1u << LUT_BITS};
+  static constexpr std::size_t LUT_SIZE{1U << LUT_BITS};
 
   HuffmanDecoder() = default;
 
@@ -88,7 +88,7 @@ public:
     std::array<std::uint32_t, MAX_HUFFMAN_BITS + 1> next_code{};
     next_code[1] = 0;
     for (unsigned int bits = 2; bits <= MAX_HUFFMAN_BITS; ++bits) {
-      next_code[bits] = (next_code[bits - 1] + this->count_[bits - 1]) << 1u;
+      next_code[bits] = (next_code[bits - 1] + this->count_[bits - 1]) << 1U;
     }
 
     std::size_t symbol_index{0};
@@ -101,8 +101,8 @@ public:
           const auto lsb_key{reverse_bits(code, code_length)};
           const auto entry{static_cast<std::uint16_t>(
               static_cast<std::uint16_t>(code_length) |
-              static_cast<std::uint16_t>(symbol << 4u))};
-          const std::uint32_t stride{1u << code_length};
+              static_cast<std::uint16_t>(symbol << 4U))};
+          const std::uint32_t stride{1U << code_length};
           for (std::uint32_t slot = lsb_key; slot < LUT_SIZE; slot += stride) {
             this->lut_[slot] = entry;
           }
@@ -117,9 +117,9 @@ public:
     const auto key{reader.peek_bits(LUT_BITS)};
     const auto entry{this->lut_[key]};
     if (entry != 0) {
-      const unsigned int length{entry & 0xfu};
+      const unsigned int length{entry & 0xfU};
       reader.consume_bits(length);
-      return static_cast<std::uint16_t>(entry >> 4u);
+      return static_cast<std::uint16_t>(entry >> 4U);
     }
     return this->decode_long(reader);
   }
@@ -131,8 +131,8 @@ private:
     int first{0};
     int index{0};
     for (unsigned int length = 1; length <= MAX_HUFFMAN_BITS; ++length) {
-      code |= static_cast<int>(bits & 1u);
-      bits >>= 1u;
+      code |= static_cast<int>(bits & 1U);
+      bits >>= 1U;
       const auto entries{static_cast<int>(this->count_[length])};
       if (code - entries < first) {
         const auto position{static_cast<std::size_t>(index) +
@@ -151,8 +151,8 @@ private:
       -> std::uint32_t {
     std::uint32_t result{0};
     for (unsigned int index = 0; index < length; ++index) {
-      if ((value & (1u << (length - 1 - index))) != 0u) {
-        result |= (1u << index);
+      if ((value & (1U << (length - 1 - index))) != 0U) {
+        result |= (1U << index);
       }
     }
     return result;

--- a/src/core/gzip/include/sourcemeta/core/gzip_streambuf.h
+++ b/src/core/gzip/include/sourcemeta/core/gzip_streambuf.h
@@ -37,7 +37,7 @@ private:
 #pragma warning(disable : 4251)
 #endif
   struct Internal;
-  std::unique_ptr<Internal> internal;
+  std::unique_ptr<Internal> internal_;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251)
 #endif

--- a/src/core/gzip/streambuf.cc
+++ b/src/core/gzip/streambuf.cc
@@ -48,7 +48,7 @@ public:
   }
 
   [[nodiscard]] auto low16() const -> std::uint16_t {
-    return static_cast<std::uint16_t>(this->checksum_ & 0xffffu);
+    return static_cast<std::uint16_t>(this->checksum_ & 0xffffU);
   }
 
 private:
@@ -148,76 +148,76 @@ auto try_parse_member_header(BitReader &reader, const std::uint8_t first_byte)
 } // namespace
 
 GZIPStreamBuffer::GZIPStreamBuffer(std::istream &compressed_stream)
-    : internal{new Internal{compressed_stream}} {}
+    : internal_{new Internal{compressed_stream}} {}
 
 GZIPStreamBuffer::~GZIPStreamBuffer() = default;
 
 auto GZIPStreamBuffer::underflow() -> int_type {
-  if (this->gptr() && this->gptr() < this->egptr()) {
+  if ((this->gptr() != nullptr) && this->gptr() < this->egptr()) {
     return traits_type::to_int_type(*this->gptr());
   }
-  if (this->internal->stream_ended) {
+  if (this->internal_->stream_ended) {
     return traits_type::eof();
   }
 
   while (true) {
-    if (!this->internal->member_started) {
+    if (!this->internal_->member_started) {
       std::uint8_t first_byte{0};
-      if (!this->internal->reader.try_read_byte(first_byte)) {
-        if (!this->internal->any_member_completed) {
+      if (!this->internal_->reader.try_read_byte(first_byte)) {
+        if (!this->internal_->any_member_completed) {
           throw GZIPError{"Empty source stream"};
         }
-        this->internal->stream_ended = true;
+        this->internal_->stream_ended = true;
         return traits_type::eof();
       }
-      if (this->internal->any_member_completed) {
+      if (this->internal_->any_member_completed) {
         // gzip(1) silently ignores any trailing data after a complete member
         // rather than treating it as the start of a new member. Bytes that do
         // not form a valid member header end the stream without error,
         // independent of the first byte value
         if (first_byte != 0x1f ||
-            !try_parse_member_header(this->internal->reader, first_byte)) {
-          this->internal->stream_ended = true;
+            !try_parse_member_header(this->internal_->reader, first_byte)) {
+          this->internal_->stream_ended = true;
           return traits_type::eof();
         }
       } else {
         if (first_byte != 0x1f) {
           throw GZIPError{"Invalid gzip magic bytes"};
         }
-        parse_member_header(this->internal->reader, first_byte);
+        parse_member_header(this->internal_->reader, first_byte);
       }
 
-      this->internal->deflate.reset();
-      this->internal->member_started = true;
-      this->internal->member_crc32 = 0;
-      this->internal->member_isize = 0;
+      this->internal_->deflate.reset();
+      this->internal_->member_started = true;
+      this->internal_->member_crc32 = 0;
+      this->internal_->member_isize = 0;
     }
 
-    const auto produced{this->internal->deflate.decompress(
-        this->internal->decompressed_buffer.data(),
-        this->internal->decompressed_buffer.size())};
+    const auto produced{this->internal_->deflate.decompress(
+        this->internal_->decompressed_buffer.data(),
+        this->internal_->decompressed_buffer.size())};
 
     if (produced > 0) {
-      this->internal->member_crc32 = crc32_update(
-          this->internal->member_crc32,
+      this->internal_->member_crc32 = crc32_update(
+          this->internal_->member_crc32,
           std::string_view{reinterpret_cast<const char *>(
-                               this->internal->decompressed_buffer.data()),
+                               this->internal_->decompressed_buffer.data()),
                            produced});
-      this->internal->member_isize += static_cast<std::uint32_t>(produced);
+      this->internal_->member_isize += static_cast<std::uint32_t>(produced);
 
-      auto *buffer_start{
-          reinterpret_cast<char *>(this->internal->decompressed_buffer.data())};
+      auto *buffer_start{reinterpret_cast<char *>(
+          this->internal_->decompressed_buffer.data())};
       this->setg(buffer_start, buffer_start,
                  buffer_start + static_cast<std::ptrdiff_t>(produced));
       return traits_type::to_int_type(*this->gptr());
     }
 
-    if (!this->internal->deflate.stream_ended()) {
+    if (!this->internal_->deflate.stream_ended()) {
       throw GZIPError{"Deflate stream ended unexpectedly"};
     }
 
     std::array<std::uint8_t, 8> trailer{};
-    this->internal->reader.read_bytes(trailer.data(), trailer.size());
+    this->internal_->reader.read_bytes(trailer.data(), trailer.size());
     const auto stored_crc32{static_cast<std::uint32_t>(trailer[0]) |
                             (static_cast<std::uint32_t>(trailer[1]) << 8) |
                             (static_cast<std::uint32_t>(trailer[2]) << 16) |
@@ -226,15 +226,15 @@ auto GZIPStreamBuffer::underflow() -> int_type {
                             (static_cast<std::uint32_t>(trailer[5]) << 8) |
                             (static_cast<std::uint32_t>(trailer[6]) << 16) |
                             (static_cast<std::uint32_t>(trailer[7]) << 24)};
-    if (stored_crc32 != this->internal->member_crc32) {
+    if (stored_crc32 != this->internal_->member_crc32) {
       throw GZIPError{"Gzip member CRC32 mismatch"};
     }
-    if (stored_isize != this->internal->member_isize) {
+    if (stored_isize != this->internal_->member_isize) {
       throw GZIPError{"Gzip member ISIZE mismatch"};
     }
 
-    this->internal->any_member_completed = true;
-    this->internal->member_started = false;
+    this->internal_->any_member_completed = true;
+    this->internal_->member_started = false;
   }
 }
 

--- a/src/core/html/include/sourcemeta/core/html_buffer.h
+++ b/src/core/html/include/sourcemeta/core/html_buffer.h
@@ -25,15 +25,16 @@ public:
   auto operator=(HTMLBuffer &&) -> HTMLBuffer & = delete;
 
   /// Reserve a number of bytes of capacity up front
-  SOURCEMETA_FORCEINLINE inline auto reserve(const std::size_t bytes) -> void {
+  SOURCEMETA_FORCEINLINE auto reserve(const std::size_t bytes) -> void {
     this->buffer_.resize(bytes);
     this->cursor_ = this->buffer_.data();
     this->end_ = this->cursor_ + bytes;
   }
 
   /// Append a single character to the buffer
-  SOURCEMETA_FORCEINLINE inline auto append(const char character) -> void {
-    if (!this->cursor_ || this->cursor_ >= this->end_) [[unlikely]] {
+  SOURCEMETA_FORCEINLINE auto append(const char character) -> void {
+    if ((this->cursor_ == nullptr) || this->cursor_ >= this->end_)
+        [[unlikely]] {
       this->grow(1);
     }
 
@@ -42,16 +43,16 @@ public:
   }
 
   /// Append a sequence of characters to the buffer
-  SOURCEMETA_FORCEINLINE inline auto append(const std::string_view data)
-      -> void {
+  SOURCEMETA_FORCEINLINE auto append(const std::string_view data) -> void {
     const auto length{data.size()};
     if (length == 0) {
       return;
     }
 
     const auto remaining{
-        this->cursor_ ? static_cast<std::size_t>(this->end_ - this->cursor_)
-                      : 0uz};
+        (this->cursor_ != nullptr)
+            ? static_cast<std::size_t>(this->end_ - this->cursor_)
+            : 0UZ};
     if (remaining < length) [[unlikely]] {
       this->grow(length);
     }
@@ -61,9 +62,8 @@ public:
   }
 
   /// Get the accumulated contents of the buffer
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto str()
-      -> const std::string & {
-    if (this->cursor_) {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto str() -> const std::string & {
+    if (this->cursor_ != nullptr) {
       this->buffer_.resize(
           static_cast<std::size_t>(this->cursor_ - this->buffer_.data()));
       this->cursor_ = nullptr;

--- a/src/core/html/include/sourcemeta/core/html_writer.h
+++ b/src/core/html/include/sourcemeta/core/html_writer.h
@@ -33,13 +33,13 @@ namespace sourcemeta::core {
 class SOURCEMETA_CORE_HTML_EXPORT HTMLWriter {
 public:
   /// Pre-allocate the output buffer
-  SOURCEMETA_FORCEINLINE inline auto reserve(std::size_t bytes) -> void {
+  SOURCEMETA_FORCEINLINE auto reserve(std::size_t bytes) -> void {
     this->buffer_.reserve(bytes);
   }
 
   /// Close the most recently opened element. Closing when no element is open
   /// has no effect.
-  SOURCEMETA_FORCEINLINE inline auto close() -> HTMLWriter & {
+  SOURCEMETA_FORCEINLINE auto close() -> HTMLWriter & {
     this->flush_open_tag();
     assert(!this->tag_stack_.empty());
     if (this->tag_stack_.empty()) [[unlikely]] {
@@ -54,8 +54,8 @@ public:
 
   /// Add an attribute to the currently open tag. Must be called
   /// immediately after an element method and before any content.
-  SOURCEMETA_FORCEINLINE inline auto attribute(std::string_view name,
-                                               std::string_view value)
+  SOURCEMETA_FORCEINLINE auto attribute(std::string_view name,
+                                        std::string_view value)
       -> HTMLWriter & {
     assert(this->tag_open_);
     this->buffer_.append(" ");
@@ -72,8 +72,7 @@ public:
   /// would corrupt it. This writer does not special-case content by element, so
   /// the content of a raw-text element must be written unescaped rather than as
   /// escaped text, and it must not contain that element's closing-tag sequence.
-  SOURCEMETA_FORCEINLINE inline auto text(std::string_view content)
-      -> HTMLWriter & {
+  SOURCEMETA_FORCEINLINE auto text(std::string_view content) -> HTMLWriter & {
     this->flush_open_tag();
     html_escape_append(this->buffer_, content);
     return *this;
@@ -81,16 +80,14 @@ public:
 
   /// Write content without HTML-escaping. This is how the content of a raw-text
   /// element is emitted, since escaped text would corrupt it.
-  SOURCEMETA_FORCEINLINE inline auto raw(std::string_view content)
-      -> HTMLWriter & {
+  SOURCEMETA_FORCEINLINE auto raw(std::string_view content) -> HTMLWriter & {
     this->flush_open_tag();
     this->buffer_.append(content);
     return *this;
   }
 
   /// Get the rendered HTML string
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto str()
-      -> const std::string & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto str() -> const std::string & {
     this->flush_open_tag();
     return this->buffer_.str();
   }
@@ -111,43 +108,46 @@ public:
 // Overloads:
 //   .tag()              open with no attributes
 //   .tag(text)          open, write escaped text, close (shorthand)
+// NOLINTBEGIN(bugprone-macro-parentheses)
 #define HTML_WRITER_CONTAINER(name)                                            \
-  SOURCEMETA_FORCEINLINE inline auto name() -> HTMLWriter & {                  \
+  SOURCEMETA_FORCEINLINE auto name() -> HTMLWriter & {                         \
     this->open_tag(#name);                                                     \
     return *this;                                                              \
   }                                                                            \
-  /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                             \
-  SOURCEMETA_FORCEINLINE inline auto name(std::string_view text_content)       \
+  SOURCEMETA_FORCEINLINE auto name(std::string_view text_content)              \
       -> HTMLWriter & {                                                        \
     this->open_tag(#name);                                                     \
     this->text(text_content);                                                  \
     this->close();                                                             \
     return *this;                                                              \
   }
+// NOLINTEND(bugprone-macro-parentheses)
 
 // Same as above but with a different C++ method name than the HTML tag
+// NOLINTBEGIN(bugprone-macro-parentheses)
 #define HTML_WRITER_CONTAINER_NAMED(name, tag)                                 \
-  SOURCEMETA_FORCEINLINE inline auto name() -> HTMLWriter & {                  \
+  SOURCEMETA_FORCEINLINE auto name() -> HTMLWriter & {                         \
     this->open_tag(#tag);                                                      \
     return *this;                                                              \
   }                                                                            \
-  /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                             \
-  SOURCEMETA_FORCEINLINE inline auto name(std::string_view text_content)       \
+  SOURCEMETA_FORCEINLINE auto name(std::string_view text_content)              \
       -> HTMLWriter & {                                                        \
     this->open_tag(#tag);                                                      \
     this->text(text_content);                                                  \
     this->close();                                                             \
     return *this;                                                              \
   }
+// NOLINTEND(bugprone-macro-parentheses)
 
 // Macro to generate void element methods.
 // Void elements are self-closing: <tag /> or <tag attr="val" />
+// NOLINTBEGIN(bugprone-macro-parentheses)
 #define HTML_WRITER_VOID(name)                                                 \
-  /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                             \
-  SOURCEMETA_FORCEINLINE inline auto name() -> HTMLWriter & {                  \
+  SOURCEMETA_FORCEINLINE auto name() -> HTMLWriter & {                         \
     this->void_tag(#name);                                                     \
     return *this;                                                              \
   }
+// NOLINTEND(bugprone-macro-parentheses)
 #endif
 
   // =========================================================================
@@ -434,6 +434,9 @@ public:
   /// @ingroup html
   HTML_WRITER_CONTAINER(slot)
   /// @ingroup html
+  // The trailing underscore keeps this element name from colliding with the
+  // template keyword
+  // NOLINTNEXTLINE(readability-identifier-naming)
   HTML_WRITER_CONTAINER_NAMED(template_, template)
 
 #ifndef DOXYGEN
@@ -443,7 +446,7 @@ public:
 #endif
 
 private:
-  SOURCEMETA_FORCEINLINE inline auto open_tag(std::string_view tag) -> void {
+  SOURCEMETA_FORCEINLINE auto open_tag(std::string_view tag) -> void {
     this->flush_open_tag();
     this->buffer_.append("<");
     this->buffer_.append(tag);
@@ -452,7 +455,7 @@ private:
     this->tag_open_is_void_ = false;
   }
 
-  SOURCEMETA_FORCEINLINE inline auto void_tag(std::string_view tag) -> void {
+  SOURCEMETA_FORCEINLINE auto void_tag(std::string_view tag) -> void {
     this->flush_open_tag();
     this->buffer_.append("<");
     this->buffer_.append(tag);

--- a/src/core/html/writer.cc
+++ b/src/core/html/writer.cc
@@ -6,10 +6,10 @@ namespace sourcemeta::core {
 
 auto HTMLBuffer::grow(const std::size_t needed) -> void {
   const auto current_size{
-      this->cursor_
+      (this->cursor_ != nullptr)
           ? static_cast<std::size_t>(this->cursor_ - this->buffer_.data())
           : 0};
-  auto new_capacity{this->buffer_.empty() ? 1024uz : this->buffer_.size() * 2};
+  auto new_capacity{this->buffer_.empty() ? 1024UZ : this->buffer_.size() * 2};
   while (new_capacity < current_size + needed) {
     new_capacity *= 2;
   }
@@ -20,7 +20,7 @@ auto HTMLBuffer::grow(const std::size_t needed) -> void {
 }
 
 auto HTMLBuffer::write(std::ostream &stream) -> void {
-  if (this->cursor_) {
+  if (this->cursor_ != nullptr) {
     const auto size{
         static_cast<std::size_t>(this->cursor_ - this->buffer_.data())};
     stream.write(this->buffer_.data(), static_cast<std::streamsize>(size));

--- a/src/core/http/accept_includes_all.cc
+++ b/src/core/http/accept_includes_all.cc
@@ -29,7 +29,7 @@ auto http_accept_includes_all(
     assert(slash > 0);
     assert(slash < media_type_bare.size() - 1);
     assert(media_type_bare.find_first_of(" \t,;*") == std::string_view::npos);
-    float best_quality{0.0f};
+    float best_quality{0.0F};
     std::uint8_t best_specificity{0};
     http_for_each_media_range(
         accept_header,
@@ -46,7 +46,7 @@ auto http_accept_includes_all(
             best_specificity = specificity;
           }
         });
-    if (best_specificity == 0 || best_quality == 0.0f) {
+    if (best_specificity == 0 || best_quality == 0.0F) {
       return false;
     }
   }

--- a/src/core/http/cache_control_max_age.cc
+++ b/src/core/http/cache_control_max_age.cc
@@ -2,6 +2,7 @@
 
 #include "helpers.h"
 
+#include <algorithm>   // std::min
 #include <chrono>      // std::chrono::seconds
 #include <cstddef>     // std::size_t
 #include <optional>    // std::optional, std::nullopt
@@ -13,7 +14,7 @@ auto http_cache_control_max_age(const std::string_view cache_control) noexcept
     -> std::optional<std::chrono::seconds> {
   // RFC 9111 §1.2.2: a delta-seconds value larger than the cache can represent
   // is treated as 2^31
-  constexpr std::chrono::seconds::rep overflow_seconds{2147483648};
+  constexpr std::chrono::seconds::rep OVERFLOW_SECONDS{2147483648};
   std::optional<std::chrono::seconds> result;
   bool found{false};
   http_for_each_list_entry(
@@ -65,17 +66,15 @@ auto http_cache_control_max_age(const std::string_view cache_control) noexcept
 
           // Clamp before multiplying so the running total cannot itself
           // overflow on a hostile number of digits
-          if (seconds > overflow_seconds / 10) {
-            seconds = overflow_seconds;
+          if (seconds > OVERFLOW_SECONDS / 10) {
+            seconds = OVERFLOW_SECONDS;
             continue;
           }
 
           seconds = (seconds * 10) + (character - '0');
         }
 
-        if (seconds > overflow_seconds) {
-          seconds = overflow_seconds;
-        }
+        seconds = std::min(seconds, OVERFLOW_SECONDS);
 
         result = std::chrono::seconds{seconds};
       });

--- a/src/core/http/client_darwin.mm
+++ b/src/core/http/client_darwin.mm
@@ -44,11 +44,11 @@ auto to_nsstring(const std::string_view input) -> NSString * {
     willPerformHTTPRedirection:(NSHTTPURLResponse *)response
                     newRequest:(NSURLRequest *)request
              completionHandler:
-                 (void (^)(NSURLRequest *))completionHandler {
+                 (void (^)(NSURLRequest *))completion_handler {
   // Passing a nil request stops the redirection and delivers the redirect
   // response itself as the final response
   if (!self.followRedirects) {
-    completionHandler(nil);
+    completion_handler(nil);
     return;
   }
 
@@ -56,15 +56,15 @@ auto to_nsstring(const std::string_view input) -> NSString * {
   if (self.redirectCount > self.maximumRedirects) {
     self.failure->assign("The maximum number of redirects was exceeded");
     [task cancel];
-    completionHandler(nil);
+    completion_handler(nil);
     return;
   }
 
-  completionHandler(request);
+  completion_handler(request);
 }
 
 - (void)URLSession:(NSURLSession *)session
-          dataTask:(NSURLSessionDataTask *)dataTask
+          dataTask:(NSURLSessionDataTask *)data_task
     didReceiveData:(NSData *)data {
   auto *body{&self.response->body};
   if (self.hasMaximumResponseSize &&
@@ -72,7 +72,7 @@ auto to_nsstring(const std::string_view input) -> NSString * {
        static_cast<std::size_t>(data.length) >
            self.maximumResponseSize - body->size())) {
     self.failure->assign(HTTP_RESPONSE_TOO_LARGE_MESSAGE);
-    [dataTask cancel];
+    [data_task cancel];
     return;
   }
 

--- a/src/core/http/helpers.h
+++ b/src/core/http/helpers.h
@@ -265,40 +265,41 @@ inline auto http_media_range_specificity(
 // routed here and keeps its 1.0 default at the call site.
 inline auto http_parse_qvalue(const std::string_view value) noexcept -> float {
   if (value.empty()) {
-    return 0.0f;
+    return 0.0F;
   }
   if (value[0] != '0' && value[0] != '1') {
-    return 0.0f;
+    return 0.0F;
   }
   const float integer_part{static_cast<float>(value[0] - '0')};
   if (value.size() == 1) {
     return integer_part;
   }
   if (value[1] != '.' || value.size() > 5) {
-    return 0.0f;
+    return 0.0F;
   }
   std::uint16_t numerator{0};
   std::uint16_t denominator{1};
   for (std::size_t index{2}; index < value.size(); ++index) {
     const char character{value[index]};
     if (character < '0' || character > '9') {
-      return 0.0f;
+      return 0.0F;
     }
-    numerator = static_cast<std::uint16_t>(numerator * 10 + (character - '0'));
+    numerator =
+        static_cast<std::uint16_t>((numerator * 10) + (character - '0'));
     denominator = static_cast<std::uint16_t>(denominator * 10);
   }
   const float fraction{static_cast<float>(numerator) /
                        static_cast<float>(denominator)};
   const float result{integer_part + fraction};
-  if (result > 1.0f) {
-    return 0.0f;
+  if (result > 1.0F) {
+    return 0.0F;
   }
   return result;
 }
 
 inline auto http_extract_quality(const std::string_view parameters) noexcept
     -> float {
-  float quality{1.0f};
+  float quality{1.0F};
   http_for_each_parameter(
       parameters,
       [&quality](const std::string_view name,
@@ -321,7 +322,7 @@ inline auto http_split_media_range(const std::string_view parameters) noexcept
     -> std::pair<std::string_view, float> {
   std::size_t position{0};
   std::size_t media_parameters_end{parameters.size()};
-  float quality{1.0f};
+  float quality{1.0F};
   while (position < parameters.size()) {
     const std::size_t separator{position};
     if (parameters[position] == ';') {

--- a/src/core/http/include/sourcemeta/core/http_message.h
+++ b/src/core/http/include/sourcemeta/core/http_message.h
@@ -24,7 +24,7 @@ namespace sourcemeta::core {
 /// assert(sourcemeta::core::http_is_status_line("HTTP/1.1 200 OK"));
 /// assert(!sourcemeta::core::http_is_status_line("Content-Type: text/html"));
 /// ```
-inline constexpr auto http_is_status_line(const std::string_view line) noexcept
+constexpr auto http_is_status_line(const std::string_view line) noexcept
     -> bool {
   // The prefix cannot open a field line, as RFC 9110 §5.6.2 defines tchar
   // as "any VCHAR, except delimiters" where delimiters include the slash,

--- a/src/core/http/include/sourcemeta/core/http_method.h
+++ b/src/core/http/include/sourcemeta/core/http_method.h
@@ -41,7 +41,7 @@ enum class HTTPMethod : std::uint8_t {
 /// assert(sourcemeta::core::http_method_string(
 ///            sourcemeta::core::HTTPMethod::GET) == "GET");
 /// ```
-inline constexpr auto http_method_string(const HTTPMethod method) noexcept
+constexpr auto http_method_string(const HTTPMethod method) noexcept
     -> std::string_view {
   switch (method) {
     case HTTPMethod::GET:

--- a/src/core/http/include/sourcemeta/core/http_status.h
+++ b/src/core/http/include/sourcemeta/core/http_status.h
@@ -401,7 +401,7 @@ inline constexpr HTTPStatus HTTP_STATUS_NETWORK_AUTHENTICATION_REQUIRED{
 ///        sourcemeta::core::HTTP_STATUS_OK);
 /// assert(sourcemeta::core::http_status_from_code(599).phrase.empty());
 /// ```
-inline constexpr auto http_status_from_code(const std::uint16_t code) noexcept
+constexpr auto http_status_from_code(const std::uint16_t code) noexcept
     -> HTTPStatus {
   switch (code) {
     case 100:

--- a/src/core/http/match_accept.cc
+++ b/src/core/http/match_accept.cc
@@ -20,7 +20,7 @@ auto http_match_accept(const std::string_view accept_header,
   }
 
   std::string_view best{};
-  float best_quality{0.0f};
+  float best_quality{0.0F};
   std::uint8_t best_specificity{0};
   std::size_t best_order{candidates.size()};
 
@@ -37,7 +37,7 @@ auto http_match_accept(const std::string_view accept_header,
     assert(candidate_slash > 0);
     assert(candidate_slash < candidate_type.size() - 1);
     assert(candidate_type.find_first_of(" \t,;*") == std::string_view::npos);
-    float candidate_quality{0.0f};
+    float candidate_quality{0.0F};
     std::uint8_t candidate_specificity{0};
     http_for_each_media_range(
         accept_header,
@@ -55,7 +55,7 @@ auto http_match_accept(const std::string_view accept_header,
             candidate_specificity = specificity;
           }
         });
-    if (candidate_quality > 0.0f &&
+    if (candidate_quality > 0.0F &&
         (candidate_quality > best_quality ||
          (candidate_quality == best_quality &&
           candidate_specificity > best_specificity) ||

--- a/src/core/http/match_accept_language.cc
+++ b/src/core/http/match_accept_language.cc
@@ -43,7 +43,7 @@ auto http_match_accept_language(
   }
 
   std::string_view best{};
-  float best_quality{0.0f};
+  float best_quality{0.0F};
   std::size_t best_specificity{0};
   std::size_t best_order{candidates.size()};
 
@@ -53,7 +53,7 @@ auto http_match_accept_language(
     assert(candidate.find_first_of(" \t,;*/") == std::string_view::npos);
     assert(candidate[0] != '-');
     assert(candidate[candidate.size() - 1] != '-');
-    float candidate_quality{0.0f};
+    float candidate_quality{0.0F};
     std::size_t candidate_specificity{0};
     http_for_each_accept_entry(
         accept_language_header,
@@ -73,7 +73,7 @@ auto http_match_accept_language(
             candidate_specificity = specificity;
           }
         });
-    if (candidate_quality > 0.0f &&
+    if (candidate_quality > 0.0F &&
         (candidate_quality > best_quality ||
          (candidate_quality == best_quality &&
           candidate_specificity > best_specificity) ||

--- a/src/core/http/negotiate_encoding.cc
+++ b/src/core/http/negotiate_encoding.cc
@@ -2,6 +2,7 @@
 
 #include "helpers.h"
 
+#include <algorithm>   // std::max
 #include <optional>    // std::optional, std::nullopt
 #include <string_view> // std::string_view
 
@@ -16,9 +17,9 @@ auto http_negotiate_encoding(
     return HTTPContentEncoding::Identity;
   }
 
-  float gzip_quality{0.0f};
-  float identity_quality{0.0f};
-  float wildcard_quality{0.0f};
+  float gzip_quality{0.0F};
+  float identity_quality{0.0F};
+  float wildcard_quality{0.0F};
   bool gzip_listed{false};
   bool identity_listed{false};
   bool wildcard_listed{false};
@@ -29,19 +30,13 @@ auto http_negotiate_encoding(
         if (equals_ignore_case(token, "gzip") ||
             equals_ignore_case(token, "x-gzip")) {
           gzip_listed = true;
-          if (quality > gzip_quality) {
-            gzip_quality = quality;
-          }
+          gzip_quality = std::max(quality, gzip_quality);
         } else if (equals_ignore_case(token, "identity")) {
           identity_listed = true;
-          if (quality > identity_quality) {
-            identity_quality = quality;
-          }
+          identity_quality = std::max(quality, identity_quality);
         } else if (token == "*") {
           wildcard_listed = true;
-          if (quality > wildcard_quality) {
-            wildcard_quality = quality;
-          }
+          wildcard_quality = std::max(quality, wildcard_quality);
         }
       });
 
@@ -52,12 +47,12 @@ auto http_negotiate_encoding(
     if (wildcard_listed) {
       identity_quality = wildcard_quality;
     } else {
-      identity_quality = 1.0f;
+      identity_quality = 1.0F;
     }
   }
 
-  const bool gzip_acceptable{gzip_quality > 0.0f};
-  const bool identity_acceptable{identity_quality > 0.0f};
+  const bool gzip_acceptable{gzip_quality > 0.0F};
+  const bool identity_acceptable{identity_quality > 0.0F};
 
   if (!gzip_acceptable && !identity_acceptable) {
     return std::nullopt;

--- a/src/core/http/parse_bearer.cc
+++ b/src/core/http/parse_bearer.cc
@@ -9,20 +9,20 @@ namespace sourcemeta::core {
 
 auto http_parse_bearer(const std::string_view authorization) noexcept
     -> std::string_view {
-  constexpr std::string_view scheme{"bearer"};
-  if (authorization.size() <= scheme.size() ||
-      authorization[scheme.size()] != ' ') {
+  constexpr std::string_view SCHEME{"bearer"};
+  if (authorization.size() <= SCHEME.size() ||
+      authorization[SCHEME.size()] != ' ') {
     return {};
   }
 
-  if (!equals_ignore_case(http_subview(authorization, 0, scheme.size()),
-                          scheme)) {
+  if (!equals_ignore_case(http_subview(authorization, 0, SCHEME.size()),
+                          SCHEME)) {
     return {};
   }
 
   const auto token{http_trim_trailing_ows(http_trim_leading_ows(
-      http_subview(authorization, scheme.size() + 1,
-                   authorization.size() - scheme.size() - 1)))};
+      http_subview(authorization, SCHEME.size() + 1,
+                   authorization.size() - SCHEME.size() - 1)))};
   if (!http_is_b64token(token)) {
     return {};
   }

--- a/src/core/idna/codegen.cc
+++ b/src/core/idna/codegen.cc
@@ -76,7 +76,8 @@ auto parse_entry(const std::string_view payload) -> PropertyEntry {
   const auto last{range_split.has_value()
                       ? parse_hex_codepoint(range_split->second)
                       : first};
-  return {first, last, property_from_token(value_part)};
+  return {
+      .first = first, .last = last, .value = property_from_token(value_part)};
 }
 
 auto parse_idna_file(const std::filesystem::path &input_path)
@@ -84,7 +85,7 @@ auto parse_idna_file(const std::filesystem::path &input_path)
   auto stream{sourcemeta::core::read_file(input_path)};
   std::vector<PropertyEntry> missing;
   std::vector<PropertyEntry> data;
-  constexpr std::string_view missing_prefix{"@missing:"};
+  constexpr std::string_view MISSING_PREFIX{"@missing:"};
   sourcemeta::core::for_each_line(stream, [&](const std::string_view raw_line) {
     const auto line{sourcemeta::core::trim(raw_line)};
     if (line.empty()) {
@@ -92,12 +93,12 @@ auto parse_idna_file(const std::filesystem::path &input_path)
     }
     if (line.front() == '#') {
       const auto comment_body{sourcemeta::core::trim(line.substr(1))};
-      if (comment_body.size() < missing_prefix.size() ||
-          comment_body.substr(0, missing_prefix.size()) != missing_prefix) {
+      if (comment_body.size() < MISSING_PREFIX.size() ||
+          !comment_body.starts_with(MISSING_PREFIX)) {
         return;
       }
       missing.push_back(
-          parse_entry(comment_body.substr(missing_prefix.size())));
+          parse_entry(comment_body.substr(MISSING_PREFIX.size())));
       return;
     }
     data.push_back(parse_entry(line));
@@ -154,10 +155,10 @@ auto build_pages(const std::vector<PropertyEntry> &entries) -> TwoStageTable {
 
 template <typename T>
 auto emit_row(std::ostream &stream, const std::span<const T> items) -> void {
-  constexpr std::size_t row_width{16};
-  for (std::size_t offset{0}; offset < items.size(); offset += row_width) {
+  constexpr std::size_t ROW_WIDTH{16};
+  for (std::size_t offset{0}; offset < items.size(); offset += ROW_WIDTH) {
     stream << "    ";
-    const auto upper{offset + row_width < items.size() ? offset + row_width
+    const auto upper{offset + ROW_WIDTH < items.size() ? offset + ROW_WIDTH
                                                        : items.size()};
     const auto row{items.subspan(offset, upper - offset)};
     const auto widened{row | std::views::transform([](const T value) {
@@ -256,7 +257,10 @@ auto parse_mapping_line(const std::string_view payload) -> MappingEntry {
     mapping = parse_mapping_sequence(mapping_part);
   }
 
-  return {first, last, status, std::move(mapping)};
+  return {.first = first,
+          .last = last,
+          .status = status,
+          .mapping = std::move(mapping)};
 }
 
 auto parse_mapping_file(const std::filesystem::path &input_path)
@@ -298,16 +302,17 @@ auto build_mapping(const std::vector<MappingEntry> &entries) -> MappingTable {
       status_values[codepoint] = static_cast<std::uint8_t>(entry.status);
       if (entry.status == sourcemeta::core::IDNAMappingStatus::Mapped) {
         table.index.push_back(
-            {codepoint, offset,
-             static_cast<std::uint32_t>(entry.mapping.size())});
+            {.codepoint = codepoint,
+             .offset = offset,
+             .length = static_cast<std::uint32_t>(entry.mapping.size())});
       }
     }
   }
 
-  std::sort(table.index.begin(), table.index.end(),
-            [](const MappingIndexEntry &left, const MappingIndexEntry &right) {
-              return left.codepoint < right.codepoint;
-            });
+  std::ranges::sort(table.index, [](const MappingIndexEntry &left,
+                                    const MappingIndexEntry &right) {
+    return left.codepoint < right.codepoint;
+  });
   table.status = compress_pages(status_values);
   return table;
 }

--- a/src/core/idna/idna.cc
+++ b/src/core/idna/idna.cc
@@ -418,8 +418,8 @@ auto idna_passes_bidi_rule(const std::u32string_view label) noexcept -> bool {
 }
 
 auto idna_is_valid_a_label(const std::string_view label) -> bool {
-  constexpr std::string_view prefix{"xn--"};
-  if (!label.starts_with(prefix)) {
+  constexpr std::string_view PREFIX{"xn--"};
+  if (!label.starts_with(PREFIX)) {
     return false;
   }
 
@@ -437,8 +437,8 @@ auto idna_is_valid_a_label(const std::string_view label) -> bool {
 
   // The substring after the prefix. Constructing the view via (data, size)
   // avoids `std::string_view::substr`, which is not noexcept.
-  const std::string_view encoded{label.data() + prefix.size(),
-                                 label.size() - prefix.size()};
+  const std::string_view encoded{label.data() + PREFIX.size(),
+                                 label.size() - PREFIX.size()};
 
   std::u32string decoded;
   return validate_a_label_body(encoded, decoded);

--- a/src/core/ip/ipv4.cc
+++ b/src/core/ip/ipv4.cc
@@ -27,7 +27,7 @@ auto is_ipv4(const std::string_view address) -> bool {
     const auto octet_start{position};
     unsigned int value{0};
     while (position < address.size() && is_digit(address[position])) {
-      value = value * 10 + static_cast<unsigned int>(address[position] - '0');
+      value = (value * 10) + static_cast<unsigned int>(address[position] - '0');
       position += 1;
     }
 

--- a/src/core/ip/ipv6.cc
+++ b/src/core/ip/ipv6.cc
@@ -118,7 +118,7 @@ auto fill_ipv6_run(const std::string_view run,
     const auto piece{run.substr(position, colon == std::string_view::npos
                                               ? std::string_view::npos
                                               : colon - position)};
-    if (piece.find('.') != std::string_view::npos) {
+    if (piece.contains('.')) {
       for (const auto octet : ipv4_octets(piece)) {
         output[length] = octet;
         length += 1;

--- a/src/core/jose/include/sourcemeta/core/jose_verify.h
+++ b/src/core/jose/include/sourcemeta/core/jose_verify.h
@@ -99,9 +99,9 @@ inline auto jwt_bounded_clock_skew(const std::chrono::seconds skew) noexcept
     -> std::chrono::seconds {
   // A mean Gregorian year, the widest grace period any deployment plausibly
   // needs, so an extreme value cannot widen the acceptance window without bound
-  constexpr std::chrono::seconds maximum{31556952};
+  constexpr std::chrono::seconds MAXIMUM{31556952};
   return skew < std::chrono::seconds::zero() ? std::chrono::seconds::zero()
-         : skew > maximum                    ? maximum
+         : skew > MAXIMUM                    ? MAXIMUM
                                              : skew;
 }
 

--- a/src/core/jose/jose_algorithm.cc
+++ b/src/core/jose/jose_algorithm.cc
@@ -12,33 +12,44 @@ auto to_jws_algorithm(const std::string_view value) noexcept
     -> std::optional<JWSAlgorithm> {
   if (value == "RS256") {
     return JWSAlgorithm::RS256;
-  } else if (value == "RS384") {
-    return JWSAlgorithm::RS384;
-  } else if (value == "RS512") {
-    return JWSAlgorithm::RS512;
-  } else if (value == "PS256") {
-    return JWSAlgorithm::PS256;
-  } else if (value == "PS384") {
-    return JWSAlgorithm::PS384;
-  } else if (value == "PS512") {
-    return JWSAlgorithm::PS512;
-  } else if (value == "ES256") {
-    return JWSAlgorithm::ES256;
-  } else if (value == "ES384") {
-    return JWSAlgorithm::ES384;
-  } else if (value == "ES512") {
-    return JWSAlgorithm::ES512;
-  } else if (value == "EdDSA") {
-    return JWSAlgorithm::EdDSA;
-  } else if (value == "HS256") {
-    return JWSAlgorithm::HS256;
-  } else if (value == "HS384") {
-    return JWSAlgorithm::HS384;
-  } else if (value == "HS512") {
-    return JWSAlgorithm::HS512;
-  } else {
-    return std::nullopt;
   }
+  if (value == "RS384") {
+    return JWSAlgorithm::RS384;
+  }
+  if (value == "RS512") {
+    return JWSAlgorithm::RS512;
+  }
+  if (value == "PS256") {
+    return JWSAlgorithm::PS256;
+  }
+  if (value == "PS384") {
+    return JWSAlgorithm::PS384;
+  }
+  if (value == "PS512") {
+    return JWSAlgorithm::PS512;
+  }
+  if (value == "ES256") {
+    return JWSAlgorithm::ES256;
+  }
+  if (value == "ES384") {
+    return JWSAlgorithm::ES384;
+  }
+  if (value == "ES512") {
+    return JWSAlgorithm::ES512;
+  }
+  if (value == "EdDSA") {
+    return JWSAlgorithm::EdDSA;
+  }
+  if (value == "HS256") {
+    return JWSAlgorithm::HS256;
+  }
+  if (value == "HS384") {
+    return JWSAlgorithm::HS384;
+  }
+  if (value == "HS512") {
+    return JWSAlgorithm::HS512;
+  }
+  return std::nullopt;
 }
 
 auto jws_algorithm_name(const JWSAlgorithm algorithm) noexcept
@@ -126,27 +137,35 @@ auto to_jwe_algorithm(const std::string_view value) noexcept
     -> std::optional<JWEAlgorithm> {
   if (value == "RSA-OAEP") {
     return JWEAlgorithm::RSA_OAEP;
-  } else if (value == "RSA-OAEP-256") {
-    return JWEAlgorithm::RSA_OAEP_256;
-  } else if (value == "ECDH-ES") {
-    return JWEAlgorithm::ECDH_ES;
-  } else if (value == "ECDH-ES+A128KW") {
-    return JWEAlgorithm::ECDH_ES_A128KW;
-  } else if (value == "ECDH-ES+A192KW") {
-    return JWEAlgorithm::ECDH_ES_A192KW;
-  } else if (value == "ECDH-ES+A256KW") {
-    return JWEAlgorithm::ECDH_ES_A256KW;
-  } else if (value == "A128KW") {
-    return JWEAlgorithm::A128KW;
-  } else if (value == "A192KW") {
-    return JWEAlgorithm::A192KW;
-  } else if (value == "A256KW") {
-    return JWEAlgorithm::A256KW;
-  } else if (value == "dir") {
-    return JWEAlgorithm::DIR;
-  } else {
-    return std::nullopt;
   }
+  if (value == "RSA-OAEP-256") {
+    return JWEAlgorithm::RSA_OAEP_256;
+  }
+  if (value == "ECDH-ES") {
+    return JWEAlgorithm::ECDH_ES;
+  }
+  if (value == "ECDH-ES+A128KW") {
+    return JWEAlgorithm::ECDH_ES_A128KW;
+  }
+  if (value == "ECDH-ES+A192KW") {
+    return JWEAlgorithm::ECDH_ES_A192KW;
+  }
+  if (value == "ECDH-ES+A256KW") {
+    return JWEAlgorithm::ECDH_ES_A256KW;
+  }
+  if (value == "A128KW") {
+    return JWEAlgorithm::A128KW;
+  }
+  if (value == "A192KW") {
+    return JWEAlgorithm::A192KW;
+  }
+  if (value == "A256KW") {
+    return JWEAlgorithm::A256KW;
+  }
+  if (value == "dir") {
+    return JWEAlgorithm::DIR;
+  }
+  return std::nullopt;
 }
 
 auto jwe_algorithm_name(const JWEAlgorithm algorithm) noexcept
@@ -181,19 +200,23 @@ auto to_jwe_encryption(const std::string_view value) noexcept
     -> std::optional<JWEEncryption> {
   if (value == "A128GCM") {
     return JWEEncryption::A128GCM;
-  } else if (value == "A192GCM") {
-    return JWEEncryption::A192GCM;
-  } else if (value == "A256GCM") {
-    return JWEEncryption::A256GCM;
-  } else if (value == "A128CBC-HS256") {
-    return JWEEncryption::A128CBC_HS256;
-  } else if (value == "A192CBC-HS384") {
-    return JWEEncryption::A192CBC_HS384;
-  } else if (value == "A256CBC-HS512") {
-    return JWEEncryption::A256CBC_HS512;
-  } else {
-    return std::nullopt;
   }
+  if (value == "A192GCM") {
+    return JWEEncryption::A192GCM;
+  }
+  if (value == "A256GCM") {
+    return JWEEncryption::A256GCM;
+  }
+  if (value == "A128CBC-HS256") {
+    return JWEEncryption::A128CBC_HS256;
+  }
+  if (value == "A192CBC-HS384") {
+    return JWEEncryption::A192CBC_HS384;
+  }
+  if (value == "A256CBC-HS512") {
+    return JWEEncryption::A256CBC_HS512;
+  }
+  return std::nullopt;
 }
 
 auto jwe_encryption_name(const JWEEncryption encryption) noexcept

--- a/src/core/jose/jose_jwt.cc
+++ b/src/core/jose/jose_jwt.cc
@@ -43,12 +43,12 @@ auto string_claim(const sourcemeta::core::JSON &object,
 // equal, and RFC 7515 Section 4.1.9 makes the media type case-insensitive
 auto strip_application_prefix(const std::string_view value)
     -> std::string_view {
-  constexpr std::string_view prefix{"application/"};
-  if (value.size() > prefix.size() &&
-      sourcemeta::core::equals_ignore_case(value.substr(0, prefix.size()),
-                                           prefix) &&
-      value.find('/', prefix.size()) == std::string_view::npos) {
-    return value.substr(prefix.size());
+  constexpr std::string_view PREFIX{"application/"};
+  if (value.size() > PREFIX.size() &&
+      sourcemeta::core::equals_ignore_case(value.substr(0, PREFIX.size()),
+                                           PREFIX) &&
+      value.find('/', PREFIX.size()) == std::string_view::npos) {
+    return value.substr(PREFIX.size());
   }
 
   return value;

--- a/src/core/jose/jose_key.h
+++ b/src/core/jose/jose_key.h
@@ -37,7 +37,7 @@ inline auto jwk_rsa_modulus_is_allowed(const std::string_view modulus) noexcept
   }
 
   const auto leading{static_cast<std::uint8_t>(modulus[offset])};
-  const auto bits{(modulus.size() - offset - 1) * 8 +
+  const auto bits{((modulus.size() - offset - 1) * 8) +
                   (8 - static_cast<std::size_t>(std::countl_zero(leading)))};
   return bits >= MINIMUM_RSA_MODULUS_BITS;
 }
@@ -47,13 +47,14 @@ inline auto jwk_ec_coordinate_bytes(const std::string_view curve)
     -> std::optional<std::size_t> {
   if (curve == "P-256") {
     return 32;
-  } else if (curve == "P-384") {
-    return 48;
-  } else if (curve == "P-521") {
-    return 66;
-  } else {
-    return std::nullopt;
   }
+  if (curve == "P-384") {
+    return 48;
+  }
+  if (curve == "P-521") {
+    return 66;
+  }
+  return std::nullopt;
 }
 
 // The key octet length is fixed per Edwards curve (RFC 8032 Sections 5.1.5 and
@@ -62,11 +63,11 @@ inline auto jwk_okp_key_bytes(const std::string_view curve)
     -> std::optional<std::size_t> {
   if (curve == "Ed25519") {
     return 32;
-  } else if (curve == "Ed448") {
-    return 57;
-  } else {
-    return std::nullopt;
   }
+  if (curve == "Ed448") {
+    return 57;
+  }
+  return std::nullopt;
 }
 
 // Both mappings are only reached after the curve has been validated above
@@ -74,20 +75,19 @@ inline auto jwk_to_elliptic_curve(const std::string_view curve) noexcept
     -> EllipticCurve {
   if (curve == "P-256") {
     return EllipticCurve::P256;
-  } else if (curve == "P-384") {
-    return EllipticCurve::P384;
-  } else {
-    return EllipticCurve::P521;
   }
+  if (curve == "P-384") {
+    return EllipticCurve::P384;
+  }
+  return EllipticCurve::P521;
 }
 
 inline auto jwk_to_edwards_curve(const std::string_view curve) noexcept
     -> EdwardsCurve {
   if (curve == "Ed25519") {
     return EdwardsCurve::Ed25519;
-  } else {
-    return EdwardsCurve::Ed448;
   }
+  return EdwardsCurve::Ed448;
 }
 
 // The JWK curve name each elliptic curve carries (RFC 7518 Section 6.2.1.1),

--- a/src/core/json/construct.h
+++ b/src/core/json/construct.h
@@ -24,8 +24,8 @@ namespace sourcemeta::core {
 namespace internal {
 
 inline auto unescape_string(const char *data, const std::uint32_t length,
-                            const bool has_escape) -> typename JSON::String {
-  typename JSON::String result;
+                            const bool has_escape) -> JSON::String {
+  JSON::String result;
   const char *cursor{data};
   const char *string_end{data + length};
 
@@ -113,7 +113,7 @@ inline auto unescape_string(const char *data, const std::uint32_t length,
 inline auto construct_number(const char *data, const std::uint32_t length,
                              const std::uint8_t flags,
                              const std::uint32_t significant_digits) -> JSON {
-  if (flags & TAPE_FLAG_NUMBER_EXPONENT) {
+  if ((flags & TAPE_FLAG_NUMBER_EXPONENT) != 0) {
     try {
       return JSON{Decimal{std::string_view{data, length}}};
     } catch (const DecimalParseError &) {
@@ -123,7 +123,7 @@ inline auto construct_number(const char *data, const std::uint32_t length,
     }
   }
 
-  if (flags & TAPE_FLAG_NUMBER_DOT) {
+  if ((flags & TAPE_FLAG_NUMBER_DOT) != 0) {
     constexpr std::uint32_t MAX_SAFE_SIGNIFICANT_DIGITS{15};
     if (significant_digits > MAX_SAFE_SIGNIFICANT_DIGITS) {
       try {
@@ -222,8 +222,8 @@ inline auto construct_json(const char *buffer,
   std::vector<std::reference_wrapper<Result>> frames;
   levels.reserve(32);
   frames.reserve(32);
-  typename Result::String key;
-  typename Result::Object::hash_type key_hash;
+  Result::String key;
+  Result::Object::hash_type key_hash;
   std::uint64_t key_line{0};
   std::uint64_t key_column{0};
   std::size_t tape_index{0};
@@ -473,7 +473,7 @@ do_construct_object_key: {
   assert(key_entry.type == TapeType::Key);
   const char *key_data{buffer + key_entry.offset};
   const auto key_length{key_entry.length};
-  if (key_entry.flags & TAPE_FLAG_STRING_ESCAPE) {
+  if ((key_entry.flags & TAPE_FLAG_STRING_ESCAPE) != 0) {
     key = internal::unescape_string(key_data, key_length, true);
     key_hash = Result::Object::hash(key);
   } else {

--- a/src/core/json/grammar.h
+++ b/src/core/json/grammar.h
@@ -21,9 +21,9 @@ namespace sourcemeta::core::internal {
 // solidus (U+005C), and the control characters U+0000 to U+001F.
 // See
 // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-template <typename CharT> static constexpr CharT token_string_quote{'\u0022'};
-template <typename CharT> static constexpr CharT token_string_escape{'\u005C'};
-template <typename CharT> static constexpr CharT token_string_solidus{'\u002F'};
+template <typename CharT> static constexpr CharT TOKEN_STRING_QUOTE{'\u0022'};
+template <typename CharT> static constexpr CharT TOKEN_STRING_ESCAPE{'\u005C'};
+template <typename CharT> static constexpr CharT TOKEN_STRING_SOLIDUS{'\u002F'};
 
 // There are two-character escape sequence representations of some characters.
 //
@@ -38,31 +38,31 @@ template <typename CharT> static constexpr CharT token_string_solidus{'\u002F'};
 // See
 // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
 template <typename CharT>
-static constexpr CharT token_string_escape_backspace{'\u0062'};
+static constexpr CharT TOKEN_STRING_ESCAPE_BACKSPACE{'\u0062'};
 template <typename CharT>
-static constexpr CharT token_string_escape_form_feed{'\u0066'};
+static constexpr CharT TOKEN_STRING_ESCAPE_FORM_FEED{'\u0066'};
 template <typename CharT>
-static constexpr CharT token_string_escape_line_feed{'\u006E'};
+static constexpr CharT TOKEN_STRING_ESCAPE_LINE_FEED{'\u006E'};
 template <typename CharT>
-static constexpr CharT token_string_escape_carriage_return{'\u0072'};
+static constexpr CharT TOKEN_STRING_ESCAPE_CARRIAGE_RETURN{'\u0072'};
 template <typename CharT>
-static constexpr CharT token_string_escape_tabulation{'\u0074'};
+static constexpr CharT TOKEN_STRING_ESCAPE_TABULATION{'\u0074'};
 template <typename CharT>
-static constexpr CharT token_string_escape_unicode{'\u0075'};
+static constexpr CharT TOKEN_STRING_ESCAPE_UNICODE{'\u0075'};
 
 // Array
-template <typename CharT> static constexpr CharT token_array_begin{'\u005B'};
-template <typename CharT> static constexpr CharT token_array_end{'\u005D'};
+template <typename CharT> static constexpr CharT TOKEN_ARRAY_BEGIN{'\u005B'};
+template <typename CharT> static constexpr CharT TOKEN_ARRAY_END{'\u005D'};
 template <typename CharT>
-static constexpr CharT token_array_delimiter{'\u002C'};
+static constexpr CharT TOKEN_ARRAY_DELIMITER{'\u002C'};
 
 // Object
-template <typename CharT> static constexpr CharT token_object_begin{'\u007B'};
-template <typename CharT> static constexpr CharT token_object_end{'\u007D'};
+template <typename CharT> static constexpr CharT TOKEN_OBJECT_BEGIN{'\u007B'};
+template <typename CharT> static constexpr CharT TOKEN_OBJECT_END{'\u007D'};
 template <typename CharT>
-static constexpr CharT token_object_key_delimiter{'\u003A'};
+static constexpr CharT TOKEN_OBJECT_KEY_DELIMITER{'\u003A'};
 template <typename CharT>
-static constexpr CharT token_object_delimiter{'\u002C'};
+static constexpr CharT TOKEN_OBJECT_DELIMITER{'\u002C'};
 
 // These are the three literal name tokens:
 // true  U+0074 U+0072 U+0075 U+0065
@@ -72,19 +72,19 @@ static constexpr CharT token_object_delimiter{'\u002C'};
 // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
 
 // Boolean
-template <typename CharT> static constexpr CharT token_true{'\u0074'};
+template <typename CharT> static constexpr CharT TOKEN_TRUE{'\u0074'};
 template <typename CharT, typename Traits>
-static constexpr std::basic_string_view<CharT, Traits> constant_true{
+static constexpr std::basic_string_view<CharT, Traits> CONSTANT_TRUE{
     "\u0074\u0072\u0075\u0065"};
-template <typename CharT> static constexpr CharT token_false{'\u0066'};
+template <typename CharT> static constexpr CharT TOKEN_FALSE{'\u0066'};
 template <typename CharT, typename Traits>
-static constexpr std::basic_string_view<CharT, Traits> constant_false{
+static constexpr std::basic_string_view<CharT, Traits> CONSTANT_FALSE{
     "\u0066\u0061\u006C\u0073\u0065"};
 
 // Null
-template <typename CharT> static constexpr CharT token_null{'\u006E'};
+template <typename CharT> static constexpr CharT TOKEN_NULL{'\u006E'};
 template <typename CharT, typename Traits>
-static constexpr std::basic_string_view<CharT, Traits> constant_null{
+static constexpr std::basic_string_view<CharT, Traits> CONSTANT_NULL{
     "\u006E\u0075\u006C\u006C"};
 
 // A number is a sequence of decimal digits with no superfluous leading zero.
@@ -95,23 +95,23 @@ static constexpr std::basic_string_view<CharT, Traits> constant_null{
 // See
 // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
 template <typename CharT>
-static constexpr CharT token_number_decimal_point{'\u002E'};
+static constexpr CharT TOKEN_NUMBER_DECIMAL_POINT{'\u002E'};
 template <typename CharT>
-static constexpr CharT token_number_exponent_uppercase{'\u0045'};
+static constexpr CharT TOKEN_NUMBER_EXPONENT_UPPERCASE{'\u0045'};
 template <typename CharT>
-static constexpr CharT token_number_exponent_lowercase{'\u0065'};
-template <typename CharT> static constexpr CharT token_number_plus{'\u002B'};
-template <typename CharT> static constexpr CharT token_number_minus{'\u002D'};
-template <typename CharT> static constexpr CharT token_number_zero{'\u0030'};
-template <typename CharT> static constexpr CharT token_number_one{'\u0031'};
-template <typename CharT> static constexpr CharT token_number_two{'\u0032'};
-template <typename CharT> static constexpr CharT token_number_three{'\u0033'};
-template <typename CharT> static constexpr CharT token_number_four{'\u0034'};
-template <typename CharT> static constexpr CharT token_number_five{'\u0035'};
-template <typename CharT> static constexpr CharT token_number_six{'\u0036'};
-template <typename CharT> static constexpr CharT token_number_seven{'\u0037'};
-template <typename CharT> static constexpr CharT token_number_eight{'\u0038'};
-template <typename CharT> static constexpr CharT token_number_nine{'\u0039'};
+static constexpr CharT TOKEN_NUMBER_EXPONENT_LOWERCASE{'\u0065'};
+template <typename CharT> static constexpr CharT TOKEN_NUMBER_PLUS{'\u002B'};
+template <typename CharT> static constexpr CharT TOKEN_NUMBER_MINUS{'\u002D'};
+template <typename CharT> static constexpr CharT TOKEN_NUMBER_ZERO{'\u0030'};
+template <typename CharT> static constexpr CharT TOKEN_NUMBER_ONE{'\u0031'};
+template <typename CharT> static constexpr CharT TOKEN_NUMBER_TWO{'\u0032'};
+template <typename CharT> static constexpr CharT TOKEN_NUMBER_THREE{'\u0033'};
+template <typename CharT> static constexpr CharT TOKEN_NUMBER_FOUR{'\u0034'};
+template <typename CharT> static constexpr CharT TOKEN_NUMBER_FIVE{'\u0035'};
+template <typename CharT> static constexpr CharT TOKEN_NUMBER_SIX{'\u0036'};
+template <typename CharT> static constexpr CharT TOKEN_NUMBER_SEVEN{'\u0037'};
+template <typename CharT> static constexpr CharT TOKEN_NUMBER_EIGHT{'\u0038'};
+template <typename CharT> static constexpr CharT TOKEN_NUMBER_NINE{'\u0039'};
 
 // Whitespace is any sequence of one or more of the following code points:
 // character tabulation (U+0009), line feed (U+000A), carriage return (U+000D),
@@ -119,13 +119,13 @@ template <typename CharT> static constexpr CharT token_number_nine{'\u0039'};
 // See
 // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
 template <typename CharT>
-static constexpr CharT token_whitespace_tabulation{'\u0009'};
+static constexpr CharT TOKEN_WHITESPACE_TABULATION{'\u0009'};
 template <typename CharT>
-static constexpr CharT token_whitespace_line_feed{'\u000A'};
+static constexpr CharT TOKEN_WHITESPACE_LINE_FEED{'\u000A'};
 template <typename CharT>
-static constexpr CharT token_whitespace_carriage_return{'\u000D'};
+static constexpr CharT TOKEN_WHITESPACE_CARRIAGE_RETURN{'\u000D'};
 template <typename CharT>
-static constexpr CharT token_whitespace_space{'\u0020'};
+static constexpr CharT TOKEN_WHITESPACE_SPACE{'\u0020'};
 
 } // namespace sourcemeta::core::internal
 

--- a/src/core/json/include/sourcemeta/core/json_array.h
+++ b/src/core/json/include/sourcemeta/core/json_array.h
@@ -14,95 +14,95 @@ public:
   /// The underlying container type that holds the array elements
   using Container =
       std::vector<Value, typename Value::template Allocator<Value>>;
-  JSONArray() : data{} {}
+  JSONArray() : data_{} {}
   /// Construct an array from a list of values
-  JSONArray(std::initializer_list<Value> values) : data{values} {}
+  JSONArray(std::initializer_list<Value> values) : data_{values} {}
 
   // Operators
   // We cannot default given that this class references
   // a JSON "value" as an incomplete type
   auto operator<(const JSONArray<Value> &other) const noexcept -> bool {
-    return this->data < other.data;
+    return this->data_ < other.data_;
   }
   auto operator<=(const JSONArray<Value> &other) const noexcept -> bool {
-    return this->data <= other.data;
+    return this->data_ <= other.data_;
   }
   auto operator>(const JSONArray<Value> &other) const noexcept -> bool {
-    return this->data > other.data;
+    return this->data_ > other.data_;
   }
   auto operator>=(const JSONArray<Value> &other) const noexcept -> bool {
-    return this->data >= other.data;
+    return this->data_ >= other.data_;
   }
   auto operator==(const JSONArray<Value> &other) const noexcept -> bool {
-    return this->data == other.data;
+    return this->data_ == other.data_;
   }
   auto operator!=(const JSONArray<Value> &other) const noexcept -> bool {
-    return this->data != other.data;
+    return this->data_ != other.data_;
   }
 
   // Member types
-  using value_type = typename Container::value_type;
-  using allocator_type = typename Container::allocator_type;
-  using size_type = typename Container::size_type;
-  using difference_type = typename Container::difference_type;
-  using reference = typename Container::reference;
-  using const_reference = typename Container::const_reference;
-  using pointer = typename Container::pointer;
-  using const_pointer = typename Container::const_pointer;
-  using iterator = typename Container::iterator;
-  using const_iterator = typename Container::const_iterator;
-  using reverse_iterator = typename Container::reverse_iterator;
-  using const_reverse_iterator = typename Container::const_reverse_iterator;
+  using value_type = Container::value_type;
+  using allocator_type = Container::allocator_type;
+  using size_type = Container::size_type;
+  using difference_type = Container::difference_type;
+  using reference = Container::reference;
+  using const_reference = Container::const_reference;
+  using pointer = Container::pointer;
+  using const_pointer = Container::const_pointer;
+  using iterator = Container::iterator;
+  using const_iterator = Container::const_iterator;
+  using reverse_iterator = Container::reverse_iterator;
+  using const_reverse_iterator = Container::const_reverse_iterator;
 
   /// Get a mutable begin iterator on the array
-  auto begin() noexcept -> iterator { return this->data.begin(); }
+  auto begin() noexcept -> iterator { return this->data_.begin(); }
   /// Get a mutable end iterator on the array
-  auto end() noexcept -> iterator { return this->data.end(); }
+  auto end() noexcept -> iterator { return this->data_.end(); }
   /// Get a constant begin iterator on the array
   [[nodiscard]] auto begin() const noexcept -> const_iterator {
-    return this->data.begin();
+    return this->data_.begin();
   }
   /// Get a constant end iterator on the array
   [[nodiscard]] auto end() const noexcept -> const_iterator {
-    return this->data.end();
+    return this->data_.end();
   }
   /// Get a constant begin iterator on the array
   [[nodiscard]] auto cbegin() const noexcept -> const_iterator {
-    return this->data.cbegin();
+    return this->data_.cbegin();
   }
   /// Get a constant end iterator on the array
   [[nodiscard]] auto cend() const noexcept -> const_iterator {
-    return this->data.cend();
+    return this->data_.cend();
   }
   /// Get a mutable reverse begin iterator on the array
-  auto rbegin() noexcept -> reverse_iterator { return this->data.rbegin(); }
+  auto rbegin() noexcept -> reverse_iterator { return this->data_.rbegin(); }
   /// Get a mutable reverse end iterator on the array
-  auto rend() noexcept -> reverse_iterator { return this->data.rend(); }
+  auto rend() noexcept -> reverse_iterator { return this->data_.rend(); }
   /// Get a constant reverse begin iterator on the array
   [[nodiscard]] auto rbegin() const noexcept -> const_reverse_iterator {
-    return this->data.rbegin();
+    return this->data_.rbegin();
   }
   /// Get a constant reverse end iterator on the array
   [[nodiscard]] auto rend() const noexcept -> const_reverse_iterator {
-    return this->data.rend();
+    return this->data_.rend();
   }
   /// Get a constant reverse begin iterator on the array
   [[nodiscard]] auto crbegin() const noexcept -> const_reverse_iterator {
-    return this->data.crbegin();
+    return this->data_.crbegin();
   }
   /// Get a constant reverse end iterator on the array
   [[nodiscard]] auto crend() const noexcept -> const_reverse_iterator {
-    return this->data.crend();
+    return this->data_.crend();
   }
 
   /// Get array size
   [[nodiscard]] auto size() const noexcept -> size_type {
-    return this->data.size();
+    return this->data_.size();
   }
 
   /// Reserve capacity for a given number of elements
   auto reserve(const size_type capacity) -> void {
-    this->data.reserve(capacity);
+    this->data_.reserve(capacity);
   }
 
 private:
@@ -113,7 +113,7 @@ private:
 #if defined(_MSC_VER)
 #pragma warning(disable : 4251)
 #endif
-  Container data;
+  Container data_;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251)
 #endif

--- a/src/core/json/include/sourcemeta/core/json_auto.h
+++ b/src/core/json/include/sourcemeta/core/json_auto.h
@@ -23,22 +23,21 @@ template <typename T>
 concept json_auto_has_mapped_type = requires { typename T::mapped_type; };
 
 /// @ingroup json
-template <typename T> struct json_auto_is_basic_string : std::false_type {};
+template <typename T> struct JSONAutoIsBasicString : std::false_type {};
 template <typename CharT, typename Traits, typename Alloc>
-struct json_auto_is_basic_string<std::basic_string<CharT, Traits, Alloc>>
+struct JSONAutoIsBasicString<std::basic_string<CharT, Traits, Alloc>>
     : std::true_type {};
 
 /// @ingroup json
-template <typename T>
-struct json_auto_is_basic_string_view : std::false_type {};
+template <typename T> struct JSONAutoIsBasicStringView : std::false_type {};
 template <typename CharT, typename Traits>
-struct json_auto_is_basic_string_view<std::basic_string_view<CharT, Traits>>
+struct JSONAutoIsBasicStringView<std::basic_string_view<CharT, Traits>>
     : std::true_type {};
 
 /// @ingroup json
-template <typename T> struct json_auto_is_bitset : std::false_type {};
+template <typename T> struct JSONAutoIsBitset : std::false_type {};
 template <std::size_t N>
-struct json_auto_is_bitset<std::bitset<N>> : std::true_type {};
+struct JSONAutoIsBitset<std::bitset<N>> : std::true_type {};
 
 /// @ingroup json
 template <typename T> struct json_auto_bitset_size;
@@ -76,8 +75,7 @@ concept json_auto_list_like =
       { type.cend() } -> std::same_as<typename T::const_iterator>;
     } && json_auto_supports_auto<T> && !json_auto_has_mapped_type<T> &&
     !json_auto_has_method_from<T> && !json_auto_has_method_to<T> &&
-    !json_auto_is_basic_string<T>::value &&
-    !json_auto_is_basic_string_view<T>::value;
+    !JSONAutoIsBasicString<T>::value && !JSONAutoIsBasicStringView<T>::value;
 
 /// @ingroup json
 template <typename T>
@@ -98,18 +96,18 @@ concept json_auto_has_reverse_iterator =
     requires { typename T::reverse_iterator; };
 
 /// @ingroup json
-template <typename T> struct json_auto_is_pair : std::false_type {};
+template <typename T> struct JSONAutoIsPair : std::false_type {};
 
 /// @ingroup json
 template <typename U, typename V>
-struct json_auto_is_pair<std::pair<U, V>> : std::true_type {};
+struct JSONAutoIsPair<std::pair<U, V>> : std::true_type {};
 
 /// @ingroup json
-template <typename T> struct json_auto_is_variant : std::false_type {};
+template <typename T> struct JSONAutoIsVariant : std::false_type {};
 
 /// @ingroup json
 template <typename... Ts>
-struct json_auto_is_variant<std::variant<Ts...>> : std::true_type {};
+struct JSONAutoIsVariant<std::variant<Ts...>> : std::true_type {};
 
 /// @ingroup json
 template <typename T>
@@ -138,7 +136,7 @@ auto to_json(const std::pair<L, R> &value) -> JSON;
 template <json_auto_tuple_mono T> auto to_json(const T &value) -> JSON;
 template <json_auto_tuple_poly T> auto to_json(const T &value) -> JSON;
 template <typename T>
-  requires json_auto_is_variant<T>::value
+  requires JSONAutoIsVariant<T>::value
 auto to_json(const T &value) -> JSON;
 #endif
 
@@ -164,9 +162,8 @@ template <typename T>
 auto from_json(const JSON &value) -> std::optional<T> {
   if (value.is_boolean()) {
     return value.to_boolean();
-  } else {
-    return std::nullopt;
   }
+  return std::nullopt;
 }
 
 /// @ingroup json
@@ -177,9 +174,8 @@ auto from_json(const JSON &value) -> std::optional<T> {
   // silently narrowed one
   if (value.is_integer() && std::in_range<T>(value.to_integer())) {
     return static_cast<T>(value.to_integer());
-  } else {
-    return std::nullopt;
   }
+  return std::nullopt;
 }
 
 /// @ingroup json
@@ -188,9 +184,8 @@ template <typename T>
 auto from_json(const JSON &value) -> std::optional<T> {
   if (value.is_decimal()) {
     return value.to_decimal();
-  } else {
-    return std::nullopt;
   }
+  return std::nullopt;
 }
 
 // TODO: How can we keep this in the hash header that does not yet know about
@@ -257,9 +252,8 @@ auto from_json(const JSON &value) -> std::optional<T> {
     using file_time_type = std::filesystem::file_time_type;
     return file_time_type{file_time_type::duration{
         static_cast<file_time_type::duration::rep>(value.to_integer())}};
-  } else {
-    return std::nullopt;
   }
+  return std::nullopt;
 }
 
 /// @ingroup json
@@ -278,17 +272,16 @@ template <typename T>
 auto from_json(const JSON &value) -> std::optional<T> {
   if (value.is_string()) {
     return value.to_string();
-  } else {
-    return std::nullopt;
   }
+  return std::nullopt;
 }
 
 /// @ingroup json
 template <typename T>
-  requires json_auto_is_bitset<T>::value
+  requires JSONAutoIsBitset<T>::value
 auto to_json(const T &bitset) -> JSON {
-  constexpr std::size_t N{json_auto_bitset_size<T>::value};
-  if constexpr (N <= 64) {
+  constexpr std::size_t BIT_COUNT{json_auto_bitset_size<T>::value};
+  if constexpr (BIT_COUNT <= 64) {
     return JSON{static_cast<std::int64_t>(bitset.to_ullong())};
   } else {
     return JSON{bitset.to_string()};
@@ -297,21 +290,20 @@ auto to_json(const T &bitset) -> JSON {
 
 /// @ingroup json
 template <typename T>
-  requires json_auto_is_bitset<T>::value
+  requires JSONAutoIsBitset<T>::value
 auto from_json(const JSON &value) -> std::optional<T> {
-  constexpr std::size_t N{json_auto_bitset_size<T>::value};
-  if constexpr (N <= 64) {
+  constexpr std::size_t BIT_COUNT{json_auto_bitset_size<T>::value};
+  if constexpr (BIT_COUNT <= 64) {
     if (value.is_integer()) {
       return T{static_cast<unsigned long long>(value.to_integer())};
-    } else {
-      return std::nullopt;
     }
+    return std::nullopt;
+
   } else {
     if (value.is_string()) {
       return T{value.to_string()};
-    } else {
-      return std::nullopt;
     }
+    return std::nullopt;
   }
 }
 
@@ -331,13 +323,12 @@ auto from_json(const JSON &value) -> std::optional<T> {
 
 /// @ingroup json
 template <typename T>
-  requires json_auto_is_basic_string<T>::value
+  requires JSONAutoIsBasicString<T>::value
 auto from_json(const JSON &value) -> std::optional<T> {
   if (value.is_string()) {
     return value.to_string();
-  } else {
-    return std::nullopt;
   }
+  return std::nullopt;
 }
 
 /// @ingroup json
@@ -353,9 +344,8 @@ template <typename T>
 auto from_json(const JSON &value) -> std::optional<T> {
   if (value.is_integer()) {
     return static_cast<T>(value.to_integer());
-  } else {
-    return std::nullopt;
   }
+  return std::nullopt;
 }
 
 /// @ingroup json
@@ -372,14 +362,13 @@ auto from_json(const JSON &value) -> std::optional<T> {
   if (value.is_null()) {
     return std::optional<T>{
         std::optional<typename T::value_type>{std::nullopt}};
-  } else {
-    auto result{from_json<typename T::value_type>(value)};
-    if (!result.has_value()) {
-      return std::nullopt;
-    }
-
-    return result;
   }
+  auto result{from_json<typename T::value_type>(value)};
+  if (!result.has_value()) {
+    return std::nullopt;
+  }
+
+  return result;
 }
 
 /// @ingroup json
@@ -590,7 +579,7 @@ auto to_json(const std::pair<L, R> &value) -> JSON {
 
 /// @ingroup json
 template <typename T>
-  requires json_auto_is_pair<T>::value
+  requires JSONAutoIsPair<T>::value
 auto from_json(const JSON &value) -> std::optional<T> {
   if (!value.is_array() || value.size() != 2) {
     return std::nullopt;
@@ -644,7 +633,8 @@ template <json_auto_tuple_poly T> auto to_json(const T &value) -> JSON {
 
 #ifndef DOXYGEN
 template <typename T, std::size_t... Indices>
-auto from_json_tuple_poly(const JSON &value, std::index_sequence<Indices...>)
+auto from_json_tuple_poly(
+    const JSON &value, [[maybe_unused]] std::index_sequence<Indices...> indices)
     -> T {
   return {from_json<std::tuple_element_t<Indices, T>>(value.at(Indices))
               .value()...};
@@ -669,7 +659,7 @@ auto from_json(const JSON &value) -> std::optional<T> {
 
 /// @ingroup json
 template <typename T>
-  requires json_auto_is_variant<T>::value
+  requires JSONAutoIsVariant<T>::value
 auto to_json(const T &value) -> JSON {
   auto result{JSON::make_array()};
   result.push_back(JSON{static_cast<std::int64_t>(value.index())});
@@ -695,16 +685,15 @@ auto from_json_variant_impl(const JSON &data, std::size_t index)
       }
 
       return std::nullopt;
-    } else {
-      return from_json_variant_impl<T, Index + 1>(data, index);
     }
+    return from_json_variant_impl<T, Index + 1>(data, index);
   }
 }
 #endif
 
 /// @ingroup json
 template <typename T>
-  requires json_auto_is_variant<T>::value
+  requires JSONAutoIsVariant<T>::value
 auto from_json(const JSON &value) -> std::optional<T> {
   if (!value.is_array() || value.size() != 2 || !value.at(0).is_integer()) {
     return std::nullopt;
@@ -713,9 +702,8 @@ auto from_json(const JSON &value) -> std::optional<T> {
   const auto index{static_cast<std::size_t>(value.at(0).to_integer())};
   if (index >= std::variant_size_v<T>) {
     return std::nullopt;
-  } else {
-    return from_json_variant_impl<T>(value.at(1), index);
   }
+  return from_json_variant_impl<T>(value.at(1), index);
 }
 
 } // namespace sourcemeta::core

--- a/src/core/json/include/sourcemeta/core/json_hash.h
+++ b/src/core/json/include/sourcemeta/core/json_hash.h
@@ -16,7 +16,7 @@ namespace sourcemeta::core {
 template <typename T> struct HashJSON {
   using hash_type = std::uint64_t;
 
-  inline auto operator()(const T &value) const noexcept -> hash_type {
+  auto operator()(const T &value) const noexcept -> hash_type {
     if constexpr (requires { value.get().fast_hash(); }) {
       return value.get().fast_hash();
     } else {
@@ -26,7 +26,8 @@ template <typename T> struct HashJSON {
 
   /// Check whether the given hash is a perfect hash
   [[nodiscard]]
-  inline auto is_perfect(const hash_type) const noexcept -> bool {
+  auto is_perfect([[maybe_unused]] const hash_type hash) const noexcept
+      -> bool {
     return false;
   }
 };
@@ -34,19 +35,19 @@ template <typename T> struct HashJSON {
 /// @ingroup json
 /// A hash function object for JSON object property keys
 template <typename T> struct PropertyHashJSON {
-  struct hash_type {
+  struct HashType {
     using type = sourcemeta::core::uint128_t;
     type a{0};
     type b{0};
 
-    auto operator==(const hash_type &) const noexcept -> bool = default;
+    auto operator==(const HashType &) const noexcept -> bool = default;
   };
 
   /// Compute a perfect hash from raw data
   [[nodiscard]]
   constexpr auto perfect(const char *data,
-                         const std::size_t size) const noexcept -> hash_type {
-    hash_type result;
+                         const std::size_t size) const noexcept -> HashType {
+    HashType result;
     assert(size > 0);
     if consteval {
       // A constant evaluation cannot memcpy through a reinterpret_cast, so pack
@@ -56,7 +57,7 @@ template <typename T> struct PropertyHashJSON {
       // silently diverge
       static_assert(std::endian::native == std::endian::little);
       for (std::size_t index = 0; index < size; index += 1) {
-        const auto byte{static_cast<typename hash_type::type>(
+        const auto byte{static_cast<HashType::type>(
             static_cast<unsigned char>(data[index]))};
         const auto position{index + 1};
         if (position < 16) {
@@ -76,7 +77,7 @@ template <typename T> struct PropertyHashJSON {
   // std::string to std::string_view, so we provide separate overloads with
   // duplicated logic instead of unifying on a single parameter type
 
-  constexpr auto operator()(const T &value) const noexcept -> hash_type {
+  constexpr auto operator()(const T &value) const noexcept -> HashType {
     const auto size{value.size()};
     switch (size) {
       case 0:
@@ -149,8 +150,8 @@ template <typename T> struct PropertyHashJSON {
         // have a lot of entries, so hash collision is not as common
         auto hash = this->perfect(value.data(), 31);
         hash.a |= 1 + (static_cast<std::uint64_t>(size) +
-                       static_cast<typename hash_type::type>(value.front()) +
-                       static_cast<typename hash_type::type>(value.back())) %
+                       static_cast<HashType::type>(value.front()) +
+                       static_cast<HashType::type>(value.back())) %
                           // Make sure the property hash can never exceed 8 bits
                           255;
         return hash;
@@ -158,8 +159,7 @@ template <typename T> struct PropertyHashJSON {
   }
 
   constexpr auto operator()(const char *data,
-                            const std::size_t size) const noexcept
-      -> hash_type {
+                            const std::size_t size) const noexcept -> HashType {
     switch (size) {
       case 0:
         return {};
@@ -231,8 +231,8 @@ template <typename T> struct PropertyHashJSON {
         // have a lot of entries, so hash collision is not as common
         auto hash = this->perfect(data, 31);
         hash.a |= 1 + (static_cast<std::uint64_t>(size) +
-                       static_cast<typename hash_type::type>(data[0]) +
-                       static_cast<typename hash_type::type>(data[size - 1])) %
+                       static_cast<HashType::type>(data[0]) +
+                       static_cast<HashType::type>(data[size - 1])) %
                           // Make sure the property hash can never exceed 8 bits
                           255;
         return hash;
@@ -241,7 +241,7 @@ template <typename T> struct PropertyHashJSON {
 
   /// Check whether the given hash is a perfect hash
   [[nodiscard]]
-  constexpr auto is_perfect(const hash_type &hash) const noexcept -> bool {
+  constexpr auto is_perfect(const HashType &hash) const noexcept -> bool {
     // If there is anything written past the first byte,
     // then it is a perfect hash
     return (hash.a & 255) == 0;
@@ -254,7 +254,7 @@ template <typename T> struct PropertyHashJSON {
 /// See
 /// https://en.cppreference.com/w/cpp/utility/functional/reference_wrapper/operator_cmp.html
 template <typename T> struct EqualJSON {
-  inline auto operator()(const T &left, const T &right) const -> bool {
+  auto operator()(const T &left, const T &right) const -> bool {
     if constexpr (requires { left.get() == right.get(); }) {
       return left.get() == right.get();
     } else {

--- a/src/core/json/include/sourcemeta/core/json_hash.h
+++ b/src/core/json/include/sourcemeta/core/json_hash.h
@@ -35,9 +35,13 @@ template <typename T> struct HashJSON {
 /// @ingroup json
 /// A hash function object for JSON object property keys
 template <typename T> struct PropertyHashJSON {
+  /// The two halves that make up a property key hash
   struct HashType {
+    /// The unsigned integer type each half is stored as
     using type = sourcemeta::core::uint128_t;
+    /// The first half of the hash
     type a{0};
+    /// The second half of the hash
     type b{0};
 
     auto operator==(const HashType &) const noexcept -> bool = default;

--- a/src/core/json/include/sourcemeta/core/json_object.h
+++ b/src/core/json/include/sourcemeta/core/json_object.h
@@ -22,15 +22,15 @@ public:
 
   using key_type = Key;
   using mapped_type = Value;
-  using hash_type = typename Hash::hash_type;
+  using hash_type = Hash::HashType;
   using pair_value_type = std::pair<key_type, mapped_type>;
   /// The string view type used to look up object keys
   using KeyView = std::basic_string_view<typename Key::value_type,
                                          typename Key::traits_type>;
 
   /// Construct an object from a list of key and value pairs
-  JSONObject(std::initializer_list<pair_value_type> entries) : data{} {
-    this->data.reserve(entries.size());
+  JSONObject(std::initializer_list<pair_value_type> entries) : data_{} {
+    this->data_.reserve(entries.size());
     for (auto &&entry : entries) {
       this->emplace(std::move(entry.first), std::move(entry.second));
     }
@@ -59,29 +59,28 @@ public:
     /// assert(entry.key_equals(
     ///   "foo", sourcemeta::core::JSON::Object::hash("foo")));
     /// ```
-    [[nodiscard]] inline auto key_equals(const KeyView key,
-                                         const hash_type key_hash) const
-        -> bool {
+    [[nodiscard]] auto key_equals(const KeyView key,
+                                  const hash_type key_hash) const -> bool {
       assert(JSONObject::hash(key) == key_hash);
       // A perfect hash captures the key bytes but not its length, so two keys
       // that differ only by trailing NUL bytes hash equal. Comparing sizes
       // disambiguates them without the cost of a full string comparison
       return this->hash == key_hash &&
-             (hasher.is_perfect(key_hash) ? this->first.size() == key.size()
+             (HASHER.is_perfect(key_hash) ? this->first.size() == key.size()
                                           : this->first == key);
     }
   };
 
   using underlying_type = std::vector<Entry>;
-  using value_type = typename underlying_type::value_type;
-  using size_type = typename underlying_type::size_type;
-  using difference_type = typename underlying_type::difference_type;
-  using allocator_type = typename underlying_type::allocator_type;
-  using reference = typename underlying_type::reference;
-  using const_reference = typename underlying_type::const_reference;
-  using pointer = typename underlying_type::pointer;
-  using const_pointer = typename underlying_type::const_pointer;
-  using const_iterator = typename underlying_type::const_iterator;
+  using value_type = underlying_type::value_type;
+  using size_type = underlying_type::size_type;
+  using difference_type = underlying_type::difference_type;
+  using allocator_type = underlying_type::allocator_type;
+  using reference = underlying_type::reference;
+  using const_reference = underlying_type::const_reference;
+  using pointer = underlying_type::pointer;
+  using const_pointer = underlying_type::const_pointer;
+  using const_iterator = underlying_type::const_iterator;
 
   // Operators
   // We cannot default given that this class references
@@ -95,13 +94,13 @@ public:
     // ordered as their entries would compare in key order. That outcome is
     // decided entirely by the smallest key at which the two objects differ,
     // which is found by scanning the entries in place to avoid allocating
-    if (this->data.size() != other.data.size()) {
-      return this->data.size() < other.data.size();
+    if (this->data_.size() != other.data_.size()) {
+      return this->data_.size() < other.data_.size();
     }
 
     const Key *decisive_key{nullptr};
     bool decision{false};
-    for (const auto &entry : this->data) {
+    for (const auto &entry : this->data_) {
       const auto match{other.find(entry.first)};
       const bool differs{match == other.cend() ||
                          !(entry.second == match->second)};
@@ -111,7 +110,7 @@ public:
       }
     }
 
-    for (const auto &entry : other.data) {
+    for (const auto &entry : other.data_) {
       if (this->find(entry.first) == this->cend() &&
           (decisive_key == nullptr || entry.first < *decisive_key)) {
         decisive_key = &entry.first;
@@ -141,9 +140,9 @@ public:
       return false;
     }
 
-    for (const auto &entry : this->data) {
+    for (const auto &entry : this->data_) {
       const auto *result{other.try_at(entry.first, entry.hash)};
-      if (!result || *result != entry.second) {
+      if ((result == nullptr) || *result != entry.second) {
         return false;
       }
     }
@@ -154,20 +153,20 @@ public:
   auto operator!=(const JSONObject<Key, Value, Hash> &other) const noexcept
       -> bool = default;
 
-  [[nodiscard]] inline auto begin() const noexcept -> const_iterator {
-    return this->data.begin();
+  [[nodiscard]] auto begin() const noexcept -> const_iterator {
+    return this->data_.begin();
   }
   /// Get a constant end iterator on the object
-  [[nodiscard]] inline auto end() const noexcept -> const_iterator {
-    return this->data.end();
+  [[nodiscard]] auto end() const noexcept -> const_iterator {
+    return this->data_.end();
   }
   /// Get a constant begin iterator on the object
-  [[nodiscard]] inline auto cbegin() const noexcept -> const_iterator {
-    return this->data.cbegin();
+  [[nodiscard]] auto cbegin() const noexcept -> const_iterator {
+    return this->data_.cbegin();
   }
   /// Get a constant end iterator on the object
-  [[nodiscard]] inline auto cend() const noexcept -> const_iterator {
-    return this->data.cend();
+  [[nodiscard]] auto cend() const noexcept -> const_iterator {
+    return this->data_.cend();
   }
 
   // GCC does not optimise well across implicit type conversions such as
@@ -180,32 +179,32 @@ public:
   /// Compute a hash for a key
   [[nodiscard]] static constexpr auto hash(const Key &key) noexcept
       -> hash_type {
-    return hasher(key);
+    return HASHER(key);
   }
 
   /// Compute a hash for a key
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, KeyView>
   [[nodiscard]] static constexpr auto hash(T key) noexcept -> hash_type {
-    return hasher(key.data(), key.size());
+    return HASHER(key.data(), key.size());
   }
 
   /// Compute a hash from raw data
   [[nodiscard]] static constexpr auto hash(const char *raw_data,
                                            const std::size_t raw_size) noexcept
       -> hash_type {
-    return hasher(raw_data, raw_size);
+    return HASHER(raw_data, raw_size);
   }
 
   /// Attempt to find an entry by key
-  [[nodiscard]] inline auto find(const Key &key) const -> const_iterator {
+  [[nodiscard]] auto find(const Key &key) const -> const_iterator {
     const auto key_hash{this->hash(key)};
 
     // Move the perfect hash condition out of the loop for extra performance
-    if (this->hasher.is_perfect(key_hash)) {
+    if (this->HASHER.is_perfect(key_hash)) {
       for (size_type index = 0; index < this->size(); index++) {
-        if (this->data[index].hash == key_hash &&
-            this->data[index].first.size() == key.size()) {
+        if (this->data_[index].hash == key_hash &&
+            this->data_[index].first.size() == key.size()) {
           auto iterator{this->cbegin()};
           std::advance(iterator, index);
           return iterator;
@@ -213,8 +212,8 @@ public:
       }
     } else {
       for (size_type index = 0; index < this->size(); index++) {
-        if (this->data[index].hash == key_hash &&
-            this->data[index].first == key) {
+        if (this->data_[index].hash == key_hash &&
+            this->data_[index].first == key) {
           auto iterator{this->cbegin()};
           std::advance(iterator, index);
           return iterator;
@@ -228,14 +227,14 @@ public:
   /// Attempt to find an entry by key
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, KeyView>
-  [[nodiscard]] inline auto find(T key) const -> const_iterator {
+  [[nodiscard]] auto find(T key) const -> const_iterator {
     const auto key_hash{this->hash(key)};
 
     // Move the perfect hash condition out of the loop for extra performance
-    if (this->hasher.is_perfect(key_hash)) {
+    if (this->HASHER.is_perfect(key_hash)) {
       for (size_type index = 0; index < this->size(); index++) {
-        if (this->data[index].hash == key_hash &&
-            this->data[index].first.size() == key.size()) {
+        if (this->data_[index].hash == key_hash &&
+            this->data_[index].first.size() == key.size()) {
           auto iterator{this->cbegin()};
           std::advance(iterator, index);
           return iterator;
@@ -243,8 +242,8 @@ public:
       }
     } else {
       for (size_type index = 0; index < this->size(); index++) {
-        if (this->data[index].hash == key_hash &&
-            this->data[index].first == key) {
+        if (this->data_[index].hash == key_hash &&
+            this->data_[index].first == key) {
           auto iterator{this->cbegin()};
           std::advance(iterator, index);
           return iterator;
@@ -256,12 +255,12 @@ public:
   }
 
   /// Check if an entry with the given key exists
-  [[nodiscard]] inline auto defines(const Key &key, const hash_type hash) const
+  [[nodiscard]] auto defines(const Key &key, const hash_type hash) const
       -> bool {
     assert(this->hash(key) == hash);
 
     // Move the perfect hash condition out of the loop for extra performance
-    if (this->hasher.is_perfect(hash)) {
+    if (this->HASHER.is_perfect(hash)) {
       for (const auto &entry : *this) {
         if (entry.hash == hash && entry.first.size() == key.size()) {
           return true;
@@ -281,11 +280,11 @@ public:
   /// Check if an entry with the given key exists
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, KeyView>
-  [[nodiscard]] inline auto defines(T key, const hash_type hash) const -> bool {
+  [[nodiscard]] auto defines(T key, const hash_type hash) const -> bool {
     assert(this->hash(key) == hash);
 
     // Move the perfect hash condition out of the loop for extra performance
-    if (this->hasher.is_perfect(hash)) {
+    if (this->HASHER.is_perfect(hash)) {
       for (const auto &entry : *this) {
         if (entry.hash == hash && entry.first.size() == key.size()) {
           return true;
@@ -303,30 +302,28 @@ public:
   }
 
   /// Check the size of the object
-  [[nodiscard]] inline auto size() const -> std::size_t {
-    return this->data.size();
-  }
+  [[nodiscard]] auto size() const -> std::size_t { return this->data_.size(); }
 
   /// Check if the object is empty
-  [[nodiscard]] inline auto empty() const -> bool { return this->data.empty(); }
+  [[nodiscard]] auto empty() const -> bool { return this->data_.empty(); }
 
   /// Reserve capacity for a given number of entries
-  inline auto reserve(const size_type capacity) -> void {
-    this->data.reserve(capacity);
+  auto reserve(const size_type capacity) -> void {
+    this->data_.reserve(capacity);
   }
 
   /// Access an object entry by its underlying positional index
-  [[nodiscard]] inline auto at(const size_type index) const -> const Entry & {
-    return this->data.at(index);
+  [[nodiscard]] auto at(const size_type index) const -> const Entry & {
+    return this->data_.at(index);
   }
 
   /// Access an object entry by its key name
-  [[nodiscard]] inline auto at(const Key &key, const hash_type key_hash) const
+  [[nodiscard]] auto at(const Key &key, const hash_type key_hash) const
       -> const mapped_type & {
     assert(this->hash(key) == key_hash);
 
     // Move the perfect hash condition out of the loop for extra performance
-    if (this->hasher.is_perfect(key_hash)) {
+    if (this->HASHER.is_perfect(key_hash)) {
       for (const auto &entry : *this) {
         if (entry.hash == key_hash && entry.first.size() == key.size()) {
           return entry.second;
@@ -346,12 +343,12 @@ public:
   /// Access an object entry by its key name
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, KeyView>
-  [[nodiscard]] inline auto at(T key, const hash_type key_hash) const
+  [[nodiscard]] auto at(T key, const hash_type key_hash) const
       -> const mapped_type & {
     assert(this->hash(key) == key_hash);
 
     // Move the perfect hash condition out of the loop for extra performance
-    if (this->hasher.is_perfect(key_hash)) {
+    if (this->HASHER.is_perfect(key_hash)) {
       for (const auto &entry : *this) {
         if (entry.hash == key_hash && entry.first.size() == key.size()) {
           return entry.second;
@@ -369,18 +366,18 @@ public:
   }
 
   /// Access an object entry by its key name
-  inline auto at(const Key &key, const hash_type key_hash) -> mapped_type & {
+  auto at(const Key &key, const hash_type key_hash) -> mapped_type & {
     assert(this->hash(key) == key_hash);
 
     // Move the perfect hash condition out of the loop for extra performance
-    if (this->hasher.is_perfect(key_hash)) {
-      for (auto &entry : this->data) {
+    if (this->HASHER.is_perfect(key_hash)) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first.size() == key.size()) {
           return entry.second;
         }
       }
     } else {
-      for (auto &entry : this->data) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first == key) {
           return entry.second;
         }
@@ -393,18 +390,18 @@ public:
   /// Access an object entry by its key name
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, KeyView>
-  inline auto at(T key, const hash_type key_hash) -> mapped_type & {
+  auto at(T key, const hash_type key_hash) -> mapped_type & {
     assert(this->hash(key) == key_hash);
 
     // Move the perfect hash condition out of the loop for extra performance
-    if (this->hasher.is_perfect(key_hash)) {
-      for (auto &entry : this->data) {
+    if (this->HASHER.is_perfect(key_hash)) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first.size() == key.size()) {
           return entry.second;
         }
       }
     } else {
-      for (auto &entry : this->data) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first == key) {
           return entry.second;
         }
@@ -415,19 +412,19 @@ public:
   }
 
   /// Try to access an object entry by its key name
-  [[nodiscard]] inline auto try_at(const Key &key, const hash_type key_hash)
+  [[nodiscard]] auto try_at(const Key &key, const hash_type key_hash)
       -> mapped_type * {
     assert(this->hash(key) == key_hash);
 
     // Move the perfect hash condition out of the loop for extra performance
-    if (this->hasher.is_perfect(key_hash)) {
-      for (auto &entry : this->data) {
+    if (this->HASHER.is_perfect(key_hash)) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first.size() == key.size()) {
           return &entry.second;
         }
       }
     } else {
-      for (auto &entry : this->data) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first == key) {
           return &entry.second;
         }
@@ -440,19 +437,18 @@ public:
   /// Try to access an object entry by its key name
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, KeyView>
-  [[nodiscard]] inline auto try_at(T key, const hash_type key_hash)
-      -> mapped_type * {
+  [[nodiscard]] auto try_at(T key, const hash_type key_hash) -> mapped_type * {
     assert(this->hash(key) == key_hash);
 
     // Move the perfect hash condition out of the loop for extra performance
-    if (this->hasher.is_perfect(key_hash)) {
-      for (auto &entry : this->data) {
+    if (this->HASHER.is_perfect(key_hash)) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first.size() == key.size()) {
           return &entry.second;
         }
       }
     } else {
-      for (auto &entry : this->data) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first == key) {
           return &entry.second;
         }
@@ -463,24 +459,23 @@ public:
   }
 
   /// Try to access an object entry by its underlying positional index
-  [[nodiscard]] inline auto try_at(const Key &key,
-                                   const hash_type key_hash) const
+  [[nodiscard]] auto try_at(const Key &key, const hash_type key_hash) const
       -> const mapped_type * {
     assert(this->hash(key) == key_hash);
 
     // Move the perfect hash condition out of the loop for extra performance
-    if (this->hasher.is_perfect(key_hash)) {
+    if (this->HASHER.is_perfect(key_hash)) {
       for (size_type index = 0; index < this->size(); index++) {
-        if (this->data[index].hash == key_hash &&
-            this->data[index].first.size() == key.size()) {
-          return &this->data[index].second;
+        if (this->data_[index].hash == key_hash &&
+            this->data_[index].first.size() == key.size()) {
+          return &this->data_[index].second;
         }
       }
     } else {
       for (size_type index = 0; index < this->size(); index++) {
-        if (this->data[index].hash == key_hash &&
-            this->data[index].first == key) {
-          return &this->data[index].second;
+        if (this->data_[index].hash == key_hash &&
+            this->data_[index].first == key) {
+          return &this->data_[index].second;
         }
       }
     }
@@ -491,23 +486,23 @@ public:
   /// Try to access an object entry by its underlying positional index
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, KeyView>
-  [[nodiscard]] inline auto try_at(T key, const hash_type key_hash) const
+  [[nodiscard]] auto try_at(T key, const hash_type key_hash) const
       -> const mapped_type * {
     assert(this->hash(key) == key_hash);
 
     // Move the perfect hash condition out of the loop for extra performance
-    if (this->hasher.is_perfect(key_hash)) {
+    if (this->HASHER.is_perfect(key_hash)) {
       for (size_type index = 0; index < this->size(); index++) {
-        if (this->data[index].hash == key_hash &&
-            this->data[index].first.size() == key.size()) {
-          return &this->data[index].second;
+        if (this->data_[index].hash == key_hash &&
+            this->data_[index].first.size() == key.size()) {
+          return &this->data_[index].second;
         }
       }
     } else {
       for (size_type index = 0; index < this->size(); index++) {
-        if (this->data[index].hash == key_hash &&
-            this->data[index].first == key) {
-          return &this->data[index].second;
+        if (this->data_[index].hash == key_hash &&
+            this->data_[index].first == key) {
+          return &this->data_[index].second;
         }
       }
     }
@@ -517,28 +512,27 @@ public:
 
   /// Try to access an object entry, scanning from a caller-provided start
   /// offset. On hit, advances `start` past the found index
-  [[nodiscard]] inline auto try_at(const Key &key, const hash_type key_hash,
-                                   size_type &start) const
-      -> const mapped_type * {
+  [[nodiscard]] auto try_at(const Key &key, const hash_type key_hash,
+                            size_type &start) const -> const mapped_type * {
     assert(this->hash(key) == key_hash);
     const auto object_size{this->size()};
     assert(start <= object_size);
-    if (this->hasher.is_perfect(key_hash)) {
+    if (this->HASHER.is_perfect(key_hash)) {
       for (size_type count = 0; count < object_size; count++) {
         const auto index{(start + count) % object_size};
-        if (this->data[index].hash == key_hash &&
-            this->data[index].first.size() == key.size()) {
+        if (this->data_[index].hash == key_hash &&
+            this->data_[index].first.size() == key.size()) {
           start = index + 1;
-          return &this->data[index].second;
+          return &this->data_[index].second;
         }
       }
     } else {
       for (size_type count = 0; count < object_size; count++) {
         const auto index{(start + count) % object_size};
-        if (this->data[index].hash == key_hash &&
-            this->data[index].first == key) {
+        if (this->data_[index].hash == key_hash &&
+            this->data_[index].first == key) {
           start = index + 1;
-          return &this->data[index].second;
+          return &this->data_[index].second;
         }
       }
     }
@@ -550,28 +544,27 @@ public:
   /// offset. On hit, advances `start` past the found index
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, KeyView>
-  [[nodiscard]] inline auto try_at(T key, const hash_type key_hash,
-                                   size_type &start) const
-      -> const mapped_type * {
+  [[nodiscard]] auto try_at(T key, const hash_type key_hash,
+                            size_type &start) const -> const mapped_type * {
     assert(this->hash(key) == key_hash);
     const auto object_size{this->size()};
     assert(start <= object_size);
-    if (this->hasher.is_perfect(key_hash)) {
+    if (this->HASHER.is_perfect(key_hash)) {
       for (size_type count = 0; count < object_size; count++) {
         const auto index{(start + count) % object_size};
-        if (this->data[index].hash == key_hash &&
-            this->data[index].first.size() == key.size()) {
+        if (this->data_[index].hash == key_hash &&
+            this->data_[index].first.size() == key.size()) {
           start = index + 1;
-          return &this->data[index].second;
+          return &this->data_[index].second;
         }
       }
     } else {
       for (size_type count = 0; count < object_size; count++) {
         const auto index{(start + count) % object_size};
-        if (this->data[index].hash == key_hash &&
-            this->data[index].first == key) {
+        if (this->data_[index].hash == key_hash &&
+            this->data_[index].first == key) {
           start = index + 1;
-          return &this->data[index].second;
+          return &this->data_[index].second;
         }
       }
     }
@@ -585,48 +578,50 @@ public:
     const auto key_hash{this->hash(key)};
     const auto suffix_hash{this->hash(suffix)};
 
-    if (this->hasher.is_perfect(key_hash)) {
-      for (auto iterator = this->data.begin(); iterator != this->data.end();
+    if (this->HASHER.is_perfect(key_hash)) {
+      for (auto iterator = this->data_.begin(); iterator != this->data_.end();
            ++iterator) {
         if (iterator->hash == key_hash &&
             iterator->first.size() == key.size()) {
           iterator->second = value;
           return key_hash;
-        } else if (iterator->hash == suffix_hash && iterator->first == suffix) {
-          this->data.insert(iterator, {key, value, key_hash});
+        }
+        if (iterator->hash == suffix_hash && iterator->first == suffix) {
+          this->data_.insert(iterator, {key, value, key_hash});
           return key_hash;
         }
       }
     } else {
-      for (auto iterator = this->data.begin(); iterator != this->data.end();
+      for (auto iterator = this->data_.begin(); iterator != this->data_.end();
            ++iterator) {
         if (iterator->hash == key_hash && iterator->first == key) {
           iterator->second = value;
           return key_hash;
-        } else if (iterator->hash == suffix_hash && iterator->first == suffix) {
-          this->data.insert(iterator, {key, value, key_hash});
+        }
+        if (iterator->hash == suffix_hash && iterator->first == suffix) {
+          this->data_.insert(iterator, {key, value, key_hash});
           return key_hash;
         }
       }
     }
 
-    this->data.push_back({key, value, key_hash});
+    this->data_.push_back({key, value, key_hash});
     return key_hash;
   }
 
   /// Emplace an object property
-  inline auto emplace(Key &&key, mapped_type &&value) -> hash_type {
+  auto emplace(Key &&key, mapped_type &&value) -> hash_type {
     const auto key_hash{this->hash(key)};
 
-    if (this->hasher.is_perfect(key_hash)) {
-      for (auto &entry : this->data) {
+    if (this->HASHER.is_perfect(key_hash)) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first.size() == key.size()) {
           entry.second = std::move(value);
           return key_hash;
         }
       }
     } else {
-      for (auto &entry : this->data) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first == key) {
           entry.second = std::move(value);
           return key_hash;
@@ -634,23 +629,23 @@ public:
       }
     }
 
-    this->data.push_back({std::move(key), std::move(value), key_hash});
+    this->data_.push_back({std::move(key), std::move(value), key_hash});
     return key_hash;
   }
 
   /// Emplace an object property
-  inline auto emplace(const Key &key, mapped_type &&value) -> hash_type {
+  auto emplace(const Key &key, mapped_type &&value) -> hash_type {
     const auto key_hash{this->hash(key)};
 
-    if (this->hasher.is_perfect(key_hash)) {
-      for (auto &entry : this->data) {
+    if (this->HASHER.is_perfect(key_hash)) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first.size() == key.size()) {
           entry.second = std::move(value);
           return key_hash;
         }
       }
     } else {
-      for (auto &entry : this->data) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first == key) {
           entry.second = std::move(value);
           return key_hash;
@@ -658,23 +653,23 @@ public:
       }
     }
 
-    this->data.push_back({key, std::move(value), key_hash});
+    this->data_.push_back({key, std::move(value), key_hash});
     return key_hash;
   }
 
   /// Emplace an object property
-  inline auto emplace(const Key &key, const mapped_type &value) -> hash_type {
+  auto emplace(const Key &key, const mapped_type &value) -> hash_type {
     const auto key_hash{this->hash(key)};
 
-    if (this->hasher.is_perfect(key_hash)) {
-      for (auto &entry : this->data) {
+    if (this->HASHER.is_perfect(key_hash)) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first.size() == key.size()) {
           entry.second = value;
           return key_hash;
         }
       }
     } else {
-      for (auto &entry : this->data) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first == key) {
           entry.second = value;
           return key_hash;
@@ -682,66 +677,65 @@ public:
       }
     }
 
-    this->data.push_back({key, value, key_hash});
+    this->data_.push_back({key, value, key_hash});
     return key_hash;
   }
 
   /// Emplace an object property assuming the key does not already exist
-  inline auto emplace_assume_new(Key &&key, mapped_type &&value) -> hash_type {
+  auto emplace_assume_new(Key &&key, mapped_type &&value) -> hash_type {
     const auto key_hash{this->hash(key)};
-    this->data.push_back({std::move(key), std::move(value), key_hash});
+    this->data_.push_back({std::move(key), std::move(value), key_hash});
     return key_hash;
   }
 
   /// Emplace an object property assuming the key does not already exist
-  inline auto emplace_assume_new(const Key &key, mapped_type &&value)
-      -> hash_type {
+  auto emplace_assume_new(const Key &key, mapped_type &&value) -> hash_type {
     const auto key_hash{this->hash(key)};
-    this->data.push_back({key, std::move(value), key_hash});
+    this->data_.push_back({key, std::move(value), key_hash});
     return key_hash;
   }
 
   /// Emplace an object property with a pre-computed hash, returning the
   /// inserted value
-  inline auto emplace_assume_new(Key &&key, mapped_type &&value,
-                                 const hash_type key_hash) -> mapped_type & {
-    this->data.push_back({std::move(key), std::move(value), key_hash});
-    return this->data.back().second;
+  auto emplace_assume_new(Key &&key, mapped_type &&value,
+                          const hash_type key_hash) -> mapped_type & {
+    this->data_.push_back({std::move(key), std::move(value), key_hash});
+    return this->data_.back().second;
   }
 
   /// Emplace an object property with a pre-computed hash
-  inline auto emplace_assume_new(const Key &key, mapped_type &&value,
-                                 const hash_type key_hash) -> void {
-    this->data.push_back({key, std::move(value), key_hash});
+  auto emplace_assume_new(const Key &key, mapped_type &&value,
+                          const hash_type key_hash) -> void {
+    this->data_.push_back({key, std::move(value), key_hash});
   }
 
   /// Get the key of the last-inserted property
-  [[nodiscard]] inline auto back_key() const noexcept -> const Key & {
-    assert(!this->data.empty());
-    return this->data.back().first;
+  [[nodiscard]] auto back_key() const noexcept -> const Key & {
+    assert(!this->data_.empty());
+    return this->data_.back().first;
   }
 
   /// Remove every property in the object
-  inline auto clear() noexcept -> void { this->data.clear(); }
+  auto clear() noexcept -> void { this->data_.clear(); }
 
   /// Rename an object property in place
-  auto rename(const Key &key, const hash_type key_hash, Key &&to,
-              const hash_type to_hash) -> void {
-    this->erase(to, to_hash);
+  auto rename(const Key &key, const hash_type key_hash, Key &&target,
+              const hash_type target_hash) -> void {
+    this->erase(target, target_hash);
 
-    if (this->hasher.is_perfect(key_hash)) {
-      for (auto &entry : this->data) {
+    if (this->HASHER.is_perfect(key_hash)) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first.size() == key.size()) {
-          entry.first = std::move(to);
-          entry.hash = to_hash;
+          entry.first = std::move(target);
+          entry.hash = target_hash;
           break;
         }
       }
     } else {
-      for (auto &entry : this->data) {
+      for (auto &entry : this->data_) {
         if (entry.hash == key_hash && entry.first == key) {
-          entry.first = std::move(to);
-          entry.hash = to_hash;
+          entry.first = std::move(target);
+          entry.hash = target_hash;
           break;
         }
       }
@@ -752,20 +746,20 @@ public:
   auto erase(const Key &key, const hash_type key_hash) -> size_type {
     const auto current_size{this->size()};
 
-    if (this->hasher.is_perfect(key_hash)) {
-      for (auto iterator = this->data.begin(); iterator != this->data.end();
+    if (this->HASHER.is_perfect(key_hash)) {
+      for (auto iterator = this->data_.begin(); iterator != this->data_.end();
            ++iterator) {
         if (iterator->hash == key_hash &&
             iterator->first.size() == key.size()) {
-          this->data.erase(iterator);
+          this->data_.erase(iterator);
           return current_size - 1;
         }
       }
     } else {
-      for (auto iterator = this->data.begin(); iterator != this->data.end();
+      for (auto iterator = this->data_.begin(); iterator != this->data_.end();
            ++iterator) {
         if (iterator->hash == key_hash && iterator->first == key) {
-          this->data.erase(iterator);
+          this->data_.erase(iterator);
           return current_size - 1;
         }
       }
@@ -780,20 +774,20 @@ public:
   auto erase(T key, const hash_type key_hash) -> size_type {
     const auto current_size{this->size()};
 
-    if (this->hasher.is_perfect(key_hash)) {
-      for (auto iterator = this->data.begin(); iterator != this->data.end();
+    if (this->HASHER.is_perfect(key_hash)) {
+      for (auto iterator = this->data_.begin(); iterator != this->data_.end();
            ++iterator) {
         if (iterator->hash == key_hash &&
             iterator->first.size() == key.size()) {
-          this->data.erase(iterator);
+          this->data_.erase(iterator);
           return current_size - 1;
         }
       }
     } else {
-      for (auto iterator = this->data.begin(); iterator != this->data.end();
+      for (auto iterator = this->data_.begin(); iterator != this->data_.end();
            ++iterator) {
         if (iterator->hash == key_hash && iterator->first == key) {
-          this->data.erase(iterator);
+          this->data_.erase(iterator);
           return current_size - 1;
         }
       }
@@ -803,20 +797,20 @@ public:
   }
 
   /// Erase an object property
-  inline auto erase(const Key &key) -> size_type {
+  auto erase(const Key &key) -> size_type {
     return this->erase(key, this->hash(key));
   }
 
   /// Erase an object property
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, KeyView>
-  inline auto erase(T key) -> size_type {
+  auto erase(T key) -> size_type {
     return this->erase(key, this->hash(key));
   }
 
   /// Reorder object properties by keys according to a comparator function
   template <typename Compare> auto reorder(const Compare &compare) -> void {
-    std::sort(this->data.begin(), this->data.end(),
+    std::sort(this->data_.begin(), this->data_.end(),
               [&compare](const auto &left, const auto &right) -> auto {
                 return compare(left.first, right.first);
               });
@@ -830,8 +824,8 @@ private:
 #if defined(_MSC_VER)
 #pragma warning(disable : 4251)
 #endif
-  static constexpr Hash hasher{};
-  underlying_type data;
+  static constexpr Hash HASHER{};
+  underlying_type data_;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251)
 #endif

--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -148,7 +148,7 @@ public:
   template <typename T = std::int64_t>
   explicit JSON(const long value)
     requires(!std::is_same_v<T, std::int64_t>)
-      : current_type{Type::Integer} {
+      : current_type_{Type::Integer} {
     this->data_integer = value;
   }
 
@@ -244,7 +244,7 @@ public:
   ///
   /// assert(my_object.is_object());
   /// ```
-  explicit JSON(std::initializer_list<typename Object::pair_value_type> values);
+  explicit JSON(std::initializer_list<Object::pair_value_type> values);
 
   /// A copy constructor for the object type.
   explicit JSON(const Object &value);
@@ -256,11 +256,11 @@ public:
   explicit JSON(Decimal &&value);
 
   /// Misc constructors
-  JSON(const JSON &);
+  JSON(const JSON &other);
   /// A move constructor.
-  JSON(JSON &&) noexcept;
-  auto operator=(const JSON &) -> JSON &;
-  auto operator=(JSON &&) noexcept -> JSON &;
+  JSON(JSON &&other) noexcept;
+  auto operator=(const JSON &other) -> JSON &;
+  auto operator=(JSON &&other) noexcept -> JSON &;
 
   /// Destructor
   ~JSON();
@@ -430,9 +430,9 @@ public:
   /// const sourcemeta::core::JSON document{true};
   /// assert(document.is_boolean());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_boolean() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_boolean() const noexcept
       -> bool {
-    return this->current_type == Type::Boolean;
+    return this->current_type_ == Type::Boolean;
   }
 
   /// Check if the input JSON document is null. For example:
@@ -444,9 +444,8 @@ public:
   /// const sourcemeta::core::JSON document{nullptr};
   /// assert(document.is_null());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_null() const noexcept
-      -> bool {
-    return this->current_type == Type::Null;
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_null() const noexcept -> bool {
+    return this->current_type_ == Type::Null;
   }
 
   /// Check if the input JSON document is an integer. For example:
@@ -458,9 +457,9 @@ public:
   /// const sourcemeta::core::JSON document{5};
   /// assert(document.is_integer());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_integer() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_integer() const noexcept
       -> bool {
-    return this->current_type == Type::Integer;
+    return this->current_type_ == Type::Integer;
   }
 
   /// Check if the input JSON document is a real type. For example:
@@ -472,9 +471,8 @@ public:
   /// const sourcemeta::core::JSON document{3.14};
   /// assert(document.is_real());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_real() const noexcept
-      -> bool {
-    return this->current_type == Type::Real;
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_real() const noexcept -> bool {
+    return this->current_type_ == Type::Real;
   }
 
   /// Check if the input JSON document is an integer, a real number that
@@ -487,7 +485,7 @@ public:
   /// const sourcemeta::core::JSON document{5.0};
   /// assert(document.is_integral());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_integral() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_integral() const noexcept
       -> bool {
     switch (this->type()) {
       case Type::Integer:
@@ -515,8 +513,7 @@ public:
   /// assert(real.is_number());
   /// assert(integer.is_number());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_number() const noexcept
-      -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_number() const noexcept -> bool {
     return this->is_integer() || this->is_real() || this->is_decimal();
   }
 
@@ -543,9 +540,8 @@ public:
   /// const sourcemeta::core::JSON document{"foo"};
   /// assert(document.is_string());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_string() const noexcept
-      -> bool {
-    return this->current_type == Type::String;
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_string() const noexcept -> bool {
+    return this->current_type_ == Type::String;
   }
 
   /// Check if the input JSON document is an array. For example:
@@ -558,9 +554,8 @@ public:
   /// document=sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   /// assert(document.is_array());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_array() const noexcept
-      -> bool {
-    return this->current_type == Type::Array;
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_array() const noexcept -> bool {
+    return this->current_type_ == Type::Array;
   }
 
   /// Check if the input JSON document is an object. For example:
@@ -573,9 +568,8 @@ public:
   /// document=sourcemeta::core::parse_json("{ \"foo\": 1 }");
   /// assert(document.is_object());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_object() const noexcept
-      -> bool {
-    return this->current_type == Type::Object;
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_object() const noexcept -> bool {
+    return this->current_type_ == Type::Object;
   }
 
   /// Check if the input JSON document is an arbitrary precision decimal value.
@@ -589,9 +583,9 @@ public:
   /// const sourcemeta::core::JSON document{value};
   /// assert(document.is_decimal());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_decimal() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_decimal() const noexcept
       -> bool {
-    return this->current_type == Type::Decimal;
+    return this->current_type_ == Type::Decimal;
   }
 
   /// Get the type of the JSON document. For example:
@@ -603,9 +597,8 @@ public:
   /// const sourcemeta::core::JSON document{true};
   /// assert(document.type() == sourcemeta::core::JSON::Type::Boolean);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto type() const noexcept
-      -> Type {
-    return this->current_type;
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto type() const noexcept -> Type {
+    return this->current_type_;
   }
 
   /*
@@ -623,7 +616,7 @@ public:
   /// assert(document.is_boolean());
   /// assert(document.to_boolean());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto to_boolean() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto to_boolean() const noexcept
       -> bool {
     assert(this->is_boolean());
     return this->data_boolean;
@@ -641,7 +634,7 @@ public:
   /// assert(document.is_integer());
   /// assert(document.to_integer() == 5);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto to_integer() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto to_integer() const noexcept
       -> Integer {
     assert(this->is_integer());
     return this->data_integer;
@@ -659,8 +652,7 @@ public:
   /// assert(document.is_real());
   /// assert(document.to_real() == 3.14);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto to_real() const noexcept
-      -> Real {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto to_real() const noexcept -> Real {
     assert(this->is_real());
     assert(!std::isinf(this->data_real));
     assert(!std::isnan(this->data_real));
@@ -679,7 +671,7 @@ public:
   /// assert(document.is_decimal());
   /// assert(document.to_decimal().to_int64() == 1234567890);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto to_decimal() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto to_decimal() const noexcept
       -> const Decimal & {
     assert(this->is_decimal());
     assert(this->data_decimal.is_finite());
@@ -699,7 +691,7 @@ public:
   /// assert(document.is_string());
   /// assert(document.to_string() == "foo");
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto to_string() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto to_string() const noexcept
       -> const String & {
     assert(this->is_string());
     return this->data_string;
@@ -742,7 +734,7 @@ public:
   // TODO: Merge const/non-const overloads of as_array, as_object, at, front,
   // back using deducing this once Apple Clang supports it
   // (__cpp_explicit_this_parameter)
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto as_array() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto as_array() const noexcept
       -> const Array & {
     assert(this->is_array());
     return this->data_array;
@@ -760,8 +752,7 @@ public:
   ///   sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   /// std::sort(document.as_array().begin(), document.as_array().end());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto as_array() noexcept
-      -> Array & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto as_array() noexcept -> Array & {
     assert(this->is_array());
     return this->data_array;
   }
@@ -788,8 +779,7 @@ public:
   ///                           << "\n";
   ///               });
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto as_object() noexcept
-      -> Object & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto as_object() noexcept -> Object & {
     assert(this->is_object());
     return this->data_object;
   }
@@ -812,7 +802,7 @@ public:
   ///   value += sourcemeta::core::JSON{1};
   /// }
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto as_object() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto as_object() const noexcept
       -> const Object & {
     assert(this->is_object());
     return this->data_object;
@@ -830,15 +820,15 @@ public:
   /// const sourcemeta::core::JSON document{5};
   /// assert(document.as_real() == 5.0);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto as_real() const -> Real {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto as_real() const -> Real {
     assert(this->is_number());
     if (this->is_real()) {
       return this->to_real();
-    } else if (this->is_integer()) {
-      return static_cast<Real>(this->to_integer());
-    } else {
-      return this->to_decimal().to_double();
     }
+    if (this->is_integer()) {
+      return static_cast<Real>(this->to_integer());
+    }
+    return this->to_decimal().to_double();
   }
 
   /// Get the JSON numeric document as an integer number if it is not one
@@ -853,12 +843,12 @@ public:
   /// const sourcemeta::core::JSON document{5.3};
   /// assert(document.as_integer() == 5);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto as_integer() const
-      -> Integer {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto as_integer() const -> Integer {
     assert(this->is_number());
     if (this->is_integer()) {
       return this->to_integer();
-    } else if (this->is_real()) {
+    }
+    if (this->is_real()) {
       const auto truncated{std::trunc(this->to_real())};
       if (truncated < static_cast<Real>(std::numeric_limits<Integer>::min()) ||
           truncated >= static_cast<Real>(std::numeric_limits<Integer>::max())) {
@@ -867,15 +857,14 @@ public:
       }
 
       return static_cast<Integer>(truncated);
-    } else {
-      const auto integral{this->to_decimal().to_integral()};
-      if (!integral.is_int64()) {
-        throw std::out_of_range{
-            "The decimal number does not fit in a 64-bit integer"};
-      }
-
-      return integral.to_int64();
     }
+    const auto integral{this->to_decimal().to_integral()};
+    if (!integral.is_int64()) {
+      throw std::out_of_range{
+          "The decimal number does not fit in a 64-bit integer"};
+    }
+
+    return integral.to_int64();
   }
 
   /*
@@ -900,11 +889,11 @@ public:
   ///   sourcemeta::core::parse_json("{ \"1\": "foo" }");
   /// assert(my_array.at(1).to_string() == "foo");
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  at(const typename Array::size_type index) const -> const JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto
+  at(const Array::size_type index) const -> const JSON & {
     assert(this->is_array());
     assert(index < this->size());
-    return this->data_array.data.at(index);
+    return this->data_array.data_.at(index);
   }
 
   /// This method retrieves a element by its index. If the input JSON instance
@@ -925,11 +914,11 @@ public:
   ///   sourcemeta::core::parse_json("{ \"1\": "foo" }");
   /// assert(my_array.at(1).to_string() == "foo");
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  at(const typename Array::size_type index) -> JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto at(const Array::size_type index)
+      -> JSON & {
     assert(this->is_array());
     assert(index < this->size());
-    return this->data_array.data.at(index);
+    return this->data_array.data_.at(index);
   }
 
   /// This method retrieves an object element.
@@ -944,7 +933,7 @@ public:
   ///   sourcemeta::core::parse_json("{ \"foo\": 1, \"bar\": 2 }");
   /// assert(my_object.at("bar").to_integer() == 2);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto at(const String &key) const
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto at(const String &key) const
       -> const JSON & {
     assert(this->is_object());
     assert(this->defines(key));
@@ -955,8 +944,7 @@ public:
   /// This method retrieves an object element by string view key
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, StringView>
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto at(T key) const
-      -> const JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto at(T key) const -> const JSON & {
     assert(this->is_object());
     assert(this->defines(key));
     const auto &object{this->data_object};
@@ -977,9 +965,8 @@ public:
   /// assert(my_object.at("bar",
   ///  my_object.as_object().hash("bar")).to_integer() == 2);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  at(const String &key, const typename Object::hash_type hash) const
-      -> const JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto
+  at(const String &key, const Object::hash_type hash) const -> const JSON & {
     assert(this->is_object());
     assert(this->defines(key));
     return this->data_object.at(key, hash);
@@ -989,8 +976,8 @@ public:
   /// pre-calculated property hash
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, StringView>
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  at(T key, const typename Object::hash_type hash) const -> const JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto
+  at(T key, const Object::hash_type hash) const -> const JSON & {
     assert(this->is_object());
     assert(this->defines(key));
     return this->data_object.at(key, hash);
@@ -1008,8 +995,7 @@ public:
   ///   sourcemeta::core::parse_json("{ \"foo\": 1, \"bar\": 2 }");
   /// assert(my_object.at("bar").to_integer() == 2);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto at(const String &key)
-      -> JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto at(const String &key) -> JSON & {
     assert(this->is_object());
     assert(this->defines(key));
     auto &object{this->data_object};
@@ -1019,7 +1005,7 @@ public:
   /// This method retrieves an object element by string view key
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, StringView>
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto at(T key) -> JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto at(T key) -> JSON & {
     assert(this->is_object());
     assert(this->defines(key));
     auto &object{this->data_object};
@@ -1040,8 +1026,9 @@ public:
   /// assert(my_object.at("bar",
   ///   my_object.as_object().hash("bar")).to_integer() == 2);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  at(const String &key, const typename Object::hash_type hash) -> JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto at(const String &key,
+                                               const Object::hash_type hash)
+      -> JSON & {
     assert(this->is_object());
     assert(this->defines(key));
     return this->data_object.at(key, hash);
@@ -1051,8 +1038,9 @@ public:
   /// pre-calculated property hash
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, StringView>
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  at(T key, const typename Object::hash_type hash) -> JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto at(T key,
+                                               const Object::hash_type hash)
+      -> JSON & {
     assert(this->is_object());
     assert(this->defines(key));
     return this->data_object.at(key, hash);
@@ -1096,14 +1084,12 @@ public:
   ///   my_object.as_object().hash("foo"),
   ///   default_value).to_integer() == 1);
   /// ```
-  [[nodiscard]] auto at_or(const String &key,
-                           const typename Object::hash_type hash,
+  [[nodiscard]] auto at_or(const String &key, const Object::hash_type hash,
                            const JSON &otherwise) const -> const JSON &;
 
   /// This overload avoids misuses of returning a const reference parameter as a
   /// constant reference.
-  [[nodiscard]] auto at_or(const String &key,
-                           const typename Object::hash_type hash,
+  [[nodiscard]] auto at_or(const String &key, const Object::hash_type hash,
                            JSON &&otherwise) const -> const JSON & = delete;
 
   /// This method retrieves a reference to the first element of a JSON array.
@@ -1118,10 +1104,10 @@ public:
   ///   sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   /// assert(document.front().to_integer() == 1);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto front() -> JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto front() -> JSON & {
     assert(this->is_array());
     assert(!this->empty());
-    return this->data_array.data.front();
+    return this->data_array.data_.front();
   }
 
   /// This method retrieves a reference to the first element of a JSON array.
@@ -1136,11 +1122,10 @@ public:
   ///   sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   /// assert(document.front().to_integer() == 1);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto front() const
-      -> const JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto front() const -> const JSON & {
     assert(this->is_array());
     assert(!this->empty());
-    return this->data_array.data.front();
+    return this->data_array.data_.front();
   }
 
   /// This method retrieves a reference to the last element of a JSON array.
@@ -1155,10 +1140,10 @@ public:
   ///   sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   /// assert(document.back().to_integer() == 3);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto back() -> JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto back() -> JSON & {
     assert(this->is_array());
     assert(!this->empty());
-    return this->data_array.data.back();
+    return this->data_array.data_.back();
   }
 
   /// This method retrieves a reference to the last element of a JSON array.
@@ -1173,11 +1158,10 @@ public:
   ///   sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   /// assert(document.back().to_integer() == 3);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto back() const
-      -> const JSON & {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto back() const -> const JSON & {
     assert(this->is_array());
     assert(!this->empty());
-    return this->data_array.data.back();
+    return this->data_array.data_.back();
   }
 
   /*
@@ -1204,14 +1188,14 @@ public:
   /// assert(my_array.size() == 2);
   /// assert(my_string.size() == 3);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto size() const -> std::size_t {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto size() const -> std::size_t {
     if (this->is_object()) {
       return this->object_size();
-    } else if (this->is_array()) {
-      return this->array_size();
-    } else {
-      return this->string_size();
     }
+    if (this->is_array()) {
+      return this->array_size();
+    }
+    return this->string_size();
   }
 
   /// If the input JSON instance is a string, return its logical length.
@@ -1225,8 +1209,7 @@ public:
   /// const sourcemeta::core::JSON my_string{"foo"};
   /// assert(my_string.string_size() == 3);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto string_size() const
-      -> std::size_t {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto string_size() const -> std::size_t {
     assert(this->is_string());
     return JSON::size(this->data_string);
   }
@@ -1243,10 +1226,9 @@ public:
   ///   sourcemeta::core::parse_json("[ 1, 2 ]");
   /// assert(my_array.array_size() == 2);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto array_size() const
-      -> std::size_t {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto array_size() const -> std::size_t {
     assert(this->is_array());
-    return this->data_array.data.size();
+    return this->data_array.data_.size();
   }
 
   /// If the input JSON instance is an object, return its number of pairs.
@@ -1261,8 +1243,7 @@ public:
   ///   sourcemeta::core::parse_json("{ \"foo\": 1 }");
   /// assert(my_object.object_size() == 1);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto object_size() const
-      -> std::size_t {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto object_size() const -> std::size_t {
     assert(this->is_object());
     return this->data_object.size();
   }
@@ -1279,8 +1260,7 @@ public:
   /// assert(my_string.size() == 1);
   /// assert(my_string.byte_size() == 4);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto byte_size() const
-      -> std::size_t {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto byte_size() const -> std::size_t {
     assert(this->is_string());
     return this->data_string.size();
   }
@@ -1351,14 +1331,14 @@ public:
   /// assert(my_array.empty());
   /// assert(my_string.empty());
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto empty() const -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto empty() const -> bool {
     if (this->is_object()) {
       return this->data_object.empty();
-    } else if (this->is_array()) {
-      return this->data_array.data.empty();
-    } else {
-      return this->data_string.empty();
     }
+    if (this->is_array()) {
+      return this->data_array.data_.empty();
+    }
+    return this->data_string.empty();
   }
 
   /// This method checks whether an input JSON object defines a specific key
@@ -1375,8 +1355,8 @@ public:
   /// EXPECT_TRUE(result);
   /// EXPECT_EQ(result->to_integer(), 1);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  try_at(const String &key) const -> const JSON * {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto try_at(const String &key) const
+      -> const JSON * {
     assert(this->is_object());
     const auto &object{this->data_object};
     return object.try_at(key, object.hash(key));
@@ -1385,7 +1365,7 @@ public:
   /// This method tries to retrieve an object element by string view key
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, StringView>
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto try_at(T key) const
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto try_at(T key) const
       -> const JSON * {
     assert(this->is_object());
     const auto &object{this->data_object};
@@ -1408,8 +1388,8 @@ public:
   /// EXPECT_TRUE(result);
   /// EXPECT_EQ(result->to_integer(), 1);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  try_at(const String &key, const typename Object::hash_type hash) const
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto
+  try_at(const String &key, const Object::hash_type hash) const
       -> const JSON * {
     assert(this->is_object());
     const auto &object{this->data_object};
@@ -1420,8 +1400,8 @@ public:
   /// pre-calculated property hash
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, StringView>
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  try_at(T key, const typename Object::hash_type hash) const -> const JSON * {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto
+  try_at(T key, const Object::hash_type hash) const -> const JSON * {
     assert(this->is_object());
     const auto &object{this->data_object};
     return object.try_at(key, hash);
@@ -1441,7 +1421,7 @@ public:
   /// result->into(sourcemeta::core::JSON{2});
   /// assert(document.at("foo").to_integer() == 2);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto try_at(const String &key)
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto try_at(const String &key)
       -> JSON * {
     assert(this->is_object());
     auto &object{this->data_object};
@@ -1451,7 +1431,7 @@ public:
   /// This method tries to retrieve a mutable object element by string view key
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, StringView>
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto try_at(T key) -> JSON * {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto try_at(T key) -> JSON * {
     assert(this->is_object());
     auto &object{this->data_object};
     return object.try_at(key, object.hash(key));
@@ -1472,8 +1452,9 @@ public:
   /// result->into(sourcemeta::core::JSON{2});
   /// assert(document.at("foo").to_integer() == 2);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  try_at(const String &key, const typename Object::hash_type hash) -> JSON * {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto try_at(const String &key,
+                                                   const Object::hash_type hash)
+      -> JSON * {
     assert(this->is_object());
     return this->data_object.try_at(key, hash);
   }
@@ -1482,8 +1463,9 @@ public:
   /// given a pre-calculated property hash
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, StringView>
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  try_at(T key, const typename Object::hash_type hash) -> JSON * {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto try_at(T key,
+                                                   const Object::hash_type hash)
+      -> JSON * {
     assert(this->is_object());
     return this->data_object.try_at(key, hash);
   }
@@ -1512,9 +1494,9 @@ public:
   /// assert(bar);
   /// assert(bar->to_integer() == 2);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  try_at(const String &key, const typename Object::hash_type hash,
-         typename Object::size_type &start) const -> const JSON * {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto
+  try_at(const String &key, const Object::hash_type hash,
+         Object::size_type &start) const -> const JSON * {
     assert(this->is_object());
     const auto &object{this->data_object};
     return object.try_at(key, hash, start);
@@ -1524,9 +1506,9 @@ public:
   /// scanning from a caller-provided start offset
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, StringView>
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  try_at(T key, const typename Object::hash_type hash,
-         typename Object::size_type &start) const -> const JSON * {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto
+  try_at(T key, const Object::hash_type hash, Object::size_type &start) const
+      -> const JSON * {
     assert(this->is_object());
     const auto &object{this->data_object};
     return object.try_at(key, hash, start);
@@ -1544,8 +1526,8 @@ public:
   /// assert(document.defines("foo"));
   /// assert(!document.defines("bar"));
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  defines(const String &key) const -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto defines(const String &key) const
+      -> bool {
     assert(this->is_object());
     const auto &object{this->data_object};
     return object.defines(key, object.hash(key));
@@ -1555,8 +1537,7 @@ public:
   /// string view key
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, StringView>
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto defines(T key) const
-      -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto defines(T key) const -> bool {
     assert(this->is_object());
     const auto &object{this->data_object};
     return object.defines(key, object.hash(key));
@@ -1576,9 +1557,8 @@ public:
   /// assert(document.defines("bar",
   ///   document.as_object().hash("bar")));
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  defines(const String &key, const typename Object::hash_type hash) const
-      -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto
+  defines(const String &key, const Object::hash_type hash) const -> bool {
     assert(this->is_object());
     return this->data_object.defines(key, hash);
   }
@@ -1587,8 +1567,8 @@ public:
   /// string view key given a pre-calculated property hash
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, StringView>
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  defines(T key, const typename Object::hash_type hash) const -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto
+  defines(T key, const Object::hash_type hash) const -> bool {
     assert(this->is_object());
     return this->data_object.defines(key, hash);
   }
@@ -1605,8 +1585,8 @@ public:
   /// assert(document.defines(0));
   /// assert(!document.defines(1));
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  defines(const typename Array::size_type index) const -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto
+  defines(const Array::size_type index) const -> bool {
     return this->defines(std::to_string(index));
   }
 
@@ -1689,9 +1669,8 @@ public:
   /// assert(document.array_member_contains("tags",
   ///   document.as_object().hash("tags"), "b"));
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
-  array_member_contains(const StringView key,
-                        const typename Object::hash_type hash,
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto
+  array_member_contains(const StringView key, const Object::hash_type hash,
                         const StringView value) const -> bool {
     assert(this->is_object());
     const auto *member{this->try_at(key, hash)};
@@ -1709,7 +1688,7 @@ public:
   ///   sourcemeta::core::parse_json(R"JSON({ "tags": [ "a", "b" ] })JSON");
   /// assert(document.array_member_contains("tags", "b"));
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto
   array_member_contains(const StringView key, const StringView value) const
       -> bool {
     return this->array_member_contains(key, Object::hash(key), value);
@@ -2045,10 +2024,10 @@ public:
   ///                             "bar");
   /// assert(document.at("foo").to_string() == "bar");
   /// ```
-  SOURCEMETA_FORCEINLINE inline auto
-  assign_if_nonempty(const StringView key,
-                     const typename Object::hash_type hash,
-                     const StringView value) -> void {
+  SOURCEMETA_FORCEINLINE auto assign_if_nonempty(const StringView key,
+                                                 const Object::hash_type hash,
+                                                 const StringView value)
+      -> void {
     if (!value.empty()) {
       this->assign_assume_new(String{key}, JSON{value}, hash);
     }
@@ -2066,8 +2045,8 @@ public:
   /// document.assign_if_nonempty("foo", "bar");
   /// assert(document.at("foo").to_string() == "bar");
   /// ```
-  SOURCEMETA_FORCEINLINE inline auto assign_if_nonempty(const StringView key,
-                                                        const StringView value)
+  SOURCEMETA_FORCEINLINE auto assign_if_nonempty(const StringView key,
+                                                 const StringView value)
       -> void {
     this->assign_if_nonempty(key, Object::hash(key), value);
   }
@@ -2087,8 +2066,7 @@ public:
   ///                             values);
   /// assert(document.at("foo").size() == 2);
   /// ```
-  auto assign_if_nonempty(const StringView key,
-                          const typename Object::hash_type hash,
+  auto assign_if_nonempty(const StringView key, const Object::hash_type hash,
                           const std::span<const StringView> values) -> void {
     if (values.empty()) {
       return;
@@ -2132,12 +2110,12 @@ public:
   /// document.erase("foo");
   /// assert(!document.defines("foo"));
   /// ```
-  auto erase(const String &key) -> typename Object::size_type;
+  auto erase(const String &key) -> Object::size_type;
 
   /// This method deletes an object key by string view.
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, StringView>
-  auto erase(T key) -> typename Object::size_type {
+  auto erase(T key) -> Object::size_type {
     assert(this->is_object());
     return this->data_object.erase(key);
   }
@@ -2205,8 +2183,7 @@ public:
   /// assert(array.at(0), 1);
   /// assert(array.at(1), 3);
   /// ```
-  auto erase(typename Array::const_iterator position) ->
-      typename Array::iterator;
+  auto erase(Array::const_iterator position) -> Array::iterator;
 
   /// This method deletes a set of array elements using iterators. For example:
   ///
@@ -2221,8 +2198,8 @@ public:
   /// assert(array.size(), 1);
   /// assert(array.at(0), 1);
   /// ```
-  auto erase(typename Array::const_iterator first,
-             typename Array::const_iterator last) -> typename Array::iterator;
+  auto erase(Array::const_iterator first, Array::const_iterator last)
+      -> Array::iterator;
 
   /// This method deletes a set of array elements given a predicate. For
   /// example:
@@ -2432,7 +2409,7 @@ public:
   /// assert(document.at("bar").is_boolean());
   /// assert(document.at("bar").to_boolean());
   /// ```
-  auto rename(const JSON::String &key, JSON::String &&to) -> void;
+  auto rename(const JSON::String &key, JSON::String &&target) -> void;
 
   /// This method sets a value to another JSON value by copying it. For example,
   /// the member of a JSON document can be transformed from a boolean to an
@@ -2496,7 +2473,7 @@ public:
   auto into_object() -> void;
 
 private:
-  Type current_type = Type::Null;
+  Type current_type_ = Type::Null;
 
 // Exporting symbols that depends on the standard C++ library is considered
 // safe.

--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -21,18 +21,18 @@
 
 namespace sourcemeta::core {
 
-template <bool should_throw>
+template <bool ShouldThrow>
 static auto internal_parse_json(const char *&cursor, const char *end,
                                 std::uint64_t &line, std::uint64_t &column,
                                 const JSON::ParseCallback &callback,
                                 const bool track_positions, JSON &output)
-    -> std::conditional_t<should_throw, void, bool> {
+    -> std::conditional_t<ShouldThrow, void, bool> {
   const char *buffer_start{cursor};
   // Tape entries address the input with 32-bit offsets and lengths, so a larger
   // input cannot be represented without truncation
   if (std::cmp_greater(end - cursor,
                        std::numeric_limits<std::uint32_t>::max())) {
-    if constexpr (should_throw) {
+    if constexpr (ShouldThrow) {
       throw JSONParseError(line, column);
     } else {
       return false;
@@ -42,7 +42,7 @@ static auto internal_parse_json(const char *&cursor, const char *end,
   std::vector<TapeEntry> tape;
   tape.reserve(static_cast<std::size_t>(end - cursor) / 8);
 
-  if constexpr (should_throw) {
+  if constexpr (ShouldThrow) {
     if (callback || track_positions) {
       scan_json<true>(cursor, end, buffer_start, line, column, tape);
     } else {
@@ -92,10 +92,10 @@ static auto skip_trailing_whitespace(const char *cursor, const char *end)
     -> const char * {
   using namespace internal;
   while (cursor != end &&
-         (*cursor == token_whitespace_tabulation<JSON::Char> ||
-          *cursor == token_whitespace_line_feed<JSON::Char> ||
-          *cursor == token_whitespace_carriage_return<JSON::Char> ||
-          *cursor == token_whitespace_space<JSON::Char>)) {
+         (*cursor == TOKEN_WHITESPACE_TABULATION<JSON::Char> ||
+          *cursor == TOKEN_WHITESPACE_LINE_FEED<JSON::Char> ||
+          *cursor == TOKEN_WHITESPACE_CARRIAGE_RETURN<JSON::Char> ||
+          *cursor == TOKEN_WHITESPACE_SPACE<JSON::Char>)) {
     ++cursor;
   }
 
@@ -111,7 +111,7 @@ static auto position_of(const char *begin, const char *target,
   line = 1;
   column = 1;
   for (const char *iterator{begin}; iterator != target; ++iterator) {
-    if (*iterator == token_whitespace_line_feed<JSON::Char>) {
+    if (*iterator == TOKEN_WHITESPACE_LINE_FEED<JSON::Char>) {
       line += 1;
       column = 1;
     } else {

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -44,14 +44,14 @@ auto reverse_ordering(const std::strong_ordering ordering)
 auto integer_real_ordering(const std::int64_t left, const double right)
     -> std::strong_ordering {
   // Real values in a JSON document are always finite
-  constexpr double lowest{-9223372036854775808.0};
-  constexpr double past_highest{9223372036854775808.0};
+  constexpr double LOWEST{-9223372036854775808.0};
+  constexpr double PAST_HIGHEST{9223372036854775808.0};
   const double floor_of_right{std::floor(right)};
-  if (floor_of_right >= past_highest) {
+  if (floor_of_right >= PAST_HIGHEST) {
     return std::strong_ordering::less;
   }
 
-  if (floor_of_right < lowest) {
+  if (floor_of_right < LOWEST) {
     return std::strong_ordering::greater;
   }
 
@@ -112,19 +112,19 @@ auto cross_numeric_ordering(const JSON &left, const JSON &right)
 
 } // namespace
 
-JSON::JSON(const std::int64_t value) : current_type{Type::Integer} {
+JSON::JSON(const std::int64_t value) : current_type_{Type::Integer} {
   this->data_integer = value;
 }
 
-JSON::JSON(const std::size_t value) : current_type{Type::Integer} {
+JSON::JSON(const std::size_t value) : current_type_{Type::Integer} {
   this->data_integer = static_cast<Integer>(value);
 }
 
-JSON::JSON(const int value) : current_type{Type::Integer} {
+JSON::JSON(const int value) : current_type_{Type::Integer} {
   this->data_integer = value;
 }
 
-JSON::JSON(const double value) : current_type{Type::Real} {
+JSON::JSON(const double value) : current_type_{Type::Real} {
   // Numeric values that cannot be represented as sequences of digits (such as
   // Infinity and NaN) are not permitted. See
   // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
@@ -137,43 +137,43 @@ JSON::JSON(const double value) : current_type{Type::Real} {
 
 JSON::JSON(const float value) : JSON(static_cast<Real>(value)) {}
 
-JSON::JSON(const bool value) : current_type{Type::Boolean} {
+JSON::JSON(const bool value) : current_type_{Type::Boolean} {
   this->data_boolean = value;
 }
 
 JSON::JSON(const std::nullptr_t) {}
 
-JSON::JSON(const String &value) : current_type{Type::String} {
+JSON::JSON(const String &value) : current_type_{Type::String} {
   std::construct_at(&this->data_string, value);
 }
 
-JSON::JSON(String &&value) : current_type{Type::String} {
+JSON::JSON(String &&value) : current_type_{Type::String} {
   std::construct_at(&this->data_string, std::move(value));
 }
 
 JSON::JSON(const std::basic_string_view<Char, CharTraits> &value)
-    : current_type{Type::String} {
+    : current_type_{Type::String} {
   std::construct_at(&this->data_string, value);
 }
 
-JSON::JSON(const Char *const value) : current_type{Type::String} {
+JSON::JSON(const Char *const value) : current_type_{Type::String} {
   std::construct_at(&this->data_string, value);
 }
 
-JSON::JSON(const Array &value) : current_type{Type::Array} {
+JSON::JSON(const Array &value) : current_type_{Type::Array} {
   std::construct_at(&this->data_array, value);
 }
 
-JSON::JSON(std::initializer_list<typename Object::pair_value_type> values)
-    : current_type{Type::Object} {
+JSON::JSON(std::initializer_list<Object::pair_value_type> values)
+    : current_type_{Type::Object} {
   std::construct_at(&this->data_object, values);
 }
 
-JSON::JSON(const Object &value) : current_type{Type::Object} {
+JSON::JSON(const Object &value) : current_type_{Type::Object} {
   std::construct_at(&this->data_object, value);
 }
 
-JSON::JSON(const Decimal &value) : current_type{Type::Decimal} {
+JSON::JSON(const Decimal &value) : current_type_{Type::Decimal} {
   if (value.is_nan() || value.is_infinite()) {
     throw std::invalid_argument("JSON does not support Infinity or NaN");
   }
@@ -181,7 +181,7 @@ JSON::JSON(const Decimal &value) : current_type{Type::Decimal} {
   std::construct_at(&this->data_decimal, value);
 }
 
-JSON::JSON(Decimal &&value) : current_type{Type::Decimal} {
+JSON::JSON(Decimal &&value) : current_type_{Type::Decimal} {
   if (value.is_nan() || value.is_infinite()) {
     throw std::invalid_argument("JSON does not support Infinity or NaN");
   }
@@ -192,28 +192,28 @@ JSON::JSON(Decimal &&value) : current_type{Type::Decimal} {
 JSON::JSON(const JSON &other) {
   // Fast path for non-container sources avoids the work-list allocation that
   // would otherwise dominate the cost of copying a scalar value
-  switch (other.current_type) {
+  switch (other.current_type_) {
     case Type::Null:
       return;
     case Type::Boolean:
       this->data_boolean = other.data_boolean;
-      this->current_type = Type::Boolean;
+      this->current_type_ = Type::Boolean;
       return;
     case Type::Integer:
       this->data_integer = other.data_integer;
-      this->current_type = Type::Integer;
+      this->current_type_ = Type::Integer;
       return;
     case Type::Real:
       this->data_real = other.data_real;
-      this->current_type = Type::Real;
+      this->current_type_ = Type::Real;
       return;
     case Type::String:
       std::construct_at(&this->data_string, other.data_string);
-      this->current_type = Type::String;
+      this->current_type_ = Type::String;
       return;
     case Type::Decimal:
       std::construct_at(&this->data_decimal, other.data_decimal);
-      this->current_type = Type::Decimal;
+      this->current_type_ = Type::Decimal;
       return;
     case Type::Array:
     case Type::Object:
@@ -242,34 +242,34 @@ JSON::JSON(const JSON &other) {
       tasks.pop_back();
       const JSON &source{*task.source};
       JSON &destination{*task.destination};
-      switch (source.current_type) {
+      switch (source.current_type_) {
         case Type::Null:
           break;
         case Type::Boolean:
           destination.data_boolean = source.data_boolean;
-          destination.current_type = Type::Boolean;
+          destination.current_type_ = Type::Boolean;
           break;
         case Type::Integer:
           destination.data_integer = source.data_integer;
-          destination.current_type = Type::Integer;
+          destination.current_type_ = Type::Integer;
           break;
         case Type::Real:
           destination.data_real = source.data_real;
-          destination.current_type = Type::Real;
+          destination.current_type_ = Type::Real;
           break;
         case Type::String:
           std::construct_at(&destination.data_string, source.data_string);
-          destination.current_type = Type::String;
+          destination.current_type_ = Type::String;
           break;
         case Type::Decimal:
           std::construct_at(&destination.data_decimal, source.data_decimal);
-          destination.current_type = Type::Decimal;
+          destination.current_type_ = Type::Decimal;
           break;
         case Type::Array: {
           std::construct_at(&destination.data_array, Array{});
-          destination.current_type = Type::Array;
-          const auto &source_data{source.data_array.data};
-          auto &destination_data{destination.data_array.data};
+          destination.current_type_ = Type::Array;
+          const auto &source_data{source.data_array.data_};
+          auto &destination_data{destination.data_array.data_};
           destination_data.reserve(source_data.size());
           for (std::size_t index = 0; index < source_data.size(); ++index) {
             destination_data.emplace_back(nullptr);
@@ -282,9 +282,9 @@ JSON::JSON(const JSON &other) {
         }
         case Type::Object: {
           std::construct_at(&destination.data_object, Object{});
-          destination.current_type = Type::Object;
-          const auto &source_data{source.data_object.data};
-          auto &destination_data{destination.data_object.data};
+          destination.current_type_ = Type::Object;
+          const auto &source_data{source.data_object.data_};
+          auto &destination_data{destination.data_object.data_};
           destination_data.reserve(source_data.size());
           for (const auto &entry : source_data) {
             destination_data.emplace_back(entry.first, JSON{nullptr},
@@ -307,8 +307,8 @@ JSON::JSON(const JSON &other) {
   }
 }
 
-JSON::JSON(JSON &&other) noexcept : current_type{other.current_type} {
-  switch (other.current_type) {
+JSON::JSON(JSON &&other) noexcept : current_type_{other.current_type_} {
+  switch (other.current_type_) {
     case Type::Boolean:
       this->data_boolean = other.data_boolean;
       break;
@@ -320,15 +320,15 @@ JSON::JSON(JSON &&other) noexcept : current_type{other.current_type} {
       break;
     case Type::String:
       std::construct_at(&this->data_string, std::move(other.data_string));
-      other.current_type = Type::Null;
+      other.current_type_ = Type::Null;
       break;
     case Type::Array:
       std::construct_at(&this->data_array, std::move(other.data_array));
-      other.current_type = Type::Null;
+      other.current_type_ = Type::Null;
       break;
     case Type::Object:
       std::construct_at(&this->data_object, std::move(other.data_object));
-      other.current_type = Type::Null;
+      other.current_type_ = Type::Null;
       break;
     case Type::Decimal:
       std::construct_at(&this->data_decimal, std::move(other.data_decimal));
@@ -337,7 +337,7 @@ JSON::JSON(JSON &&other) noexcept : current_type{other.current_type} {
       // moved-from state owns no heap coefficient, making this a no-op
       // branch rather than a deallocation
       other.data_decimal.~Decimal();
-      other.current_type = Type::Null;
+      other.current_type_ = Type::Null;
       break;
     default:
       break;
@@ -354,44 +354,44 @@ auto JSON::operator=(const JSON &other) -> JSON & {
   // buffered into a local first, because the source may be nested inside this
   // value, and tearing this value down would otherwise free the storage still
   // being read from
-  switch (other.current_type) {
+  switch (other.current_type_) {
     case Type::Null:
       this->~JSON();
-      this->current_type = Type::Null;
+      this->current_type_ = Type::Null;
       return *this;
     case Type::Boolean: {
       const auto value{other.data_boolean};
       this->~JSON();
       this->data_boolean = value;
-      this->current_type = Type::Boolean;
+      this->current_type_ = Type::Boolean;
       return *this;
     }
     case Type::Integer: {
       const auto value{other.data_integer};
       this->~JSON();
       this->data_integer = value;
-      this->current_type = Type::Integer;
+      this->current_type_ = Type::Integer;
       return *this;
     }
     case Type::Real: {
       const auto value{other.data_real};
       this->~JSON();
       this->data_real = value;
-      this->current_type = Type::Real;
+      this->current_type_ = Type::Real;
       return *this;
     }
     case Type::String: {
       String value{other.data_string};
       this->~JSON();
       std::construct_at(&this->data_string, std::move(value));
-      this->current_type = Type::String;
+      this->current_type_ = Type::String;
       return *this;
     }
     case Type::Decimal: {
       Decimal value{other.data_decimal};
       this->~JSON();
       std::construct_at(&this->data_decimal, std::move(value));
-      this->current_type = Type::Decimal;
+      this->current_type_ = Type::Decimal;
       return *this;
     }
     case Type::Array:
@@ -431,21 +431,22 @@ JSON::~JSON() {
   // own container children, so containers full of scalars cost no heap
   // allocation. Allocation failures during destruction have no sensible
   // recovery, so terminate
-  if (this->current_type == Type::Array || this->current_type == Type::Object) {
+  if (this->current_type_ == Type::Array ||
+      this->current_type_ == Type::Object) {
     try {
       std::vector<JSON> pending;
 
-      if (this->current_type == Type::Array) {
-        for (auto &child : this->data_array.data) {
-          if (child.current_type == Type::Array ||
-              child.current_type == Type::Object) {
+      if (this->current_type_ == Type::Array) {
+        for (auto &child : this->data_array.data_) {
+          if (child.current_type_ == Type::Array ||
+              child.current_type_ == Type::Object) {
             pending.push_back(std::move(child));
           }
         }
       } else {
-        for (auto &entry : this->data_object.data) {
-          if (entry.second.current_type == Type::Array ||
-              entry.second.current_type == Type::Object) {
+        for (auto &entry : this->data_object.data_) {
+          if (entry.second.current_type_ == Type::Array ||
+              entry.second.current_type_ == Type::Object) {
             pending.push_back(std::move(entry.second));
           }
         }
@@ -454,24 +455,24 @@ JSON::~JSON() {
       while (!pending.empty()) {
         JSON node = std::move(pending.back());
         pending.pop_back();
-        if (node.current_type == Type::Array) {
-          for (auto &child : node.data_array.data) {
-            if (child.current_type == Type::Array ||
-                child.current_type == Type::Object) {
+        if (node.current_type_ == Type::Array) {
+          for (auto &child : node.data_array.data_) {
+            if (child.current_type_ == Type::Array ||
+                child.current_type_ == Type::Object) {
               pending.push_back(std::move(child));
             }
           }
           node.data_array.~JSONArray();
-          node.current_type = Type::Null;
+          node.current_type_ = Type::Null;
         } else {
-          for (auto &entry : node.data_object.data) {
-            if (entry.second.current_type == Type::Array ||
-                entry.second.current_type == Type::Object) {
+          for (auto &entry : node.data_object.data_) {
+            if (entry.second.current_type_ == Type::Array ||
+                entry.second.current_type_ == Type::Object) {
               pending.push_back(std::move(entry.second));
             }
           }
           node.data_object.~JSONObject();
-          node.current_type = Type::Null;
+          node.current_type_ = Type::Null;
         }
       }
     } catch (...) {
@@ -487,7 +488,7 @@ auto JSON::make_array() -> JSON { return JSON{Array{}}; }
 auto JSON::make_array(std::initializer_list<JSON> values) -> JSON {
   JSON result{nullptr};
   std::construct_at(&result.data_array, values);
-  result.current_type = Type::Array;
+  result.current_type_ = Type::Array;
   return result;
 }
 
@@ -515,19 +516,20 @@ auto JSON::size(const String &value) noexcept -> std::size_t {
 // arbitrary precision expansion, so this comparison is not noexcept
 auto JSON::operator<(const JSON &other) const -> bool {
   if (this->is_number() && other.is_number() &&
-      this->current_type != other.current_type) {
+      this->current_type_ != other.current_type_) {
     return std::is_lt(cross_numeric_ordering(*this, other));
   }
 
   if (this->type() != other.type()) {
-    return this->current_type < other.current_type;
+    return this->current_type_ < other.current_type_;
   }
 
   switch (this->type()) {
     case Type::Null:
       return false;
     case Type::Boolean:
-      return this->to_boolean() < other.to_boolean();
+      return static_cast<int>(this->to_boolean()) <
+             static_cast<int>(other.to_boolean());
     case Type::Integer:
       return this->to_integer() < other.to_integer();
     case Type::Real:
@@ -561,15 +563,15 @@ auto JSON::operator>=(const JSON &other) const -> bool {
 // arbitrary precision expansion, so this comparison is not noexcept
 auto JSON::operator==(const JSON &other) const -> bool {
   if (this->is_number() && other.is_number() &&
-      this->current_type != other.current_type) {
+      this->current_type_ != other.current_type_) {
     return std::is_eq(cross_numeric_ordering(*this, other));
   }
 
-  if (this->current_type != other.current_type) {
+  if (this->current_type_ != other.current_type_) {
     return false;
   }
 
-  switch (this->current_type) {
+  switch (this->current_type_) {
     case Type::Boolean:
       return this->data_boolean == other.data_boolean;
     case Type::Integer:
@@ -601,7 +603,8 @@ auto JSON::operator+(const JSON &other) const -> JSON {
                           : other.is_integer() ? Decimal{other.to_integer()}
                                                : Decimal{other.to_real()};
     return JSON{left + right};
-  } else if (this->is_integer() && other.is_integer()) {
+  }
+  if (this->is_integer() && other.is_integer()) {
     const auto left{this->to_integer()};
     const auto right{other.to_integer()};
     // Promote to arbitrary precision when the sum would not fit, since signed
@@ -612,13 +615,14 @@ auto JSON::operator+(const JSON &other) const -> JSON {
     }
 
     return JSON{left + right};
-  } else if (this->is_integer() && other.is_real()) {
-    return JSON{this->as_real() + other.to_real()};
-  } else if (this->is_real() && other.is_integer()) {
-    return JSON{this->to_real() + other.as_real()};
-  } else {
-    return JSON{this->to_real() + other.to_real()};
   }
+  if (this->is_integer() && other.is_real()) {
+    return JSON{this->as_real() + other.to_real()};
+  }
+  if (this->is_real() && other.is_integer()) {
+    return JSON{this->to_real() + other.as_real()};
+  }
+  return JSON{this->to_real() + other.to_real()};
 }
 
 auto JSON::operator-(const JSON &other) const -> JSON {
@@ -633,7 +637,8 @@ auto JSON::operator-(const JSON &other) const -> JSON {
                           : other.is_integer() ? Decimal{other.to_integer()}
                                                : Decimal{other.to_real()};
     return JSON{left - right};
-  } else if (this->is_integer() && other.is_integer()) {
+  }
+  if (this->is_integer() && other.is_integer()) {
     const auto left{this->to_integer()};
     const auto right{other.to_integer()};
     // Promote to arbitrary precision when the difference would not fit, since
@@ -644,13 +649,14 @@ auto JSON::operator-(const JSON &other) const -> JSON {
     }
 
     return JSON{left - right};
-  } else if (this->is_integer() && other.is_real()) {
-    return JSON{this->as_real() - other.to_real()};
-  } else if (this->is_real() && other.is_integer()) {
-    return JSON{this->to_real() - other.as_real()};
-  } else {
-    return JSON{this->to_real() - other.to_real()};
   }
+  if (this->is_integer() && other.is_real()) {
+    return JSON{this->as_real() - other.to_real()};
+  }
+  if (this->is_real() && other.is_integer()) {
+    return JSON{this->to_real() - other.as_real()};
+  }
+  return JSON{this->to_real() - other.to_real()};
 }
 
 auto JSON::operator+=(const JSON &additive) -> JSON & {
@@ -680,12 +686,11 @@ auto JSON::operator-=(const JSON &substractive) -> JSON & {
       this->data_string};
 }
 
-[[nodiscard]] auto JSON::at_or(const String &key,
-                               const typename Object::hash_type hash,
+[[nodiscard]] auto JSON::at_or(const String &key, const Object::hash_type hash,
                                const JSON &otherwise) const -> const JSON & {
   assert(this->is_object());
-  const auto result{this->try_at(key, hash)};
-  return result ? *result : otherwise;
+  const auto *const result{this->try_at(key, hash)};
+  return (result != nullptr) ? *result : otherwise;
 }
 
 [[nodiscard]] auto JSON::at_or(const String &key, const JSON &otherwise) const
@@ -702,34 +707,37 @@ auto JSON::operator-=(const JSON &substractive) -> JSON & {
     return std::ranges::fold_left(
         this->as_object(), static_cast<std::uint64_t>(0),
         [](const std::uint64_t accumulator,
-           const typename Object::value_type &pair) -> std::uint64_t {
+           const Object::value_type &pair) -> std::uint64_t {
           return accumulator + (pair.first.size() * sizeof(Char)) +
                  pair.second.estimated_byte_size();
         });
-  } else if (this->is_array()) {
+  }
+  if (this->is_array()) {
     return std::ranges::fold_left(
         this->as_array(), static_cast<std::uint64_t>(0),
         [](const std::uint64_t accumulator, const JSON &item) -> std::uint64_t {
           return accumulator + item.estimated_byte_size();
         });
-  } else if (this->is_string()) {
+  }
+  if (this->is_string()) {
     // Keep in mind that standard strings might reserve more
     // space than what it is actually used by the string
     return this->byte_size() * sizeof(Char);
-  } else if (this->is_integer()) {
-    return sizeof(Integer);
-  } else if (this->is_real()) {
-    return sizeof(Real);
-  } else if (this->is_boolean()) {
-    return sizeof(bool);
-  } else {
-    // The size of the union
-    return 8;
   }
+  if (this->is_integer()) {
+    return sizeof(Integer);
+  }
+  if (this->is_real()) {
+    return sizeof(Real);
+  }
+  if (this->is_boolean()) {
+    return sizeof(bool);
+  } // The size of the union
+  return 8;
 }
 
 [[nodiscard]] auto JSON::fast_hash() const -> std::uint64_t {
-  switch (this->current_type) {
+  switch (this->current_type_) {
     case Type::Null:
       return 2;
     case Type::Boolean:
@@ -764,7 +772,7 @@ auto JSON::operator-=(const JSON &substractive) -> JSON & {
       return std::ranges::fold_left(
           this->as_object(), static_cast<std::uint64_t>(7),
           [](const std::uint64_t accumulator,
-             const typename Object::value_type &pair) -> std::uint64_t {
+             const Object::value_type &pair) -> std::uint64_t {
             return accumulator + 1 + pair.first.size() +
                    pair.second.fast_hash();
           });
@@ -878,7 +886,7 @@ JSON::defines_any(std::initializer_list<JSON::String> keys) const -> bool {
 
 [[nodiscard]] auto JSON::unique() const -> bool {
   assert(this->is_array());
-  const auto &items{this->data_array.data};
+  const auto &items{this->data_array.data_};
   const auto size{items.size()};
 
   // Arrays of 0 or 1 item are unique by definition
@@ -908,7 +916,7 @@ JSON::defines_any(std::initializer_list<JSON::String> keys) const -> bool {
 
 [[nodiscard]] auto JSON::unique_keys() const -> bool {
   assert(this->is_object());
-  const auto &entries{this->data_object.data};
+  const auto &entries{this->data_object.data_};
   const auto size{entries.size()};
 
   // Objects of 0 or 1 member have unique keys by definition
@@ -930,36 +938,34 @@ JSON::defines_any(std::initializer_list<JSON::String> keys) const -> bool {
 
 auto JSON::push_back(const JSON &value) -> void {
   assert(this->is_array());
-  return this->data_array.data.push_back(value);
+  this->data_array.data_.push_back(value);
 }
 
 auto JSON::push_back(JSON &&value) -> void {
   assert(this->is_array());
-  return this->data_array.data.push_back(std::move(value));
+  this->data_array.data_.push_back(std::move(value));
 }
 
 auto JSON::push_back_if_unique(const JSON &value)
     -> std::pair<std::reference_wrapper<const JSON>, bool> {
   assert(this->is_array());
-  auto &array_data{this->as_array().data};
+  auto &array_data{this->as_array().data_};
   if (!std::ranges::contains(array_data, value)) {
     array_data.push_back(value);
     return {array_data.back(), true};
-  } else {
-    return {*std::ranges::find(array_data, value), false};
   }
+  return {*std::ranges::find(array_data, value), false};
 }
 
 auto JSON::push_back_if_unique(JSON &&value)
     -> std::pair<std::reference_wrapper<const JSON>, bool> {
   assert(this->is_array());
-  auto &array_data{this->as_array().data};
+  auto &array_data{this->as_array().data_};
   if (!std::ranges::contains(array_data, value)) {
     array_data.push_back(std::move(value));
     return {array_data.back(), true};
-  } else {
-    return {*std::ranges::find(array_data, value), false};
   }
+  return {*std::ranges::find(array_data, value), false};
 }
 
 auto JSON::assign(const JSON::String &key, const JSON &value) -> void {
@@ -1010,7 +1016,7 @@ auto JSON::assign_assume_new(JSON::String &&key, JSON &&value,
                                               hash);
 }
 
-auto JSON::erase(const JSON::String &key) -> typename Object::size_type {
+auto JSON::erase(const JSON::String &key) -> Object::size_type {
   assert(this->is_object());
   return this->data_object.erase(key);
 }
@@ -1019,30 +1025,29 @@ auto JSON::erase_keys(std::initializer_list<JSON::String> keys) -> void {
   this->erase_keys(keys.begin(), keys.end());
 }
 
-auto JSON::erase(typename JSON::Array::const_iterator position) ->
-    typename JSON::Array::iterator {
+auto JSON::erase(JSON::Array::const_iterator position)
+    -> JSON::Array::iterator {
   assert(this->is_array());
-  return this->data_array.data.erase(position);
+  return this->data_array.data_.erase(position);
 }
 
-auto JSON::erase(typename JSON::Array::const_iterator first,
-                 typename JSON::Array::const_iterator last) ->
-    typename JSON::Array::iterator {
+auto JSON::erase(JSON::Array::const_iterator first,
+                 JSON::Array::const_iterator last) -> JSON::Array::iterator {
   assert(this->is_array());
-  return this->data_array.data.erase(first, last);
+  return this->data_array.data_.erase(first, last);
 }
 
 auto JSON::erase_if(const std::function<bool(const JSON &)> &predicate)
     -> void {
   assert(this->is_array());
-  std::erase_if(this->data_array.data, predicate);
+  std::erase_if(this->data_array.data_, predicate);
 }
 
 auto JSON::clear() -> void {
   if (this->is_object()) {
     this->data_object.clear();
   } else {
-    this->data_array.data.clear();
+    this->data_array.data_.clear();
   }
 }
 
@@ -1062,8 +1067,9 @@ auto JSON::merge(const JSON::Object &other) -> void {
   }
 
   for (const auto &pair : other) {
-    const auto maybe_key{this->try_at(pair.first, pair.hash)};
-    if (maybe_key && maybe_key->is_object() && pair.second.is_object()) {
+    auto *const maybe_key{this->try_at(pair.first, pair.hash)};
+    if ((maybe_key != nullptr) && maybe_key->is_object() &&
+        pair.second.is_object()) {
       this->at(pair.first, pair.hash).merge(pair.second.as_object());
     } else {
       this->assign(pair.first, pair.second);
@@ -1100,10 +1106,10 @@ auto JSON::reorder(const KeyComparison &compare) -> void {
   this->data_object.reorder(compare);
 }
 
-auto JSON::rename(const JSON::String &key, JSON::String &&to) -> void {
+auto JSON::rename(const JSON::String &key, JSON::String &&target) -> void {
   assert(this->is_object());
   auto &object{this->data_object};
-  object.rename(key, object.hash(key), std::move(to), object.hash(to));
+  object.rename(key, object.hash(key), std::move(target), object.hash(target));
 }
 
 auto JSON::into(const JSON &other) -> void { this->operator=(other); }
@@ -1117,7 +1123,7 @@ auto JSON::into_array() -> void { this->into(JSON::make_array()); }
 auto JSON::into_object() -> void { this->into(JSON::make_object()); }
 
 auto JSON::maybe_destruct_union() -> void {
-  switch (this->current_type) {
+  switch (this->current_type_) {
     case Type::String:
       this->data_string.~basic_string();
       break;
@@ -1134,7 +1140,7 @@ auto JSON::maybe_destruct_union() -> void {
       break;
   }
 
-  this->current_type = Type::Null;
+  this->current_type_ = Type::Null;
 }
 
 } // namespace sourcemeta::core

--- a/src/core/json/parser.h
+++ b/src/core/json/parser.h
@@ -53,8 +53,8 @@ constexpr std::uint64_t WORD_LOW_BITS{0x0101010101010101ULL};
 constexpr std::uint64_t WORD_HIGH_BITS{0x8080808080808080ULL};
 
 inline auto is_plain_string_byte(const char character) -> bool {
-  return character != internal::token_string_quote<char> &&
-         character != internal::token_string_escape<char> &&
+  return character != internal::TOKEN_STRING_QUOTE<char> &&
+         character != internal::TOKEN_STRING_ESCAPE<char> &&
          static_cast<unsigned char>(character) >= 0x20;
 }
 
@@ -65,14 +65,14 @@ inline auto is_plain_string_byte(const char character) -> bool {
 // first flagged byte, and the first flag is always genuine
 inline auto match_string_special_bytes(const std::uint64_t word)
     -> std::uint64_t {
-  constexpr auto quote_pattern{
+  constexpr auto QUOTE_PATTERN{
       WORD_LOW_BITS *
-      static_cast<unsigned char>(internal::token_string_quote<char>)};
-  constexpr auto escape_pattern{
+      static_cast<unsigned char>(internal::TOKEN_STRING_QUOTE<char>)};
+  constexpr auto ESCAPE_PATTERN{
       WORD_LOW_BITS *
-      static_cast<unsigned char>(internal::token_string_escape<char>)};
-  const auto quote_difference{word ^ quote_pattern};
-  const auto escape_difference{word ^ escape_pattern};
+      static_cast<unsigned char>(internal::TOKEN_STRING_ESCAPE<char>)};
+  const auto quote_difference{word ^ QUOTE_PATTERN};
+  const auto escape_difference{word ^ ESCAPE_PATTERN};
   const auto quote_matches{(quote_difference - WORD_LOW_BITS) &
                            ~quote_difference & WORD_HIGH_BITS};
   const auto escape_matches{(escape_difference - WORD_LOW_BITS) &
@@ -88,15 +88,15 @@ inline auto skip_whitespace(const char *&cursor, const char *end,
     -> void {
   while (cursor < end) {
     switch (*cursor) {
-      case internal::token_whitespace_space<typename JSON::Char>:
-      case internal::token_whitespace_tabulation<typename JSON::Char>:
-      case internal::token_whitespace_carriage_return<typename JSON::Char>:
+      case internal::TOKEN_WHITESPACE_SPACE<JSON::Char>:
+      case internal::TOKEN_WHITESPACE_TABULATION<JSON::Char>:
+      case internal::TOKEN_WHITESPACE_CARRIAGE_RETURN<JSON::Char>:
         if constexpr (TrackPositions) {
           column += 1;
         }
         cursor++;
         continue;
-      case internal::token_whitespace_line_feed<typename JSON::Char>:
+      case internal::TOKEN_WHITESPACE_LINE_FEED<JSON::Char>:
         if constexpr (TrackPositions) {
           line += 1;
           column = 0;
@@ -112,10 +112,8 @@ inline auto skip_whitespace(const char *&cursor, const char *end,
 template <bool TrackPositions>
 inline auto scan_null(const std::uint64_t line, std::uint64_t &column,
                       const char *&cursor, const char *end) -> void {
-  for (
-      const auto character :
-      internal::constant_null<typename JSON::Char, typename JSON::CharTraits>.substr(
-          1)) {
+  for (const auto character :
+       internal::CONSTANT_NULL<JSON::Char, JSON::CharTraits>.substr(1)) {
     if constexpr (TrackPositions) {
       column += 1;
     }
@@ -132,10 +130,8 @@ inline auto scan_null(const std::uint64_t line, std::uint64_t &column,
 template <bool TrackPositions>
 inline auto scan_true(const std::uint64_t line, std::uint64_t &column,
                       const char *&cursor, const char *end) -> void {
-  for (
-      const auto character :
-      internal::constant_true<typename JSON::Char, typename JSON::CharTraits>.substr(
-          1)) {
+  for (const auto character :
+       internal::CONSTANT_TRUE<JSON::Char, JSON::CharTraits>.substr(1)) {
     if constexpr (TrackPositions) {
       column += 1;
     }
@@ -152,10 +148,8 @@ inline auto scan_true(const std::uint64_t line, std::uint64_t &column,
 template <bool TrackPositions>
 inline auto scan_false(const std::uint64_t line, std::uint64_t &column,
                        const char *&cursor, const char *end) -> void {
-  for (
-      const auto character :
-      internal::constant_false<typename JSON::Char, typename JSON::CharTraits>.substr(
-          1)) {
+  for (const auto character :
+       internal::CONSTANT_FALSE<JSON::Char, JSON::CharTraits>.substr(1)) {
     if constexpr (TrackPositions) {
       column += 1;
     }
@@ -198,7 +192,7 @@ inline auto scan_string_unicode(const std::uint64_t line, std::uint64_t &column,
                                 const char *&cursor, const char *end) -> void {
   auto code_point{scan_string_unicode_code_point<TrackPositions>(line, column,
                                                                  cursor, end)};
-  using CharT = typename JSON::Char;
+  using CharT = JSON::Char;
 
   if (code_point >= 0xDC00 && code_point <= 0xDFFF) [[unlikely]] {
     throw JSONParseError(line, column);
@@ -211,7 +205,7 @@ inline auto scan_string_unicode(const std::uint64_t line, std::uint64_t &column,
     if (cursor >= end) [[unlikely]] {
       throw JSONParseError(line, column);
     }
-    if (*cursor != internal::token_string_escape<CharT>) [[unlikely]] {
+    if (*cursor != internal::TOKEN_STRING_ESCAPE<CharT>) [[unlikely]] {
       throw JSONParseError(line, column);
     }
     cursor++;
@@ -222,7 +216,7 @@ inline auto scan_string_unicode(const std::uint64_t line, std::uint64_t &column,
     if (cursor >= end) [[unlikely]] {
       throw JSONParseError(line, column);
     }
-    if (*cursor != internal::token_string_escape_unicode<CharT>) [[unlikely]] {
+    if (*cursor != internal::TOKEN_STRING_ESCAPE_UNICODE<CharT>) [[unlikely]] {
       throw JSONParseError(line, column);
     }
     cursor++;
@@ -248,16 +242,16 @@ inline auto scan_string_escape(const std::uint64_t line, std::uint64_t &column,
     throw JSONParseError(line, column);
   }
   switch (*cursor++) {
-    case internal::token_string_quote<typename JSON::Char>:
-    case internal::token_string_escape<typename JSON::Char>:
-    case internal::token_string_solidus<typename JSON::Char>:
-    case internal::token_string_escape_backspace<typename JSON::Char>:
-    case internal::token_string_escape_form_feed<typename JSON::Char>:
-    case internal::token_string_escape_line_feed<typename JSON::Char>:
-    case internal::token_string_escape_carriage_return<typename JSON::Char>:
-    case internal::token_string_escape_tabulation<typename JSON::Char>:
+    case internal::TOKEN_STRING_QUOTE<JSON::Char>:
+    case internal::TOKEN_STRING_ESCAPE<JSON::Char>:
+    case internal::TOKEN_STRING_SOLIDUS<JSON::Char>:
+    case internal::TOKEN_STRING_ESCAPE_BACKSPACE<JSON::Char>:
+    case internal::TOKEN_STRING_ESCAPE_FORM_FEED<JSON::Char>:
+    case internal::TOKEN_STRING_ESCAPE_LINE_FEED<JSON::Char>:
+    case internal::TOKEN_STRING_ESCAPE_CARRIAGE_RETURN<JSON::Char>:
+    case internal::TOKEN_STRING_ESCAPE_TABULATION<JSON::Char>:
       return;
-    case internal::token_string_escape_unicode<typename JSON::Char>:
+    case internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>:
       scan_string_unicode<TrackPositions>(line, column, cursor, end);
       return;
     default:
@@ -310,9 +304,9 @@ inline auto scan_string(const std::uint64_t line, std::uint64_t &column,
     const char character{*cursor++};
 
     switch (character) {
-      case internal::token_string_quote<typename JSON::Char>:
+      case internal::TOKEN_STRING_QUOTE<JSON::Char>:
         return has_escape;
-      case internal::token_string_escape<typename JSON::Char>:
+      case internal::TOKEN_STRING_ESCAPE<JSON::Char>:
         has_escape = true;
         scan_string_escape<TrackPositions>(line, column, cursor, end);
         break;
@@ -331,10 +325,10 @@ template <bool TrackPositions>
 inline auto scan_digits(const std::uint64_t line, std::uint64_t &column,
                         const char *&cursor, const char *end,
                         const bool at_least_one) -> void {
-  using CharT = typename JSON::Char;
+  using CharT = JSON::Char;
   bool found{false};
-  while (cursor < end && *cursor >= internal::token_number_zero<CharT> &&
-         *cursor <= internal::token_number_nine<CharT>) {
+  while (cursor < end && *cursor >= internal::TOKEN_NUMBER_ZERO<CharT> &&
+         *cursor <= internal::TOKEN_NUMBER_NINE<CharT>) {
     found = true;
     if constexpr (TrackPositions) {
       column += 1;
@@ -358,12 +352,12 @@ template <bool TrackPositions>
 inline auto scan_number(const std::uint64_t line, std::uint64_t &column,
                         const char *&cursor, const char *end, const char first)
     -> NumberFacts {
-  using CharT = typename JSON::Char;
+  using CharT = JSON::Char;
   NumberFacts facts;
   const char *literal_start{cursor - 1};
-  if (first == internal::token_number_minus<CharT>) {
-    if (cursor >= end || *cursor < internal::token_number_zero<CharT> ||
-        *cursor > internal::token_number_nine<CharT>) [[unlikely]] {
+  if (first == internal::TOKEN_NUMBER_MINUS<CharT>) {
+    if (cursor >= end || *cursor < internal::TOKEN_NUMBER_ZERO<CharT> ||
+        *cursor > internal::TOKEN_NUMBER_NINE<CharT>) [[unlikely]] {
       if constexpr (TrackPositions) {
         column += 1;
       }
@@ -371,20 +365,20 @@ inline auto scan_number(const std::uint64_t line, std::uint64_t &column,
     }
   }
 
-  const char int_start{first == internal::token_number_minus<CharT> ? *cursor
+  const char int_start{first == internal::TOKEN_NUMBER_MINUS<CharT> ? *cursor
                                                                     : first};
   const char *integer_begin{
-      first == internal::token_number_minus<CharT> ? cursor : cursor - 1};
-  if (first == internal::token_number_minus<CharT>) {
+      first == internal::TOKEN_NUMBER_MINUS<CharT> ? cursor : cursor - 1};
+  if (first == internal::TOKEN_NUMBER_MINUS<CharT>) {
     if constexpr (TrackPositions) {
       column += 1;
     }
     cursor++;
   }
 
-  if (int_start == internal::token_number_zero<CharT>) {
-    if (cursor < end && *cursor >= internal::token_number_zero<CharT> &&
-        *cursor <= internal::token_number_nine<CharT>) [[unlikely]] {
+  if (int_start == internal::TOKEN_NUMBER_ZERO<CharT>) {
+    if (cursor < end && *cursor >= internal::TOKEN_NUMBER_ZERO<CharT> &&
+        *cursor <= internal::TOKEN_NUMBER_NINE<CharT>) [[unlikely]] {
       if constexpr (TrackPositions) {
         column += 1;
       }
@@ -395,7 +389,7 @@ inline auto scan_number(const std::uint64_t line, std::uint64_t &column,
   }
 
   const char *dot_position{nullptr};
-  if (cursor < end && *cursor == internal::token_number_decimal_point<CharT>) {
+  if (cursor < end && *cursor == internal::TOKEN_NUMBER_DECIMAL_POINT<CharT>) {
     dot_position = cursor;
     facts.flags |= TAPE_FLAG_NUMBER_DOT;
     if constexpr (TrackPositions) {
@@ -406,15 +400,15 @@ inline auto scan_number(const std::uint64_t line, std::uint64_t &column,
   }
 
   if (cursor < end &&
-      (*cursor == internal::token_number_exponent_lowercase<CharT> ||
-       *cursor == internal::token_number_exponent_uppercase<CharT>)) {
+      (*cursor == internal::TOKEN_NUMBER_EXPONENT_LOWERCASE<CharT> ||
+       *cursor == internal::TOKEN_NUMBER_EXPONENT_UPPERCASE<CharT>)) {
     facts.flags |= TAPE_FLAG_NUMBER_EXPONENT;
     if constexpr (TrackPositions) {
       column += 1;
     }
     cursor++;
-    if (cursor < end && (*cursor == internal::token_number_plus<CharT> ||
-                         *cursor == internal::token_number_minus<CharT>)) {
+    if (cursor < end && (*cursor == internal::TOKEN_NUMBER_PLUS<CharT> ||
+                         *cursor == internal::TOKEN_NUMBER_MINUS<CharT>)) {
       if constexpr (TrackPositions) {
         column += 1;
       }
@@ -428,12 +422,12 @@ inline auto scan_number(const std::uint64_t line, std::uint64_t &column,
   // on their own
   if (dot_position && !(facts.flags & TAPE_FLAG_NUMBER_EXPONENT)) {
     const char *first_significant{nullptr};
-    if (int_start != internal::token_number_zero<CharT>) {
+    if (int_start != internal::TOKEN_NUMBER_ZERO<CharT>) {
       first_significant = integer_begin;
     } else {
       for (const char *pointer = dot_position + 1; pointer < cursor;
            pointer++) {
-        if (*pointer != internal::token_number_zero<CharT>) {
+        if (*pointer != internal::TOKEN_NUMBER_ZERO<CharT>) {
           first_significant = pointer;
           break;
         }
@@ -467,7 +461,7 @@ inline auto scan_json(const char *&cursor, const char *end,
     std::uint32_t child_count;
   };
 
-  using CharT = typename JSON::Char;
+  using CharT = JSON::Char;
   char character = 0;
   std::vector<ContainerFrame> container_stack;
   container_stack.reserve(32);
@@ -488,7 +482,7 @@ inline auto scan_json(const char *&cursor, const char *end,
     const auto value_line{line};
     const auto value_column{column};
     switch (character) {
-      case internal::token_true<CharT>:
+      case internal::TOKEN_TRUE<CharT>:
         internal::scan_true<TrackPositions>(line, column, cursor, end);
         tape.push_back({.type = TapeType::True,
                         .flags = 0,
@@ -498,7 +492,7 @@ inline auto scan_json(const char *&cursor, const char *end,
                         .line = value_line,
                         .column = value_column});
         return;
-      case internal::token_false<CharT>:
+      case internal::TOKEN_FALSE<CharT>:
         internal::scan_false<TrackPositions>(line, column, cursor, end);
         tape.push_back({.type = TapeType::False,
                         .flags = 0,
@@ -508,7 +502,7 @@ inline auto scan_json(const char *&cursor, const char *end,
                         .line = value_line,
                         .column = value_column});
         return;
-      case internal::token_null<CharT>:
+      case internal::TOKEN_NULL<CharT>:
         internal::scan_null<TrackPositions>(line, column, cursor, end);
         tape.push_back({.type = TapeType::Null,
                         .flags = 0,
@@ -518,7 +512,7 @@ inline auto scan_json(const char *&cursor, const char *end,
                         .line = value_line,
                         .column = value_column});
         return;
-      case internal::token_string_quote<CharT>: {
+      case internal::TOKEN_STRING_QUOTE<CharT>: {
         const auto string_start{
             static_cast<std::uint32_t>(cursor - buffer_start)};
         const auto string_has_escape{
@@ -531,21 +525,21 @@ inline auto scan_json(const char *&cursor, const char *end,
              string_start, string_length, 0, value_line, value_column});
         return;
       }
-      case internal::token_array_begin<CharT>:
+      case internal::TOKEN_ARRAY_BEGIN<CharT>:
         goto do_scan_array;
-      case internal::token_object_begin<CharT>:
+      case internal::TOKEN_OBJECT_BEGIN<CharT>:
         goto do_scan_object;
-      case internal::token_number_minus<CharT>:
-      case internal::token_number_zero<CharT>:
-      case internal::token_number_one<CharT>:
-      case internal::token_number_two<CharT>:
-      case internal::token_number_three<CharT>:
-      case internal::token_number_four<CharT>:
-      case internal::token_number_five<CharT>:
-      case internal::token_number_six<CharT>:
-      case internal::token_number_seven<CharT>:
-      case internal::token_number_eight<CharT>:
-      case internal::token_number_nine<CharT>: {
+      case internal::TOKEN_NUMBER_MINUS<CharT>:
+      case internal::TOKEN_NUMBER_ZERO<CharT>:
+      case internal::TOKEN_NUMBER_ONE<CharT>:
+      case internal::TOKEN_NUMBER_TWO<CharT>:
+      case internal::TOKEN_NUMBER_THREE<CharT>:
+      case internal::TOKEN_NUMBER_FOUR<CharT>:
+      case internal::TOKEN_NUMBER_FIVE<CharT>:
+      case internal::TOKEN_NUMBER_SIX<CharT>:
+      case internal::TOKEN_NUMBER_SEVEN<CharT>:
+      case internal::TOKEN_NUMBER_EIGHT<CharT>:
+      case internal::TOKEN_NUMBER_NINE<CharT>: {
         const auto number_start{
             static_cast<std::uint32_t>(cursor - buffer_start - 1)};
         const auto number_facts{internal::scan_number<TrackPositions>(
@@ -585,7 +579,7 @@ do_scan_array: {
     throw JSONParseError(line, column);
   }
 
-  if (*cursor == internal::token_array_end<CharT>) {
+  if (*cursor == internal::TOKEN_ARRAY_END<CharT>) {
     if constexpr (TrackPositions) {
       column += 1;
     }
@@ -625,11 +619,11 @@ do_scan_array_item:
     const auto value_line{line};
     const auto value_column{column};
     switch (character) {
-      case internal::token_array_begin<CharT>:
+      case internal::TOKEN_ARRAY_BEGIN<CharT>:
         goto do_scan_array;
-      case internal::token_object_begin<CharT>:
+      case internal::TOKEN_OBJECT_BEGIN<CharT>:
         goto do_scan_object;
-      case internal::token_true<CharT>:
+      case internal::TOKEN_TRUE<CharT>:
         internal::scan_true<TrackPositions>(line, column, cursor, end);
         tape.push_back({.type = TapeType::True,
                         .flags = 0,
@@ -639,7 +633,7 @@ do_scan_array_item:
                         .line = value_line,
                         .column = value_column});
         goto do_scan_array_item_separator;
-      case internal::token_false<CharT>:
+      case internal::TOKEN_FALSE<CharT>:
         internal::scan_false<TrackPositions>(line, column, cursor, end);
         tape.push_back({.type = TapeType::False,
                         .flags = 0,
@@ -649,7 +643,7 @@ do_scan_array_item:
                         .line = value_line,
                         .column = value_column});
         goto do_scan_array_item_separator;
-      case internal::token_null<CharT>:
+      case internal::TOKEN_NULL<CharT>:
         internal::scan_null<TrackPositions>(line, column, cursor, end);
         tape.push_back({.type = TapeType::Null,
                         .flags = 0,
@@ -659,7 +653,7 @@ do_scan_array_item:
                         .line = value_line,
                         .column = value_column});
         goto do_scan_array_item_separator;
-      case internal::token_string_quote<CharT>: {
+      case internal::TOKEN_STRING_QUOTE<CharT>: {
         const auto string_start{
             static_cast<std::uint32_t>(cursor - buffer_start)};
         const auto string_has_escape{
@@ -672,17 +666,17 @@ do_scan_array_item:
              string_start, string_length, 0, value_line, value_column});
         goto do_scan_array_item_separator;
       }
-      case internal::token_number_minus<CharT>:
-      case internal::token_number_zero<CharT>:
-      case internal::token_number_one<CharT>:
-      case internal::token_number_two<CharT>:
-      case internal::token_number_three<CharT>:
-      case internal::token_number_four<CharT>:
-      case internal::token_number_five<CharT>:
-      case internal::token_number_six<CharT>:
-      case internal::token_number_seven<CharT>:
-      case internal::token_number_eight<CharT>:
-      case internal::token_number_nine<CharT>: {
+      case internal::TOKEN_NUMBER_MINUS<CharT>:
+      case internal::TOKEN_NUMBER_ZERO<CharT>:
+      case internal::TOKEN_NUMBER_ONE<CharT>:
+      case internal::TOKEN_NUMBER_TWO<CharT>:
+      case internal::TOKEN_NUMBER_THREE<CharT>:
+      case internal::TOKEN_NUMBER_FOUR<CharT>:
+      case internal::TOKEN_NUMBER_FIVE<CharT>:
+      case internal::TOKEN_NUMBER_SIX<CharT>:
+      case internal::TOKEN_NUMBER_SEVEN<CharT>:
+      case internal::TOKEN_NUMBER_EIGHT<CharT>:
+      case internal::TOKEN_NUMBER_NINE<CharT>: {
         const auto number_start{
             static_cast<std::uint32_t>(cursor - buffer_start - 1)};
         const auto number_facts{internal::scan_number<TrackPositions>(
@@ -712,9 +706,9 @@ do_scan_array_item_separator:
   }
   character = *cursor++;
   switch (character) {
-    case internal::token_array_delimiter<CharT>:
+    case internal::TOKEN_ARRAY_DELIMITER<CharT>:
       goto do_scan_array_item;
-    case internal::token_array_end<CharT>: {
+    case internal::TOKEN_ARRAY_END<CharT>: {
       assert(!container_stack.empty());
       auto &frame{container_stack.back()};
       tape[frame.tape_index].count = frame.child_count;
@@ -755,7 +749,7 @@ do_scan_object: {
     throw JSONParseError(line, column);
   }
 
-  if (*cursor == internal::token_object_end<CharT>) {
+  if (*cursor == internal::TOKEN_OBJECT_END<CharT>) {
     if constexpr (TrackPositions) {
       column += 1;
     }
@@ -791,7 +785,7 @@ do_scan_object_key:
   }
   character = *cursor++;
   switch (character) {
-    case internal::token_string_quote<CharT>: {
+    case internal::TOKEN_STRING_QUOTE<CharT>: {
       const auto key_start{static_cast<std::uint32_t>(cursor - buffer_start)};
       const auto key_line{line};
       const auto key_column{column};
@@ -822,7 +816,7 @@ do_scan_object_separator:
   }
   character = *cursor++;
   switch (character) {
-    case internal::token_object_key_delimiter<CharT>:
+    case internal::TOKEN_OBJECT_KEY_DELIMITER<CharT>:
       goto do_scan_object_value;
     default:
       [[unlikely]] throw JSONParseError(line, column);
@@ -845,11 +839,11 @@ do_scan_object_value:
     const auto value_line{line};
     const auto value_column{column};
     switch (character) {
-      case internal::token_array_begin<CharT>:
+      case internal::TOKEN_ARRAY_BEGIN<CharT>:
         goto do_scan_array;
-      case internal::token_object_begin<CharT>:
+      case internal::TOKEN_OBJECT_BEGIN<CharT>:
         goto do_scan_object;
-      case internal::token_true<CharT>:
+      case internal::TOKEN_TRUE<CharT>:
         internal::scan_true<TrackPositions>(line, column, cursor, end);
         tape.push_back({.type = TapeType::True,
                         .flags = 0,
@@ -859,7 +853,7 @@ do_scan_object_value:
                         .line = value_line,
                         .column = value_column});
         goto do_scan_object_property_end;
-      case internal::token_false<CharT>:
+      case internal::TOKEN_FALSE<CharT>:
         internal::scan_false<TrackPositions>(line, column, cursor, end);
         tape.push_back({.type = TapeType::False,
                         .flags = 0,
@@ -869,7 +863,7 @@ do_scan_object_value:
                         .line = value_line,
                         .column = value_column});
         goto do_scan_object_property_end;
-      case internal::token_null<CharT>:
+      case internal::TOKEN_NULL<CharT>:
         internal::scan_null<TrackPositions>(line, column, cursor, end);
         tape.push_back({.type = TapeType::Null,
                         .flags = 0,
@@ -879,7 +873,7 @@ do_scan_object_value:
                         .line = value_line,
                         .column = value_column});
         goto do_scan_object_property_end;
-      case internal::token_string_quote<CharT>: {
+      case internal::TOKEN_STRING_QUOTE<CharT>: {
         const auto string_start{
             static_cast<std::uint32_t>(cursor - buffer_start)};
         const auto string_has_escape{
@@ -892,17 +886,17 @@ do_scan_object_value:
              string_start, string_length, 0, value_line, value_column});
         goto do_scan_object_property_end;
       }
-      case internal::token_number_minus<CharT>:
-      case internal::token_number_zero<CharT>:
-      case internal::token_number_one<CharT>:
-      case internal::token_number_two<CharT>:
-      case internal::token_number_three<CharT>:
-      case internal::token_number_four<CharT>:
-      case internal::token_number_five<CharT>:
-      case internal::token_number_six<CharT>:
-      case internal::token_number_seven<CharT>:
-      case internal::token_number_eight<CharT>:
-      case internal::token_number_nine<CharT>: {
+      case internal::TOKEN_NUMBER_MINUS<CharT>:
+      case internal::TOKEN_NUMBER_ZERO<CharT>:
+      case internal::TOKEN_NUMBER_ONE<CharT>:
+      case internal::TOKEN_NUMBER_TWO<CharT>:
+      case internal::TOKEN_NUMBER_THREE<CharT>:
+      case internal::TOKEN_NUMBER_FOUR<CharT>:
+      case internal::TOKEN_NUMBER_FIVE<CharT>:
+      case internal::TOKEN_NUMBER_SIX<CharT>:
+      case internal::TOKEN_NUMBER_SEVEN<CharT>:
+      case internal::TOKEN_NUMBER_EIGHT<CharT>:
+      case internal::TOKEN_NUMBER_NINE<CharT>: {
         const auto number_start{
             static_cast<std::uint32_t>(cursor - buffer_start - 1)};
         const auto number_facts{internal::scan_number<TrackPositions>(
@@ -932,9 +926,9 @@ do_scan_object_property_end:
   }
   character = *cursor++;
   switch (character) {
-    case internal::token_object_delimiter<CharT>:
+    case internal::TOKEN_OBJECT_DELIMITER<CharT>:
       goto do_scan_object_key;
-    case internal::token_object_end<CharT>: {
+    case internal::TOKEN_OBJECT_END<CharT>: {
       assert(!container_stack.empty());
       auto &frame{container_stack.back()};
       tape[frame.tape_index].count = frame.child_count;

--- a/src/core/json/stringify.h
+++ b/src/core/json/stringify.h
@@ -25,7 +25,7 @@ auto indent(std::basic_ostream<CharT, Traits> &stream,
             const std::size_t indentation, const std::size_t indent_by)
     -> void {
   for (std::size_t index{0}; index < indentation * indent_by; index++) {
-    stream.put(internal::token_whitespace_space<CharT>);
+    stream.put(internal::TOKEN_WHITESPACE_SPACE<CharT>);
   }
 }
 } // namespace sourcemeta::core::internal
@@ -33,48 +33,41 @@ auto indent(std::basic_ostream<CharT, Traits> &stream,
 namespace sourcemeta::core {
 
 template <template <typename T> typename Allocator>
-auto stringify(
-    const std::nullptr_t,
-    std::basic_ostream<typename JSON::Char, typename JSON::CharTraits> &stream)
+auto stringify(const std::nullptr_t,
+               std::basic_ostream<JSON::Char, JSON::CharTraits> &stream)
     -> void {
-  stream.write(
-      internal::constant_null<typename JSON::Char, typename JSON::CharTraits>.data(),
-      internal::constant_null<typename JSON::Char, typename JSON::CharTraits>.size());
+  stream.write(internal::CONSTANT_NULL<JSON::Char, JSON::CharTraits>.data(),
+               internal::CONSTANT_NULL<JSON::Char, JSON::CharTraits>.size());
 }
 
 template <template <typename T> typename Allocator>
-auto stringify(
-    const bool value,
-    std::basic_ostream<typename JSON::Char, typename JSON::CharTraits> &stream)
+auto stringify(const bool value,
+               std::basic_ostream<JSON::Char, JSON::CharTraits> &stream)
     -> void {
   if (value) {
-    stream.write(
-        internal::constant_true<typename JSON::Char, typename JSON::CharTraits>.data(),
-        internal::constant_true<typename JSON::Char, typename JSON::CharTraits>.size());
+    stream.write(internal::CONSTANT_TRUE<JSON::Char, JSON::CharTraits>.data(),
+                 internal::CONSTANT_TRUE<JSON::Char, JSON::CharTraits>.size());
   } else {
-    stream.write(
-        internal::constant_false<typename JSON::Char, typename JSON::CharTraits>.data(),
-        internal::constant_false<typename JSON::Char, typename JSON::CharTraits>.size());
+    stream.write(internal::CONSTANT_FALSE<JSON::Char, JSON::CharTraits>.data(),
+                 internal::CONSTANT_FALSE<JSON::Char, JSON::CharTraits>.size());
   }
 }
 
 template <template <typename T> typename Allocator>
-auto stringify(
-    const std::int64_t value,
-    std::basic_ostream<typename JSON::Char, typename JSON::CharTraits> &stream)
+auto stringify(const std::int64_t value,
+               std::basic_ostream<JSON::Char, JSON::CharTraits> &stream)
     -> void {
   digits_write(stream, value);
 }
 
 template <template <typename T> typename Allocator>
-auto stringify(
-    const double value, const bool is_integral,
-    std::basic_ostream<typename JSON::Char, typename JSON::CharTraits> &stream)
+auto stringify(const double value, const bool is_integral,
+               std::basic_ostream<JSON::Char, JSON::CharTraits> &stream)
     -> void {
   // RFC 8259 Section 6 permits the -0.0 number syntax and parsing preserves
   // the sign of a zero, so serialisation keeps the sign as well and the
   // round trip is lossless
-  if (value == static_cast<double>(0.0)) {
+  if (value == 0.0) {
     if (std::signbit(value)) {
       stream.write("-0.0", 4);
     } else {
@@ -103,16 +96,15 @@ auto stringify(
 }
 
 template <template <typename T> typename Allocator>
-auto stringify(
-    const typename JSON::String &document,
-    std::basic_ostream<typename JSON::Char, typename JSON::CharTraits> &stream)
+auto stringify(const typename JSON::String &document,
+               std::basic_ostream<JSON::Char, JSON::CharTraits> &stream)
     -> void {
-  stream.put(internal::token_string_quote<typename JSON::Char>);
+  stream.put(internal::TOKEN_STRING_QUOTE<JSON::Char>);
   for (const auto character : document) {
     switch (character) {
-      case internal::token_string_escape<typename JSON::Char>:
-      case internal::token_string_quote<typename JSON::Char>:
-        stream.put(internal::token_string_escape<typename JSON::Char>);
+      case internal::TOKEN_STRING_ESCAPE<JSON::Char>:
+      case internal::TOKEN_STRING_QUOTE<JSON::Char>:
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
         stream.put(character);
         break;
 
@@ -121,8 +113,8 @@ auto stringify(
 
       // Null
       case '\u0000':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -130,8 +122,8 @@ auto stringify(
         break;
       // Start of heading
       case '\u0001':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -139,8 +131,8 @@ auto stringify(
         break;
       // Start of text
       case '\u0002':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -148,8 +140,8 @@ auto stringify(
         break;
       // End of text
       case '\u0003':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -157,8 +149,8 @@ auto stringify(
         break;
       // End of transmission
       case '\u0004':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -166,8 +158,8 @@ auto stringify(
         break;
       // Enquiry
       case '\u0005':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -175,8 +167,8 @@ auto stringify(
         break;
       // Acknowledge
       case '\u0006':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -184,8 +176,8 @@ auto stringify(
         break;
       // Bell
       case '\u0007':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -193,26 +185,23 @@ auto stringify(
         break;
       // Backspace
       case '\b':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(
-            internal::token_string_escape_backspace<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_BACKSPACE<JSON::Char>);
         break;
       // Horizontal tab
       case '\t':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(
-            internal::token_string_escape_tabulation<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_TABULATION<JSON::Char>);
         break;
       // Line feed
       case '\n':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(
-            internal::token_string_escape_line_feed<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_LINE_FEED<JSON::Char>);
         break;
       // Vertical tab
       case '\u000B':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -220,20 +209,18 @@ auto stringify(
         break;
       // Form feed
       case '\f':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(
-            internal::token_string_escape_form_feed<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_FORM_FEED<JSON::Char>);
         break;
       // Carriage return
       case '\r':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(
-            internal::token_string_escape_carriage_return<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_CARRIAGE_RETURN<JSON::Char>);
         break;
       // Shift out
       case '\u000E':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -241,8 +228,8 @@ auto stringify(
         break;
       // Shift in
       case '\u000F':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -250,8 +237,8 @@ auto stringify(
         break;
       // Data link escape
       case '\u0010':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -259,8 +246,8 @@ auto stringify(
         break;
       // Device control 1
       case '\u0011':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -268,8 +255,8 @@ auto stringify(
         break;
       // Device control 2
       case '\u0012':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -277,8 +264,8 @@ auto stringify(
         break;
       // Device control 3
       case '\u0013':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -286,8 +273,8 @@ auto stringify(
         break;
       // Device control 4
       case '\u0014':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -295,8 +282,8 @@ auto stringify(
         break;
       // Negative acknowledge
       case '\u0015':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -304,8 +291,8 @@ auto stringify(
         break;
       // Synchronous idle
       case '\u0016':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -313,8 +300,8 @@ auto stringify(
         break;
       // End of transmission block
       case '\u0017':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -322,8 +309,8 @@ auto stringify(
         break;
       // Cancel
       case '\u0018':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -331,8 +318,8 @@ auto stringify(
         break;
       // End of medium
       case '\u0019':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -340,8 +327,8 @@ auto stringify(
         break;
       // Substitute
       case '\u001A':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -349,8 +336,8 @@ auto stringify(
         break;
       // Escape
       case '\u001B':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -358,8 +345,8 @@ auto stringify(
         break;
       // File separator
       case '\u001C':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -367,8 +354,8 @@ auto stringify(
         break;
       // Group separator
       case '\u001D':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -376,8 +363,8 @@ auto stringify(
         break;
       // Record separator
       case '\u001E':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -385,8 +372,8 @@ auto stringify(
         break;
       // Unit separator
       case '\u001F':
-        stream.put(internal::token_string_escape<typename JSON::Char>);
-        stream.put(internal::token_string_escape_unicode<typename JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE<JSON::Char>);
+        stream.put(internal::TOKEN_STRING_ESCAPE_UNICODE<JSON::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -397,58 +384,55 @@ auto stringify(
     }
   }
 
-  stream.put(internal::token_string_quote<typename JSON::Char>);
+  stream.put(internal::TOKEN_STRING_QUOTE<JSON::Char>);
 }
 
 template <template <typename T> typename Allocator>
-auto stringify(
-    const typename JSON::Array &document,
-    std::basic_ostream<typename JSON::Char, typename JSON::CharTraits> &stream)
+auto stringify(const typename JSON::Array &document,
+               std::basic_ostream<JSON::Char, JSON::CharTraits> &stream)
     -> void {
-  stream.put(internal::token_array_begin<typename JSON::Char>);
+  stream.put(internal::TOKEN_ARRAY_BEGIN<JSON::Char>);
   const auto end{std::cend(document)};
   for (auto iterator = std::cbegin(document); iterator != end; ++iterator) {
     stringify<Allocator>(*iterator, stream);
     if (std::next(iterator) != end) {
-      stream.put(internal::token_array_delimiter<typename JSON::Char>);
+      stream.put(internal::TOKEN_ARRAY_DELIMITER<JSON::Char>);
     }
   }
 
-  stream.put(internal::token_array_end<typename JSON::Char>);
+  stream.put(internal::TOKEN_ARRAY_END<JSON::Char>);
 }
 
 template <template <typename T> typename Allocator>
-auto stringify(
-    const typename JSON::Object &document,
-    std::basic_ostream<typename JSON::Char, typename JSON::CharTraits> &stream)
+auto stringify(const typename JSON::Object &document,
+               std::basic_ostream<JSON::Char, JSON::CharTraits> &stream)
     -> void {
-  stream.put(internal::token_object_begin<typename JSON::Char>);
+  stream.put(internal::TOKEN_OBJECT_BEGIN<JSON::Char>);
 
   const auto end{std::cend(document)};
   for (auto iterator = std::cbegin(document); iterator != end; ++iterator) {
     stringify<Allocator>(iterator->first, stream);
-    stream.put(internal::token_object_key_delimiter<typename JSON::Char>);
+    stream.put(internal::TOKEN_OBJECT_KEY_DELIMITER<JSON::Char>);
     stringify<Allocator>(iterator->second, stream);
     if (std::next(iterator) != end) {
-      stream.put(internal::token_object_delimiter<typename JSON::Char>);
+      stream.put(internal::TOKEN_OBJECT_DELIMITER<JSON::Char>);
     }
   }
 
-  stream.put(internal::token_object_end<typename JSON::Char>);
+  stream.put(internal::TOKEN_OBJECT_END<JSON::Char>);
 }
 
 template <template <typename T> typename Allocator>
-auto prettify(
-    const typename JSON::Object &document,
-    std::basic_ostream<typename JSON::Char, typename JSON::CharTraits> &stream,
-    const std::size_t, const std::size_t) -> void;
+auto prettify(const typename JSON::Object &document,
+              std::basic_ostream<JSON::Char, JSON::CharTraits> &stream,
+              const std::size_t indentation, const std::size_t indent_by)
+    -> void;
 
 template <template <typename T> typename Allocator>
-auto prettify(
-    const typename JSON::Array &document,
-    std::basic_ostream<typename JSON::Char, typename JSON::CharTraits> &stream,
-    const std::size_t indentation, const std::size_t indent_by,
-    const std::size_t property_size) -> void {
+auto prettify(const typename JSON::Array &document,
+              std::basic_ostream<JSON::Char, JSON::CharTraits> &stream,
+              const std::size_t indentation, const std::size_t indent_by,
+              const std::size_t property_size) -> void {
   const auto end{std::cend(document)};
   const auto effective_indentation{(indentation * indent_by) + property_size};
 
@@ -456,19 +440,19 @@ auto prettify(
 
   bool prettify_in_place{effective_indentation < internal::LINE_WIDTH};
   std::ostringstream inplace;
-  inplace.put(internal::token_array_begin<typename JSON::Char>);
+  inplace.put(internal::TOKEN_ARRAY_BEGIN<JSON::Char>);
   for (auto iterator = std::cbegin(document); iterator != end; ++iterator) {
     if (iterator->is_object() || iterator->is_array()) {
       prettify_in_place = false;
       break;
     }
 
-    inplace.put(internal::token_whitespace_space<typename JSON::Char>);
+    inplace.put(internal::TOKEN_WHITESPACE_SPACE<JSON::Char>);
     prettify<Allocator>(*iterator, inplace, indentation, indent_by);
     if (std::next(iterator) == end) {
-      inplace.put(internal::token_whitespace_space<typename JSON::Char>);
+      inplace.put(internal::TOKEN_WHITESPACE_SPACE<JSON::Char>);
     } else {
-      inplace.put(internal::token_array_delimiter<typename JSON::Char>);
+      inplace.put(internal::TOKEN_ARRAY_DELIMITER<JSON::Char>);
     }
 
     if (inplace.str().size() + effective_indentation >= internal::LINE_WIDTH) {
@@ -479,19 +463,19 @@ auto prettify(
 
   if (prettify_in_place) {
     stream << inplace.str();
-    stream.put(internal::token_array_end<typename JSON::Char>);
+    stream.put(internal::TOKEN_ARRAY_END<JSON::Char>);
     return;
   }
 
-  stream.put(internal::token_array_begin<typename JSON::Char>);
+  stream.put(internal::TOKEN_ARRAY_BEGIN<JSON::Char>);
   for (auto iterator = std::cbegin(document); iterator != end; ++iterator) {
-    stream.put(internal::token_whitespace_line_feed<typename JSON::Char>);
+    stream.put(internal::TOKEN_WHITESPACE_LINE_FEED<JSON::Char>);
     internal::indent(stream, indentation + 1, indent_by);
     prettify<Allocator>(*iterator, stream, indentation + 1, indent_by);
     if (std::next(iterator) == end) {
-      stream.put(internal::token_whitespace_line_feed<typename JSON::Char>);
+      stream.put(internal::TOKEN_WHITESPACE_LINE_FEED<JSON::Char>);
     } else {
-      stream.put(internal::token_array_delimiter<typename JSON::Char>);
+      stream.put(internal::TOKEN_ARRAY_DELIMITER<JSON::Char>);
     }
   }
 
@@ -499,33 +483,33 @@ auto prettify(
     internal::indent(stream, indentation, indent_by);
   }
 
-  stream.put(internal::token_array_end<typename JSON::Char>);
+  stream.put(internal::TOKEN_ARRAY_END<JSON::Char>);
 }
 
 template <template <typename T> typename Allocator>
-auto prettify(
-    const typename JSON::Object &document,
-    std::basic_ostream<typename JSON::Char, typename JSON::CharTraits> &stream,
-    const std::size_t indentation, const std::size_t indent_by) -> void {
-  stream.put(internal::token_object_begin<typename JSON::Char>);
+auto prettify(const typename JSON::Object &document,
+              std::basic_ostream<JSON::Char, JSON::CharTraits> &stream,
+              const std::size_t indentation, const std::size_t indent_by)
+    -> void {
+  stream.put(internal::TOKEN_OBJECT_BEGIN<JSON::Char>);
 
   const auto end{std::cend(document)};
   for (auto iterator = std::cbegin(document); iterator != end; ++iterator) {
-    stream.put(internal::token_whitespace_line_feed<typename JSON::Char>);
+    stream.put(internal::TOKEN_WHITESPACE_LINE_FEED<JSON::Char>);
     internal::indent(stream, indentation + 1, indent_by);
     const auto current_position{stream.tellp()};
     stringify<Allocator>(iterator->first, stream);
-    stream.put(internal::token_object_key_delimiter<typename JSON::Char>);
-    stream.put(internal::token_whitespace_space<typename JSON::Char>);
+    stream.put(internal::TOKEN_OBJECT_KEY_DELIMITER<JSON::Char>);
+    stream.put(internal::TOKEN_WHITESPACE_SPACE<JSON::Char>);
     prettify<Allocator>(
         iterator->second, stream, indentation + 1, indent_by,
         // Pass the length of the property name as encoded in JSON
         // to help determine the actual current column
         static_cast<std::size_t>(stream.tellp() - current_position));
     if (std::next(iterator) == end) {
-      stream.put(internal::token_whitespace_line_feed<typename JSON::Char>);
+      stream.put(internal::TOKEN_WHITESPACE_LINE_FEED<JSON::Char>);
     } else {
-      stream.put(internal::token_object_delimiter<typename JSON::Char>);
+      stream.put(internal::TOKEN_OBJECT_DELIMITER<JSON::Char>);
     }
   }
 
@@ -533,13 +517,12 @@ auto prettify(
     internal::indent(stream, indentation, indent_by);
   }
 
-  stream.put(internal::token_object_end<typename JSON::Char>);
+  stream.put(internal::TOKEN_OBJECT_END<JSON::Char>);
 }
 
 template <template <typename T> typename Allocator>
-auto stringify(
-    const JSON &document,
-    std::basic_ostream<typename JSON::Char, typename JSON::CharTraits> &stream)
+auto stringify(const JSON &document,
+               std::basic_ostream<JSON::Char, JSON::CharTraits> &stream)
     -> void {
   switch (document.type()) {
     case JSON::Type::Null:
@@ -575,11 +558,11 @@ auto stringify(
 // TODO: Get rid of unused Allocator templates in this file
 
 template <template <typename T> typename Allocator>
-auto prettify(
-    const JSON &document,
-    std::basic_ostream<typename JSON::Char, typename JSON::CharTraits> &stream,
-    const std::size_t indentation = 0, const std::size_t indent_by = 2,
-    const std::size_t property_size = 0) -> void {
+auto prettify(const JSON &document,
+              std::basic_ostream<JSON::Char, JSON::CharTraits> &stream,
+              const std::size_t indentation = 0,
+              const std::size_t indent_by = 2,
+              const std::size_t property_size = 0) -> void {
   switch (document.type()) {
     case JSON::Type::Null:
       stringify<Allocator>(nullptr, stream);

--- a/src/core/jsonl/grammar.h
+++ b/src/core/jsonl/grammar.h
@@ -3,7 +3,7 @@
 
 namespace sourcemeta::core::internal {
 template <typename CharT>
-static constexpr CharT token_jsonl_line_feed{'\u000A'};
+static constexpr CharT TOKEN_JSONL_LINE_FEED{'\u000A'};
 
 // Whitespace is any sequence of one or more of the following code points:
 // character tabulation (U+0009), line feed (U+000A), carriage return (U+000D),
@@ -11,11 +11,11 @@ static constexpr CharT token_jsonl_line_feed{'\u000A'};
 // See
 // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
 template <typename CharT>
-static constexpr CharT token_jsonl_whitespace_tabulation{'\u0009'};
+static constexpr CharT TOKEN_JSONL_WHITESPACE_TABULATION{'\u0009'};
 template <typename CharT>
-static constexpr CharT token_jsonl_whitespace_carriage_return{'\u000D'};
+static constexpr CharT TOKEN_JSONL_WHITESPACE_CARRIAGE_RETURN{'\u000D'};
 template <typename CharT>
-static constexpr CharT token_jsonl_whitespace_space{'\u0020'};
+static constexpr CharT TOKEN_JSONL_WHITESPACE_SPACE{'\u0020'};
 
 } // namespace sourcemeta::core::internal
 

--- a/src/core/jsonl/include/sourcemeta/core/jsonl.h
+++ b/src/core/jsonl/include/sourcemeta/core/jsonl.h
@@ -67,7 +67,7 @@ public:
   /// ```
   ///
   /// If parsing fails, sourcemeta::core::JSONParseError will be thrown.
-  JSONL(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
+  JSONL(std::basic_istream<JSON::Char, JSON::CharTraits> &input,
         Mode mode = Mode::Raw);
   ~JSONL();
 
@@ -89,9 +89,9 @@ private:
 #if defined(_MSC_VER)
 #pragma warning(disable : 4251)
 #endif
-  std::basic_istream<JSON::Char, JSON::CharTraits> *stream;
+  std::basic_istream<JSON::Char, JSON::CharTraits> *stream_;
   struct Internal;
-  std::unique_ptr<Internal> internal;
+  std::unique_ptr<Internal> internal_;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251)
 #endif

--- a/src/core/jsonl/include/sourcemeta/core/jsonl_iterator.h
+++ b/src/core/jsonl/include/sourcemeta/core/jsonl_iterator.h
@@ -40,10 +40,10 @@ public:
       -> bool;
 
 private:
-  std::uint64_t line{0};
-  std::uint64_t column{0};
+  std::uint64_t line_{0};
+  std::uint64_t column_{0};
   auto parse_next() -> JSON;
-  std::basic_istream<JSON::Char, JSON::CharTraits> *data{};
+  std::basic_istream<JSON::Char, JSON::CharTraits> *data_{};
 
 // Exporting symbols that depends on the standard C++ library is considered
 // safe.
@@ -54,7 +54,7 @@ private:
   // Use PIMPL idiom to hide internal details, mainly
   // templated members, which are tricky to DLL-export.
   struct Internal;
-  std::unique_ptr<Internal> internal{};
+  std::unique_ptr<Internal> internal_{};
 #if defined(_MSC_VER)
 #pragma warning(default : 4251)
 #endif

--- a/src/core/jsonl/iterator.cc
+++ b/src/core/jsonl/iterator.cc
@@ -23,25 +23,25 @@ auto ConstJSONLIterator::parse_next() -> JSON {
   // Each line in a JSONL stream is a complete JSON value.
   // See https://jsonlines.org
   std::basic_string<JSON::Char, JSON::CharTraits> row;
-  while (this->data && std::getline(*this->data, row)) {
-    this->line += 1;
-    this->column = 0;
+  while ((this->data_ != nullptr) && std::getline(*this->data_, row)) {
+    this->line_ += 1;
+    this->column_ = 0;
 
     // Strip trailing carriage return for \r\n line endings
     if (!row.empty() &&
         row.back() ==
-            internal::token_jsonl_whitespace_carriage_return<JSON::Char>) {
+            internal::TOKEN_JSONL_WHITESPACE_CARRIAGE_RETURN<JSON::Char>) {
       row.pop_back();
     }
 
     // Skip whitespace-only lines
     bool has_content{false};
     for (const auto character : row) {
-      if (character != internal::token_jsonl_whitespace_space<JSON::Char> &&
+      if (character != internal::TOKEN_JSONL_WHITESPACE_SPACE<JSON::Char> &&
           character !=
-              internal::token_jsonl_whitespace_tabulation<JSON::Char> &&
+              internal::TOKEN_JSONL_WHITESPACE_TABULATION<JSON::Char> &&
           character !=
-              internal::token_jsonl_whitespace_carriage_return<JSON::Char>) {
+              internal::TOKEN_JSONL_WHITESPACE_CARRIAGE_RETURN<JSON::Char>) {
         has_content = true;
         break;
       }
@@ -51,31 +51,31 @@ auto ConstJSONLIterator::parse_next() -> JSON {
       continue;
     }
 
-    auto result{parse_json(row, this->line, this->column)};
+    auto result{parse_json(row, this->line_, this->column_)};
 
     // Verify that the remainder of the line is only whitespace
-    for (auto index{static_cast<std::size_t>(this->column)}; index < row.size();
-         ++index) {
-      if (row[index] != internal::token_jsonl_whitespace_space<JSON::Char> &&
+    for (auto index{static_cast<std::size_t>(this->column_)};
+         index < row.size(); ++index) {
+      if (row[index] != internal::TOKEN_JSONL_WHITESPACE_SPACE<JSON::Char> &&
           row[index] !=
-              internal::token_jsonl_whitespace_tabulation<JSON::Char> &&
+              internal::TOKEN_JSONL_WHITESPACE_TABULATION<JSON::Char> &&
           row[index] !=
-              internal::token_jsonl_whitespace_carriage_return<JSON::Char>) {
-        this->column = static_cast<std::uint64_t>(index) + 1;
-        throw JSONParseError(this->line, this->column);
+              internal::TOKEN_JSONL_WHITESPACE_CARRIAGE_RETURN<JSON::Char>) {
+        this->column_ = static_cast<std::uint64_t>(index) + 1;
+        throw JSONParseError(this->line_, this->column_);
       }
     }
 
     return result;
   }
 
-  this->data = nullptr;
+  this->data_ = nullptr;
   return JSON{nullptr};
 }
 
 auto ConstJSONLIterator::operator++() -> ConstJSONLIterator & {
-  assert(this->data);
-  this->internal->current = this->parse_next();
+  assert(this->data_);
+  this->internal_->current = this->parse_next();
   return *this;
 }
 
@@ -85,25 +85,25 @@ auto ConstJSONLIterator::operator++() -> ConstJSONLIterator & {
 
 ConstJSONLIterator::ConstJSONLIterator(
     std::basic_istream<JSON::Char, JSON::CharTraits> *stream)
-    : data{stream}, internal{new Internal({this->parse_next()})} {}
+    : data_{stream}, internal_{new Internal({this->parse_next()})} {}
 
 ConstJSONLIterator::~ConstJSONLIterator() = default;
 
 auto operator==(const ConstJSONLIterator &left, const ConstJSONLIterator &right)
     -> bool {
-  return (!left.data && !right.data) ||
-         (left.data && right.data &&
-          left.internal->current == right.internal->current);
+  return ((left.data_ == nullptr) && (right.data_ == nullptr)) ||
+         ((left.data_ != nullptr) && (right.data_ != nullptr) &&
+          left.internal_->current == right.internal_->current);
 };
 
 auto ConstJSONLIterator::operator*() const -> ConstJSONLIterator::reference {
-  assert(this->data);
-  return this->internal->current;
+  assert(this->data_);
+  return this->internal_->current;
 }
 
 auto ConstJSONLIterator::operator->() const -> ConstJSONLIterator::pointer {
-  assert(this->data);
-  return &(this->internal->current);
+  assert(this->data_);
+  return &(this->internal_->current);
 }
 
 } // namespace sourcemeta::core

--- a/src/core/jsonl/jsonl.cc
+++ b/src/core/jsonl/jsonl.cc
@@ -14,21 +14,21 @@ struct JSONL::Internal {
 
 JSONL::JSONL(std::basic_istream<JSON::Char, JSON::CharTraits> &input,
              const Mode mode)
-    : stream{&input}, internal{std::make_unique<Internal>()} {
+    : stream_{&input}, internal_{std::make_unique<Internal>()} {
   if (mode == Mode::GZIP) {
-    this->internal->streambuf = std::make_unique<GZIPStreamBuffer>(input);
-    this->internal->decompressed_stream =
-        std::make_unique<std::istream>(this->internal->streambuf.get());
-    this->internal->decompressed_stream->exceptions(std::istream::badbit);
-    this->stream = this->internal->decompressed_stream.get();
+    this->internal_->streambuf = std::make_unique<GZIPStreamBuffer>(input);
+    this->internal_->decompressed_stream =
+        std::make_unique<std::istream>(this->internal_->streambuf.get());
+    this->internal_->decompressed_stream->exceptions(std::istream::badbit);
+    this->stream_ = this->internal_->decompressed_stream.get();
   }
 }
 
 JSONL::~JSONL() = default;
 
-auto JSONL::begin() -> JSONL::const_iterator { return {this->stream}; }
+auto JSONL::begin() -> JSONL::const_iterator { return {this->stream_}; }
 auto JSONL::end() -> JSONL::const_iterator { return {nullptr}; }
-auto JSONL::cbegin() -> JSONL::const_iterator { return {this->stream}; }
+auto JSONL::cbegin() -> JSONL::const_iterator { return {this->stream_}; }
 auto JSONL::cend() -> JSONL::const_iterator { return {nullptr}; }
 
 } // namespace sourcemeta::core

--- a/src/core/jsonld/jsonld.cc
+++ b/src/core/jsonld/jsonld.cc
@@ -16,7 +16,7 @@ namespace sourcemeta::core {
 auto run_expansion(ExpansionState &state, ActiveContext &active_context,
                    const JSON &input) -> JSON {
   auto expanded{
-      expand(state, active_context, std::nullopt, input, empty_weak_pointer)};
+      expand(state, active_context, std::nullopt, input, EMPTY_WEAK_POINTER)};
 
   // A top-level map containing only @graph is replaced by its value.
   if (expanded.is_object() && expanded.object_size() == 1 &&
@@ -83,7 +83,7 @@ auto jsonld_expand(const JSON &input, const JSON &expand_context,
           : expand_context};
   // The external expansion context is not part of the input document, so its
   // errors carry an empty pointer.
-  process_context(state, active_context, context, empty_weak_pointer);
+  process_context(state, active_context, context, EMPTY_WEAK_POINTER);
   return run_expansion(state, active_context, input);
 }
 
@@ -105,7 +105,7 @@ auto jsonld_compact(const JSON &input, const JSON &context,
               context.defines(KEYWORD_CONTEXT, KEYWORD_CONTEXT_HASH)
           ? context.at(KEYWORD_CONTEXT, KEYWORD_CONTEXT_HASH)
           : context};
-  process_context(state, active_context, local_context, empty_weak_pointer);
+  process_context(state, active_context, local_context, EMPTY_WEAK_POINTER);
 
   const auto inverse_context{create_inverse_context(active_context)};
   auto result{compact(state, active_context, inverse_context, std::nullopt,

--- a/src/core/jsonld/jsonld_algorithms.h
+++ b/src/core/jsonld/jsonld_algorithms.h
@@ -77,7 +77,7 @@ struct ExpansionState {
   // cannot overflow the stack on attacker-controlled input. The bound is
   // conservative so that it holds on platforms with a small default stack such
   // as Windows, and is still far above any realistic nesting
-  static constexpr std::size_t maximum_depth{100};
+  static constexpr std::size_t MAXIMUM_DEPTH{100};
   std::size_t depth{0};
 
   // Used to load remote contexts. The chain detects recursive inclusion.

--- a/src/core/jsonld/jsonld_compaction.cc
+++ b/src/core/jsonld/jsonld_compaction.cc
@@ -86,7 +86,7 @@ auto nest_target(JSON &result, const TermDefinition *const definition,
     if (iterator == active_context.terms.cend() ||
         !iterator->second.iri.has_value() ||
         iterator->second.iri.value() != KEYWORD_NEST) {
-      throw JSONLDError("Invalid @nest value", empty_weak_pointer);
+      throw JSONLDError("Invalid @nest value", EMPTY_WEAK_POINTER);
     }
   }
   if (!result.defines(key)) {
@@ -105,8 +105,8 @@ auto compact(ExpansionState &state, const ActiveContext &active_context,
              const std::optional<JSON::String> &active_property,
              const JSON &element, const bool compact_arrays) -> JSON {
   const NestingDepthScope scope{state.depth};
-  if (state.depth > ExpansionState::maximum_depth) {
-    throw JSONLDError("Maximum nesting depth exceeded", empty_weak_pointer);
+  if (state.depth > ExpansionState::MAXIMUM_DEPTH) {
+    throw JSONLDError("Maximum nesting depth exceeded", EMPTY_WEAK_POINTER);
   }
 
   if (!element.is_object() && !element.is_array()) {
@@ -172,7 +172,7 @@ auto compact(ExpansionState &state, const ActiveContext &active_context,
     const bool saved_context_protected{state.context_protected};
     state.protected_override = true;
     process_context(state, scoped, scoped_definition->context.value(),
-                    empty_weak_pointer);
+                    EMPTY_WEAK_POINTER);
     state.protected_override = saved_override;
     state.context_protected = saved_context_protected;
     scoped_inverse = create_inverse_context(scoped);
@@ -228,7 +228,7 @@ auto compact(ExpansionState &state, const ActiveContext &active_context,
       if (iterator != context.terms.cend() &&
           iterator->second.context.has_value()) {
         process_context(state, typed, iterator->second.context.value(),
-                        empty_weak_pointer, false);
+                        EMPTY_WEAK_POINTER, false);
         typed_changed = true;
       }
     }
@@ -446,7 +446,7 @@ auto compact(ExpansionState &state, const ActiveContext &active_context,
             if (member.is_object() &&
                 member.defines(KEYWORD_LIST, KEYWORD_LIST_HASH)) {
               throw JSONLDError("Compaction to list of lists",
-                                empty_weak_pointer);
+                                EMPTY_WEAK_POINTER);
             }
           }
         }

--- a/src/core/jsonld/jsonld_context_processing.cc
+++ b/src/core/jsonld/jsonld_context_processing.cc
@@ -221,13 +221,12 @@ auto process_context(ExpansionState &state, ActiveContext &active_context,
       } else {
         const auto &vocabulary_string{vocabulary.to_string()};
         // In 1.0, @vocab must be an absolute IRI or blank node identifier.
-        if (state.processing_1_0 &&
-            vocabulary_string.find(':') == JSON::String::npos) {
+        if (state.processing_1_0 && !vocabulary_string.contains(':')) {
           throw JSONLDError("Invalid vocab mapping", location, {KEYWORD_VOCAB});
         }
         active_context.vocabulary =
             expand_iri(state, active_context, vocabulary_string, true, true,
-                       nullptr, nullptr, empty_weak_pointer);
+                       nullptr, nullptr, EMPTY_WEAK_POINTER);
       }
     }
 

--- a/src/core/jsonld/jsonld_create_term_definition.cc
+++ b/src/core/jsonld/jsonld_create_term_definition.cc
@@ -197,9 +197,9 @@ auto create_term_definition(ExpansionState &state,
         } else {
           definition.iri = term;
         }
-      } else if (term.find('/') != JSON::String::npos) {
+      } else if (term.contains('/')) {
         definition.iri = expand_iri(state, active_context, term, false, true,
-                                    nullptr, nullptr, empty_weak_pointer);
+                                    nullptr, nullptr, EMPTY_WEAK_POINTER);
       } else if (active_context.vocabulary.has_value()) {
         definition.iri = active_context.vocabulary.value() + term;
       }
@@ -213,11 +213,11 @@ auto create_term_definition(ExpansionState &state,
         const bool iri_like_colon{colon_position != JSON::String::npos &&
                                   colon_position != 0 &&
                                   colon_position + 1 != term.size()};
-        if (iri_like_colon || term.find('/') != JSON::String::npos) {
+        if (iri_like_colon || term.contains('/')) {
           auto probe{active_context};
           const auto expanded_term{expand_iri(state, probe, term, false, true,
                                               nullptr, nullptr,
-                                              empty_weak_pointer)};
+                                              EMPTY_WEAK_POINTER)};
           if (expanded_term.has_value() && expanded_term != definition.iri) {
             throw JSONLDError("Invalid IRI mapping", term_pointer);
           }
@@ -226,7 +226,7 @@ auto create_term_definition(ExpansionState &state,
     }
   } else if (value.is_object()) {
     const bool has_id{id_entry != nullptr};
-    const JSON *const id{id_entry};
+    const JSON *const identifier{id_entry};
     if (const auto *reverse_entry{
             value.try_at(KEYWORD_REVERSE, KEYWORD_REVERSE_HASH)}) {
       if (has_id || value.defines(KEYWORD_NEST, KEYWORD_NEST_HASH)) {
@@ -247,16 +247,16 @@ auto create_term_definition(ExpansionState &state,
         defined[term] = true;
         return;
       }
-      if (definition.iri.value().find(':') == JSON::String::npos) {
+      if (!definition.iri.value().contains(':')) {
         throw JSONLDError("Invalid IRI mapping", term_pointer,
                           {KEYWORD_REVERSE});
       }
-    } else if (has_id && !id->is_null() &&
-               (!id->is_string() || id->to_string() != term)) {
-      if (!id->is_string()) {
+    } else if (has_id && !identifier->is_null() &&
+               (!identifier->is_string() || identifier->to_string() != term)) {
+      if (!identifier->is_string()) {
         throw JSONLDError("Invalid IRI mapping", term_pointer, {KEYWORD_ID});
       }
-      const auto &id_value{id->to_string()};
+      const auto &id_value{identifier->to_string()};
       if (!is_keyword(id_value) && has_keyword_form(id_value)) {
         defined[term] = true;
         return;
@@ -265,8 +265,7 @@ auto create_term_definition(ExpansionState &state,
                                   &local_context, &defined, context_pointer);
       const auto &mapping{definition.iri};
       if (!mapping.has_value() ||
-          (!is_keyword(mapping.value()) &&
-           mapping.value().find(':') == JSON::String::npos &&
+          (!is_keyword(mapping.value()) && !mapping.value().contains(':') &&
            !active_context.vocabulary.has_value())) {
         throw JSONLDError("Invalid IRI mapping", term_pointer, {KEYWORD_ID});
       }
@@ -280,18 +279,18 @@ auto create_term_definition(ExpansionState &state,
         const bool iri_like_colon{colon_position != JSON::String::npos &&
                                   colon_position != 0 &&
                                   colon_position + 1 != term.size()};
-        if (iri_like_colon || term.find('/') != JSON::String::npos) {
+        if (iri_like_colon || term.contains('/')) {
           auto probe{active_context};
           const auto expanded_term{expand_iri(state, probe, term, false, true,
                                               nullptr, nullptr,
-                                              empty_weak_pointer)};
+                                              EMPTY_WEAK_POINTER)};
           if (expanded_term.has_value() && expanded_term != mapping) {
             throw JSONLDError("Invalid IRI mapping", term_pointer,
                               {KEYWORD_ID});
           }
         }
       }
-    } else if (term.find(':') != JSON::String::npos && !term.starts_with(':') &&
+    } else if (term.contains(':') && !term.starts_with(':') &&
                !term.ends_with(':')) {
       const auto colon{term.find(':')};
       const auto prefix{term.substr(0, colon)};
@@ -311,9 +310,9 @@ auto create_term_definition(ExpansionState &state,
       } else {
         definition.iri = term;
       }
-    } else if (term.find('/') != JSON::String::npos) {
+    } else if (term.contains('/')) {
       definition.iri = expand_iri(state, active_context, term, false, true,
-                                  nullptr, nullptr, empty_weak_pointer);
+                                  nullptr, nullptr, EMPTY_WEAK_POINTER);
     } else if (active_context.vocabulary.has_value()) {
       definition.iri = active_context.vocabulary.value() + term;
     }
@@ -329,7 +328,7 @@ auto create_term_definition(ExpansionState &state,
       if (!type.has_value() || type.value().starts_with("_:") ||
           (type.value() != KEYWORD_ID && type.value() != KEYWORD_VOCAB &&
            type.value() != KEYWORD_JSON && type.value() != KEYWORD_NONE &&
-           type.value().find(':') == JSON::String::npos) ||
+           !type.value().contains(':')) ||
           (state.processing_1_0 &&
            (type.value() == KEYWORD_JSON || type.value() == KEYWORD_NONE))) {
         throw JSONLDError("Invalid type mapping", term_pointer, {KEYWORD_TYPE});
@@ -490,7 +489,7 @@ auto create_term_definition(ExpansionState &state,
         // not matter.
         ActiveContext probe{active_context};
         state.protected_override = true;
-        process_context(state, probe, *context_entry, empty_weak_pointer);
+        process_context(state, probe, *context_entry, EMPTY_WEAK_POINTER);
         state.protected_override = saved_override;
         state.context_protected = saved_context_protected;
       } catch (const JSONLDError &error) {
@@ -514,8 +513,7 @@ auto create_term_definition(ExpansionState &state,
     if (const auto *prefix_entry{
             value.try_at(KEYWORD_PREFIX, KEYWORD_PREFIX_HASH)};
         prefix_entry != nullptr && !definition.reverse) {
-      if (state.processing_1_0 || term.find(':') != JSON::String::npos ||
-          term.find('/') != JSON::String::npos) {
+      if (state.processing_1_0 || term.contains(':') || term.contains('/')) {
         throw JSONLDError("Invalid term definition", term_pointer,
                           {KEYWORD_PREFIX});
       }
@@ -610,8 +608,8 @@ auto create_term_definition(ExpansionState &state,
     throw JSONLDError("Invalid term definition", term_pointer);
   }
 
-  if (simple_term && term.find(':') == JSON::String::npos &&
-      term.find('/') == JSON::String::npos && definition.iri.has_value() &&
+  if (simple_term && !term.contains(':') && !term.contains('/') &&
+      definition.iri.has_value() &&
       (ends_with_gen_delim(definition.iri.value()) ||
        definition.iri.value().starts_with("_:"))) {
     definition.prefix = true;

--- a/src/core/jsonld/jsonld_expansion.cc
+++ b/src/core/jsonld/jsonld_expansion.cc
@@ -67,7 +67,7 @@ auto expand_type(ExpansionState &state, const ActiveContext &type_context,
                  const JSON &item) -> JSON {
   auto context{type_context};
   const auto type{expand_iri(state, context, item.to_string(), true, true,
-                             nullptr, nullptr, empty_weak_pointer)};
+                             nullptr, nullptr, EMPTY_WEAK_POINTER)};
   return type.has_value() ? JSON{type.value()} : JSON{nullptr};
 }
 
@@ -95,7 +95,7 @@ auto expand_object(ExpansionState &state, ActiveContext active_context,
   std::vector<JSON::StringView> type_values;
   for (const auto &entry : element.as_object()) {
     const auto expanded{expand_iri(state, active_context, entry.first, false,
-                                   true, nullptr, nullptr, empty_weak_pointer)};
+                                   true, nullptr, nullptr, EMPTY_WEAK_POINTER)};
     if (!expanded.has_value() || expanded.value() != KEYWORD_TYPE) {
       continue;
     }
@@ -164,7 +164,7 @@ auto expand_object(ExpansionState &state, ActiveContext active_context,
       throw JSONLDError("Invalid language-tagged value", pointer);
     }
     if (has_type && (type_string == nullptr || type_string->starts_with("_:") ||
-                     type_string->find(' ') != JSON::String::npos)) {
+                     type_string->contains(' '))) {
       throw JSONLDError("Invalid typed value", pointer);
     }
     if (!is_json && !content.is_string() && !content.is_number() &&
@@ -247,7 +247,7 @@ auto expand_entries(ExpansionState &state, ActiveContext &active_context,
 
     const auto expanded_property{expand_iri(state, active_context, property,
                                             false, true, nullptr, nullptr,
-                                            empty_weak_pointer)};
+                                            EMPTY_WEAK_POINTER)};
 
     if (expanded_property.has_value() &&
         expanded_property.value() == KEYWORD_NEST) {
@@ -272,7 +272,7 @@ auto expand_entries(ExpansionState &state, ActiveContext &active_context,
     }
 
     const auto &name{expanded_property.value()};
-    if (name.find(':') == JSON::String::npos && !is_keyword(name)) {
+    if (!name.contains(':') && !is_keyword(name)) {
       continue;
     }
 
@@ -295,7 +295,7 @@ auto expand_entries(ExpansionState &state, ActiveContext &active_context,
       }
       const auto identifier{expand_iri(state, active_context,
                                        entry.second.to_string(), true, false,
-                                       nullptr, nullptr, empty_weak_pointer)};
+                                       nullptr, nullptr, EMPTY_WEAK_POINTER)};
       if (identifier.has_value()) {
         result.assign_assume_new(JSON::String{KEYWORD_ID},
                                  JSON{identifier.value()}, KEYWORD_ID_HASH);
@@ -463,7 +463,7 @@ auto expand_entries(ExpansionState &state, ActiveContext &active_context,
         for (const auto &reverse_entry : reversed.as_object()) {
           const auto &reverse_property{reverse_entry.first};
           if (reverse_entry.key_equals(KEYWORD_REVERSE, KEYWORD_REVERSE_HASH)) {
-            for (auto &forward : reverse_entry.second.as_object()) {
+            for (const auto &forward : reverse_entry.second.as_object()) {
               merge(result, JSON::StringView{forward.first},
                     into_array(JSON{forward.second}));
             }
@@ -542,7 +542,7 @@ auto expand_entries(ExpansionState &state, ActiveContext &active_context,
       if (property_valued) {
         index_property =
             expand_iri(state, value_context, definition->index.value(), false,
-                       true, nullptr, nullptr, empty_weak_pointer);
+                       true, nullptr, nullptr, EMPTY_WEAK_POINTER);
       }
       expanded_value = JSON::make_array();
       for (const auto &[graph_key, graph_value] :
@@ -552,7 +552,7 @@ auto expand_entries(ExpansionState &state, ActiveContext &active_context,
                                     ? std::optional<JSON::String>{KEYWORD_NONE}
                                     : expand_iri(state, value_context, index,
                                                  true, false, nullptr, nullptr,
-                                                 empty_weak_pointer)};
+                                                 EMPTY_WEAK_POINTER)};
         const bool none_key{expanded_key.has_value() &&
                             expanded_key.value() == KEYWORD_NONE};
         auto graph_items{
@@ -603,7 +603,7 @@ auto expand_entries(ExpansionState &state, ActiveContext &active_context,
         const JSON::String &language{*language_key};
         const auto expanded_language{expand_iri(state, value_context, language,
                                                 false, true, nullptr, nullptr,
-                                                empty_weak_pointer)};
+                                                EMPTY_WEAK_POINTER)};
         const bool is_none{language == KEYWORD_NONE ||
                            (expanded_language.has_value() &&
                             expanded_language.value() == KEYWORD_NONE)};
@@ -642,7 +642,7 @@ auto expand_entries(ExpansionState &state, ActiveContext &active_context,
       if (property_valued) {
         index_property =
             expand_iri(state, value_context, definition->index.value(), false,
-                       true, nullptr, nullptr, empty_weak_pointer);
+                       true, nullptr, nullptr, EMPTY_WEAK_POINTER);
       }
       expanded_value = JSON::make_array();
       for (const auto &[index_key, index_value] :
@@ -688,7 +688,7 @@ auto expand_entries(ExpansionState &state, ActiveContext &active_context,
         if (index != KEYWORD_NONE) {
           expanded_index =
               expand_iri(state, value_context, index, by_id, !by_id, nullptr,
-                         nullptr, empty_weak_pointer);
+                         nullptr, EMPTY_WEAK_POINTER);
         }
         // The key may be an alias of @none, which carries no identifier.
         if (expanded_index.has_value() &&
@@ -730,7 +730,7 @@ auto expand_entries(ExpansionState &state, ActiveContext &active_context,
             const auto &raw_string{raw.to_string()};
             const auto referenced{expand_iri(state, value_context, raw_string,
                                              true, reference_vocab, nullptr,
-                                             nullptr, empty_weak_pointer)};
+                                             nullptr, EMPTY_WEAK_POINTER)};
             reference.assign_assume_new(JSON::String{KEYWORD_ID},
                                         JSON{referenced.value_or(raw_string)},
                                         KEYWORD_ID_HASH);
@@ -872,7 +872,7 @@ auto expand(ExpansionState &state, ActiveContext &active_context,
             const std::optional<JSON::String> &active_property,
             const JSON &element, const WeakPointer &pointer) -> JSON {
   const NestingDepthScope scope{state.depth};
-  if (state.depth > ExpansionState::maximum_depth) {
+  if (state.depth > ExpansionState::MAXIMUM_DEPTH) {
     throw JSONLDError("Maximum nesting depth exceeded", pointer);
   }
 
@@ -940,7 +940,7 @@ auto expand(ExpansionState &state, ActiveContext &active_context,
     for (const auto &entry : element.as_object()) {
       const auto expanded{expand_iri(state, active_context, entry.first, false,
                                      true, nullptr, nullptr,
-                                     empty_weak_pointer)};
+                                     EMPTY_WEAK_POINTER)};
       if (expanded.has_value() &&
           (expanded.value() == KEYWORD_VALUE ||
            (single && expanded.value() == KEYWORD_ID))) {

--- a/src/core/jsonld/jsonld_flatten.cc
+++ b/src/core/jsonld/jsonld_flatten.cc
@@ -59,8 +59,8 @@ auto flatten(BlankNodeState &state, const JSON &element) -> JSON {
 
     auto graph_array{JSON::make_array()};
     const auto &graph{node_map.at(graph_name)};
-    for (const auto &id : sorted_ids(graph)) {
-      const auto &node{graph.at(id)};
+    for (const auto &identifier : sorted_ids(graph)) {
+      const auto &node{graph.at(identifier)};
       if (!is_reference_only(node)) {
         graph_array.push_back(node);
       }
@@ -70,8 +70,8 @@ auto flatten(BlankNodeState &state, const JSON &element) -> JSON {
   }
 
   auto flattened{JSON::make_array()};
-  for (const auto &id : sorted_ids(default_graph)) {
-    const auto &node{default_graph.at(id)};
+  for (const auto &identifier : sorted_ids(default_graph)) {
+    const auto &node{default_graph.at(identifier)};
     if (!is_reference_only(node)) {
       flattened.push_back(node);
     }

--- a/src/core/jsonld/jsonld_iri_compaction.cc
+++ b/src/core/jsonld/jsonld_iri_compaction.cc
@@ -403,7 +403,7 @@ auto compact_iri(const ActiveContext &active_context,
     const auto scheme{variable.substr(0, colon)};
     const auto iterator{active_context.terms.find(scheme)};
     if (iterator != active_context.terms.cend() && iterator->second.prefix) {
-      throw JSONLDError("IRI confused with prefix", empty_weak_pointer);
+      throw JSONLDError("IRI confused with prefix", EMPTY_WEAK_POINTER);
     }
   }
 

--- a/src/core/jsonld/jsonld_keywords.h
+++ b/src/core/jsonld/jsonld_keywords.h
@@ -79,8 +79,8 @@ inline constexpr auto KEYWORD_DEFAULT_HASH{JSON::Object::hash(KEYWORD_DEFAULT)};
 // token. (A namespace-scope JSON::String constant would trip clang-tidy's
 // throwing-static-initialization check, hence the function-local static.)
 inline auto keyword_context() -> const JSON::String & {
-  static const JSON::String value{KEYWORD_CONTEXT};
-  return value;
+  static const JSON::String VALUE{KEYWORD_CONTEXT};
+  return VALUE;
 }
 
 inline auto is_keyword(const JSON::StringView value) -> bool {

--- a/src/core/jsonld/jsonld_materialize.cc
+++ b/src/core/jsonld/jsonld_materialize.cc
@@ -25,8 +25,8 @@ using AnnotationIndex = std::vector<const JSONLDBasicAnnotation<PointerT> *>;
 // A contiguous run of sorted annotations whose positions are all extensions
 // of, or equal to, the position currently being visited
 template <typename PointerT> struct AnnotationRange {
-  typename AnnotationIndex<PointerT>::const_iterator begin;
-  typename AnnotationIndex<PointerT>::const_iterator end;
+  AnnotationIndex<PointerT>::const_iterator begin;
+  AnnotationIndex<PointerT>::const_iterator end;
 };
 
 // The sub-run of annotations that belong to the child position the pointer
@@ -108,7 +108,7 @@ auto types_to_array(const std::vector<JSON::String> &types) -> JSON {
 // The property array of node under the given predicate, creating it as needed.
 auto property_target(JSON &node, const JSON::StringView predicate) -> JSON & {
   const auto hash{node.as_object().hash(predicate)};
-  const auto existing{node.try_at(predicate, hash)};
+  auto *const existing{node.try_at(predicate, hash)};
   if (existing != nullptr) {
     return *existing;
   }
@@ -118,7 +118,7 @@ auto property_target(JSON &node, const JSON::StringView predicate) -> JSON & {
 
 // The property array nested under @reverse and the given predicate.
 auto reverse_target(JSON &node, const JSON::StringView predicate) -> JSON & {
-  const auto existing{node.try_at(KEYWORD_REVERSE, KEYWORD_REVERSE_HASH)};
+  auto *const existing{node.try_at(KEYWORD_REVERSE, KEYWORD_REVERSE_HASH)};
   auto &reverse{existing != nullptr
                     ? *existing
                     : node.assign_assume_new(JSON::String{KEYWORD_REVERSE},

--- a/src/core/jsonld/jsonld_node_map.cc
+++ b/src/core/jsonld/jsonld_node_map.cc
@@ -137,36 +137,37 @@ auto generate_node_map(BlankNodeState &state, JSON &node_map,
   }
 
   // A node object.
-  std::optional<JSON::String> id;
+  std::optional<JSON::String> identifier;
   if (working.defines(KEYWORD_ID, KEYWORD_ID_HASH)) {
     const auto &id_value{working.at(KEYWORD_ID, KEYWORD_ID_HASH)};
     if (id_value.is_string()) {
-      id = is_blank_node(id_value.to_string())
-               ? generate_blank_node_identifier(state, id_value.to_string())
-               : id_value.to_string();
+      identifier =
+          is_blank_node(id_value.to_string())
+              ? generate_blank_node_identifier(state, id_value.to_string())
+              : id_value.to_string();
     }
     working.erase(KEYWORD_ID);
   }
-  if (!id.has_value()) {
-    id = generate_blank_node_identifier(state, std::nullopt);
+  if (!identifier.has_value()) {
+    identifier = generate_blank_node_identifier(state, std::nullopt);
   }
 
-  if (!node_map.at(active_graph).defines(id.value())) {
+  if (!node_map.at(active_graph).defines(identifier.value())) {
     auto node{JSON::make_object()};
-    node.assign_assume_new(JSON::String{KEYWORD_ID}, JSON{id.value()},
+    node.assign_assume_new(JSON::String{KEYWORD_ID}, JSON{identifier.value()},
                            KEYWORD_ID_HASH);
     node_map.at(active_graph)
-        .assign_assume_new(JSON::String{id.value()}, std::move(node));
+        .assign_assume_new(JSON::String{identifier.value()}, std::move(node));
   }
 
   if (active_subject != nullptr && active_subject->is_object()) {
     // A reverse relationship wires the referenced subject into this node.
-    add_unique(node_map.at(active_graph).at(id.value()),
+    add_unique(node_map.at(active_graph).at(identifier.value()),
                active_property.value(), *active_subject);
   } else if (active_property.has_value()) {
     auto reference{JSON::make_object()};
-    reference.assign_assume_new(JSON::String{KEYWORD_ID}, JSON{id.value()},
-                                KEYWORD_ID_HASH);
+    reference.assign_assume_new(JSON::String{KEYWORD_ID},
+                                JSON{identifier.value()}, KEYWORD_ID_HASH);
     if (list == nullptr) {
       add_unique(node_map.at(active_graph).at(active_subject->to_string()),
                  active_property.value(), std::move(reference));
@@ -176,7 +177,7 @@ auto generate_node_map(BlankNodeState &state, JSON &node_map,
   }
 
   if (working.defines(KEYWORD_TYPE, KEYWORD_TYPE_HASH)) {
-    auto &node{node_map.at(active_graph).at(id.value())};
+    auto &node{node_map.at(active_graph).at(identifier.value())};
     if (!node.defines(KEYWORD_TYPE, KEYWORD_TYPE_HASH)) {
       node.assign_assume_new(JSON::String{KEYWORD_TYPE}, JSON::make_array(),
                              KEYWORD_TYPE_HASH);
@@ -199,11 +200,11 @@ auto generate_node_map(BlankNodeState &state, JSON &node_map,
   }
 
   if (working.defines(KEYWORD_INDEX, KEYWORD_INDEX_HASH)) {
-    auto &node{node_map.at(active_graph).at(id.value())};
+    auto &node{node_map.at(active_graph).at(identifier.value())};
     const auto &index_value{working.at(KEYWORD_INDEX, KEYWORD_INDEX_HASH)};
     if (node.defines(KEYWORD_INDEX, KEYWORD_INDEX_HASH) &&
         node.at(KEYWORD_INDEX, KEYWORD_INDEX_HASH) != index_value) {
-      throw JSONLDError("Conflicting indexes", empty_weak_pointer);
+      throw JSONLDError("Conflicting indexes", EMPTY_WEAK_POINTER);
     }
     node.assign(JSON::String{KEYWORD_INDEX}, JSON{index_value});
     working.erase(KEYWORD_INDEX);
@@ -211,8 +212,8 @@ auto generate_node_map(BlankNodeState &state, JSON &node_map,
 
   if (working.defines(KEYWORD_REVERSE, KEYWORD_REVERSE_HASH)) {
     auto referenced_node{JSON::make_object()};
-    referenced_node.assign_assume_new(JSON::String{KEYWORD_ID},
-                                      JSON{id.value()}, KEYWORD_ID_HASH);
+    referenced_node.assign_assume_new(
+        JSON::String{KEYWORD_ID}, JSON{identifier.value()}, KEYWORD_ID_HASH);
     for (const auto &entry :
          working.at(KEYWORD_REVERSE, KEYWORD_REVERSE_HASH).as_object()) {
       for (const auto &value : entry.second.as_array()) {
@@ -225,8 +226,8 @@ auto generate_node_map(BlankNodeState &state, JSON &node_map,
 
   if (working.defines(KEYWORD_GRAPH, KEYWORD_GRAPH_HASH)) {
     generate_node_map(state, node_map,
-                      working.at(KEYWORD_GRAPH, KEYWORD_GRAPH_HASH), id.value(),
-                      nullptr, std::nullopt, nullptr);
+                      working.at(KEYWORD_GRAPH, KEYWORD_GRAPH_HASH),
+                      identifier.value(), nullptr, std::nullopt, nullptr);
     working.erase(KEYWORD_GRAPH);
   }
 
@@ -243,12 +244,12 @@ auto generate_node_map(BlankNodeState &state, JSON &node_map,
     properties.push_back(entry.first);
   }
   std::ranges::sort(properties);
-  const JSON subject{id.value()};
+  const JSON subject{identifier.value()};
   for (const auto property : properties) {
     const JSON::String key{is_blank_node(property)
                                ? generate_blank_node_identifier(state, property)
                                : JSON::String{property}};
-    auto &node{node_map.at(active_graph).at(id.value())};
+    auto &node{node_map.at(active_graph).at(identifier.value())};
     if (!node.defines(key)) {
       node.assign_assume_new(JSON::String{key}, JSON::make_array());
     }

--- a/src/core/jsonld/jsonld_value_compaction.cc
+++ b/src/core/jsonld/jsonld_value_compaction.cc
@@ -76,7 +76,8 @@ auto compact_value(const ActiveContext &active_context,
 
     if (type_matches && index_ok) {
       return contents;
-    } else if (type_disabled) {
+    }
+    if (type_disabled) {
       // Value compaction is disabled, but the @type IRI is still compacted in
       // the full form below.
     } else if (!contents.is_string()) {

--- a/src/core/jsonld/jsonld_value_expansion.cc
+++ b/src/core/jsonld/jsonld_value_expansion.cc
@@ -23,7 +23,7 @@ auto expand_value(ExpansionState &state, ActiveContext &active_context,
       auto result{JSON::make_object()};
       const auto identifier{expand_iri(state, active_context, value.to_string(),
                                        true, false, nullptr, nullptr,
-                                       empty_weak_pointer)};
+                                       EMPTY_WEAK_POINTER)};
       result.assign_assume_new(JSON::String{KEYWORD_ID},
                                identifier.has_value() ? JSON{identifier.value()}
                                                       : JSON{nullptr},
@@ -34,7 +34,7 @@ auto expand_value(ExpansionState &state, ActiveContext &active_context,
       auto result{JSON::make_object()};
       const auto identifier{expand_iri(state, active_context, value.to_string(),
                                        true, true, nullptr, nullptr,
-                                       empty_weak_pointer)};
+                                       EMPTY_WEAK_POINTER)};
       result.assign_assume_new(JSON::String{KEYWORD_ID},
                                identifier.has_value() ? JSON{identifier.value()}
                                                       : JSON{nullptr},

--- a/src/core/jsonpointer/grammar.h
+++ b/src/core/jsonpointer/grammar.h
@@ -2,46 +2,46 @@
 #define SOURCEMETA_CORE_JSONPOINTER_GRAMMAR_H_
 
 namespace sourcemeta::core::internal {
-template <typename CharT> static constexpr CharT token_pointer_slash{'\u002F'};
-template <typename CharT> static constexpr CharT token_pointer_tilde{'\u007E'};
-template <typename CharT> static constexpr CharT token_pointer_zero{'\u0030'};
-template <typename CharT> static constexpr CharT token_pointer_one{'\u0031'};
-template <typename CharT> static constexpr CharT token_pointer_quote{'\u0022'};
+template <typename CharT> static constexpr CharT TOKEN_POINTER_SLASH{'\u002F'};
+template <typename CharT> static constexpr CharT TOKEN_POINTER_TILDE{'\u007E'};
+template <typename CharT> static constexpr CharT TOKEN_POINTER_ZERO{'\u0030'};
+template <typename CharT> static constexpr CharT TOKEN_POINTER_ONE{'\u0031'};
+template <typename CharT> static constexpr CharT TOKEN_POINTER_QUOTE{'\u0022'};
 template <typename CharT>
-static constexpr CharT token_pointer_escape_unicode{'\u0075'};
+static constexpr CharT TOKEN_POINTER_ESCAPE_UNICODE{'\u0075'};
 template <typename CharT>
-static constexpr CharT token_pointer_escape_backspace{'\u0062'};
+static constexpr CharT TOKEN_POINTER_ESCAPE_BACKSPACE{'\u0062'};
 template <typename CharT>
-static constexpr CharT token_pointer_escape_form_feed{'\u0066'};
+static constexpr CharT TOKEN_POINTER_ESCAPE_FORM_FEED{'\u0066'};
 template <typename CharT>
-static constexpr CharT token_pointer_escape_line_feed{'\u006E'};
+static constexpr CharT TOKEN_POINTER_ESCAPE_LINE_FEED{'\u006E'};
 template <typename CharT>
-static constexpr CharT token_pointer_escape_carriage_return{'\u0072'};
+static constexpr CharT TOKEN_POINTER_ESCAPE_CARRIAGE_RETURN{'\u0072'};
 template <typename CharT>
-static constexpr CharT token_pointer_escape_tab{'\u0074'};
+static constexpr CharT TOKEN_POINTER_ESCAPE_TAB{'\u0074'};
 template <typename CharT>
-static constexpr CharT token_pointer_reverse_solidus{'\u005C'};
+static constexpr CharT TOKEN_POINTER_REVERSE_SOLIDUS{'\u005C'};
 
 template <typename CharT>
-static constexpr CharT token_pointer_number_zero{'\u0030'};
+static constexpr CharT TOKEN_POINTER_NUMBER_ZERO{'\u0030'};
 template <typename CharT>
-static constexpr CharT token_pointer_number_one{'\u0031'};
+static constexpr CharT TOKEN_POINTER_NUMBER_ONE{'\u0031'};
 template <typename CharT>
-static constexpr CharT token_pointer_number_two{'\u0032'};
+static constexpr CharT TOKEN_POINTER_NUMBER_TWO{'\u0032'};
 template <typename CharT>
-static constexpr CharT token_pointer_number_three{'\u0033'};
+static constexpr CharT TOKEN_POINTER_NUMBER_THREE{'\u0033'};
 template <typename CharT>
-static constexpr CharT token_pointer_number_four{'\u0034'};
+static constexpr CharT TOKEN_POINTER_NUMBER_FOUR{'\u0034'};
 template <typename CharT>
-static constexpr CharT token_pointer_number_five{'\u0035'};
+static constexpr CharT TOKEN_POINTER_NUMBER_FIVE{'\u0035'};
 template <typename CharT>
-static constexpr CharT token_pointer_number_six{'\u0036'};
+static constexpr CharT TOKEN_POINTER_NUMBER_SIX{'\u0036'};
 template <typename CharT>
-static constexpr CharT token_pointer_number_seven{'\u0037'};
+static constexpr CharT TOKEN_POINTER_NUMBER_SEVEN{'\u0037'};
 template <typename CharT>
-static constexpr CharT token_pointer_number_eight{'\u0038'};
+static constexpr CharT TOKEN_POINTER_NUMBER_EIGHT{'\u0038'};
 template <typename CharT>
-static constexpr CharT token_pointer_number_nine{'\u0039'};
+static constexpr CharT TOKEN_POINTER_NUMBER_NINE{'\u0039'};
 } // namespace sourcemeta::core::internal
 
 #endif

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
@@ -47,11 +47,11 @@ using WeakPointer = GenericPointer<
 
 /// @ingroup jsonpointer
 /// A global constant instance of the empty JSON Pointer.
-const Pointer empty_pointer;
+const Pointer EMPTY_POINTER;
 
 /// @ingroup jsonpointer
 /// A global constant instance of the empty JSON WeakPointer.
-const WeakPointer empty_weak_pointer;
+const WeakPointer EMPTY_WEAK_POINTER;
 
 /// @ingroup jsonpointer
 /// Get a value from a JSON document using a JSON Pointer (`const` overload).

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
@@ -27,7 +27,7 @@ public:
   /// A single reference token within this pointer
   using Token = GenericToken<PropertyT, Hash>;
   /// The JSON value type used for serialisation
-  using Value = typename Token::Value;
+  using Value = Token::Value;
   /// The underlying sequence container of tokens
   using Container = std::vector<Token>;
 
@@ -40,7 +40,7 @@ public:
   /// const sourcemeta::core::Pointer pointer;
   /// assert(pointer.empty());
   /// ```
-  GenericPointer() noexcept : data{} {}
+  GenericPointer() noexcept : data_{} {}
 
   /// This constructor is the preferred way of creating a pointer.
   /// For example:
@@ -54,61 +54,61 @@ public:
   /// assert(pointer.size() == 3);
   /// ```
   GenericPointer(std::initializer_list<Token> tokens)
-      : data{std::move(tokens)} {}
+      : data_{std::move(tokens)} {}
 
   // Member types
-  using value_type = typename Container::value_type;
-  using allocator_type = typename Container::allocator_type;
-  using size_type = typename Container::size_type;
-  using difference_type = typename Container::difference_type;
-  using reference = typename Container::reference;
-  using const_reference = typename Container::const_reference;
-  using pointer = typename Container::pointer;
-  using const_pointer = typename Container::const_pointer;
-  using iterator = typename Container::iterator;
-  using const_iterator = typename Container::const_iterator;
-  using reverse_iterator = typename Container::reverse_iterator;
-  using const_reverse_iterator = typename Container::const_reverse_iterator;
+  using value_type = Container::value_type;
+  using allocator_type = Container::allocator_type;
+  using size_type = Container::size_type;
+  using difference_type = Container::difference_type;
+  using reference = Container::reference;
+  using const_reference = Container::const_reference;
+  using pointer = Container::pointer;
+  using const_pointer = Container::const_pointer;
+  using iterator = Container::iterator;
+  using const_iterator = Container::const_iterator;
+  using reverse_iterator = Container::reverse_iterator;
+  using const_reverse_iterator = Container::const_reverse_iterator;
 
   /// Get a mutable begin iterator on the pointer
-  auto begin() noexcept -> iterator { return this->data.begin(); }
+  auto begin() noexcept -> iterator { return this->data_.begin(); }
   /// Get a mutable end iterator on the pointer
-  auto end() noexcept -> iterator { return this->data.end(); }
+  auto end() noexcept -> iterator { return this->data_.end(); }
   /// Get a constant begin iterator on the pointer
   [[nodiscard]] auto begin() const noexcept -> const_iterator {
-    return this->data.begin();
+    return this->data_.begin();
   }
   /// Get a constant end iterator on the pointer
   [[nodiscard]] auto end() const noexcept -> const_iterator {
-    return this->data.end();
+    return this->data_.end();
   }
   /// Get a constant begin iterator on the pointer
   [[nodiscard]] auto cbegin() const noexcept -> const_iterator {
-    return this->data.cbegin();
+    return this->data_.cbegin();
   }
   /// Get a constant end iterator on the pointer
   [[nodiscard]] auto cend() const noexcept -> const_iterator {
-    return this->data.cend();
+    return this->data_.cend();
   }
   /// Get a mutable reverse begin iterator on the pointer
-  auto rbegin() noexcept -> reverse_iterator { return this->data.rbegin(); }
+  auto rbegin() noexcept -> reverse_iterator { return this->data_.rbegin(); }
   /// Get a mutable reverse end iterator on the pointer
-  auto rend() noexcept -> reverse_iterator { return this->data.rend(); }
+  auto rend() noexcept -> reverse_iterator { return this->data_.rend(); }
   /// Get a constant reverse begin iterator on the pointer
   [[nodiscard]] auto rbegin() const noexcept -> const_reverse_iterator {
-    return this->data.rbegin();
+    return this->data_.rbegin();
   }
   /// Get a constant reverse end iterator on the pointer
   [[nodiscard]] auto rend() const noexcept -> const_reverse_iterator {
-    return this->data.rend();
+    return this->data_.rend();
   }
   /// Get a constant reverse begin iterator on the pointer
   [[nodiscard]] auto crbegin() const noexcept -> const_reverse_iterator {
-    return this->data.crbegin();
+    return this->data_.crbegin();
   }
   /// Get a constant reverse end iterator on the pointer
   [[nodiscard]] auto crend() const noexcept -> const_reverse_iterator {
-    return this->data.crend();
+    return this->data_.crend();
   }
 
   /// Access a token in a JSON Pointer at a given index.
@@ -124,7 +124,7 @@ public:
   /// ```
   [[nodiscard]] auto at(const size_type index) const -> const_reference {
     assert(this->size() > index);
-    return this->data[index];
+    return this->data_[index];
   }
 
   /// Access the last token in a JSON Pointer
@@ -140,7 +140,7 @@ public:
   /// ```
   [[nodiscard]] SOURCEMETA_FORCEINLINE auto back() const -> const_reference {
     assert(!this->empty());
-    return this->data.back();
+    return this->data_.back();
   }
 
   /// Get the number of tokens in a JSON Pointer.
@@ -154,7 +154,7 @@ public:
   /// assert(pointer.size() == 2);
   /// ```
   [[nodiscard]] SOURCEMETA_FORCEINLINE auto size() const noexcept -> size_type {
-    return this->data.size();
+    return this->data_.size();
   }
 
   /// Check if a JSON Pointer is the empty pointer.
@@ -170,7 +170,7 @@ public:
   /// assert(!non_empty_pointer.empty());
   /// ```
   [[nodiscard]] SOURCEMETA_FORCEINLINE auto empty() const noexcept -> bool {
-    return this->data.empty();
+    return this->data_.empty();
   }
 
   /// Emplace a token into the back of a JSON Pointer.
@@ -188,7 +188,7 @@ public:
   /// ```
   template <class... Args>
   SOURCEMETA_FORCEINLINE auto emplace_back(Args &&...args) -> reference {
-    return this->data.emplace_back(std::forward<Args>(args)...);
+    return this->data_.emplace_back(std::forward<Args>(args)...);
   }
 
   /// Reserve capacity for a JSON Pointer. For example:
@@ -199,8 +199,8 @@ public:
   /// sourcemeta::core::Pointer pointer;
   /// pointer.reserve(1024);
   /// ```
-  auto reserve(const typename Container::size_type capacity) -> void {
-    this->data.reserve(capacity);
+  auto reserve(const Container::size_type capacity) -> void {
+    this->data_.reserve(capacity);
   }
 
   /// Push a copy of a JSON Pointer into the back of a JSON Pointer.
@@ -227,15 +227,16 @@ public:
   push_back(const GenericPointer<PropertyT, Hash> &other) -> void {
     if (other.empty()) {
       return;
-    } else if (other.size() == 1) {
+    }
+    if (other.size() == 1) {
       this->emplace_back(other.back());
       return;
     }
 
-    this->reserve(this->data.size() + other.size());
+    this->reserve(this->data_.size() + other.size());
 // TODO: Remove once GitHub Actions ship proper C++23 support
 #if __cpp_lib_containers_ranges >= 202202L
-    this->data.append_range(other.data);
+    this->data_.append_range(other.data_);
 #else
     std::copy(other.data.cbegin(), other.data.cend(),
               std::back_inserter(this->data));
@@ -266,14 +267,15 @@ public:
       -> void {
     if (other.empty()) {
       return;
-    } else if (other.size() == 1) {
+    }
+    if (other.size() == 1) {
       this->emplace_back(std::move(other.back()));
       return;
     }
 
-    this->reserve(this->data.size() + other.size());
-    std::move(other.data.begin(), other.data.end(),
-              std::back_inserter(this->data));
+    this->reserve(this->data_.size() + other.size());
+    std::move(other.data_.begin(), other.data_.end(),
+              std::back_inserter(this->data_));
   }
 
   /// Push a JSON Pointer into the back of a JSON WeakPointer. Make sure that
@@ -305,22 +307,23 @@ public:
   {
     if (other.empty()) {
       return;
-    } else if (other.size() == 1) {
+    }
+    if (other.size() == 1) {
       const auto &token{other.back()};
       if (token.is_property()) {
         // We should make sure to re-use the existing hash
-        this->data.emplace_back(token.to_property(), token.property_hash());
+        this->data_.emplace_back(token.to_property(), token.property_hash());
       } else {
-        this->data.emplace_back(token.to_index());
+        this->data_.emplace_back(token.to_index());
       }
     } else {
-      this->reserve(this->data.size() + other.size());
+      this->reserve(this->data_.size() + other.size());
       for (const auto &token : other) {
         if (token.is_property()) {
           // We should make sure to re-use the existing hash
-          this->data.emplace_back(token.to_property(), token.property_hash());
+          this->data_.emplace_back(token.to_property(), token.property_hash());
         } else {
-          this->data.emplace_back(token.to_index());
+          this->data_.emplace_back(token.to_index());
         }
       }
     }
@@ -344,9 +347,9 @@ public:
   /// assert(pointer.at(0).to_property() == "foo");
   /// assert(pointer.at(1).to_property() == "bar");
   /// ```
-  SOURCEMETA_FORCEINLINE auto
-  push_back(const typename Token::Property &property) -> void {
-    this->data.emplace_back(property);
+  SOURCEMETA_FORCEINLINE auto push_back(const Token::Property &property)
+      -> void {
+    this->data_.emplace_back(property);
   }
 
   /// Move a property token into the back of a JSON Pointer.
@@ -366,9 +369,8 @@ public:
   /// assert(pointer.at(0).to_property() == "foo");
   /// assert(pointer.at(1).to_property() == "bar");
   /// ```
-  SOURCEMETA_FORCEINLINE auto push_back(typename Token::Property &&property)
-      -> void {
-    this->data.emplace_back(std::move(property));
+  SOURCEMETA_FORCEINLINE auto push_back(Token::Property &&property) -> void {
+    this->data_.emplace_back(std::move(property));
   }
 
   /// Push an index token into the back of a JSON Pointer.
@@ -389,9 +391,8 @@ public:
   /// assert(pointer.at(0).to_property() == "foo");
   /// assert(pointer.at(1).to_index() == 0);
   /// ```
-  SOURCEMETA_FORCEINLINE auto push_back(const typename Token::Index &index)
-      -> void {
-    this->data.emplace_back(index);
+  SOURCEMETA_FORCEINLINE auto push_back(const Token::Index &index) -> void {
+    this->data_.emplace_back(index);
   }
 
   /// Remove the last token of a JSON Pointer. For example:
@@ -408,7 +409,7 @@ public:
   /// ```
   auto pop_back() -> void {
     assert(!this->empty());
-    this->data.pop_back();
+    this->data_.pop_back();
   }
 
   /// Remove a number of tokens from the back of a JSON Pointer. For example:
@@ -426,7 +427,7 @@ public:
   auto pop_back(const size_type count) -> void {
     assert(this->size() >= count);
     for (std::size_t index = 0; index < count; index++) {
-      this->data.pop_back();
+      this->data_.pop_back();
     }
   }
 
@@ -471,14 +472,14 @@ public:
   [[nodiscard]] auto slice(const std::size_t index) const
       -> GenericPointer<PropertyT, Hash> {
     assert(index <= this->size());
-    auto new_begin{this->data.cbegin()};
+    auto new_begin{this->data_.cbegin()};
     std::advance(new_begin, index);
     GenericPointer<PropertyT, Hash> result;
     result.reserve(this->size() - index);
 // TODO: Remove once GitHub Actions ship proper C++23 support
 #if __cpp_lib_containers_ranges >= 202202L
-    result.data.append_range(
-        std::ranges::subrange(new_begin, this->data.cend()));
+    result.data_.append_range(
+        std::ranges::subrange(new_begin, this->data_.cend()));
 #else
     std::copy(new_begin, this->data.cend(), std::back_inserter(result.data));
 #endif
@@ -506,15 +507,15 @@ public:
       -> GenericPointer<PropertyT, Hash> {
     assert(start <= end);
     assert(end <= this->size());
-    auto new_begin{this->data.cbegin()};
+    auto new_begin{this->data_.cbegin()};
     std::advance(new_begin, start);
-    auto new_end{this->data.cbegin()};
+    auto new_end{this->data_.cbegin()};
     std::advance(new_end, end);
     GenericPointer<PropertyT, Hash> result;
     result.reserve(end - start);
 // TODO: Remove once GitHub Actions ship proper C++23 support
 #if __cpp_lib_containers_ranges >= 202202L
-    result.data.append_range(std::ranges::subrange(new_begin, new_end));
+    result.data_.append_range(std::ranges::subrange(new_begin, new_end));
 #else
     std::copy(new_begin, new_end, std::back_inserter(result.data));
 #endif
@@ -550,7 +551,7 @@ public:
   /// const sourcemeta::core::Pointer pointer{"foo"};
   /// assert(pointer.concat("bar") == sourcemeta::core::Pointer{"foo", "bar"});
   /// ```
-  [[nodiscard]] auto concat(const typename Token::Property &property) const
+  [[nodiscard]] auto concat(const Token::Property &property) const
       -> GenericPointer<PropertyT, Hash> {
     GenericPointer<PropertyT, Hash> result{*this};
     result.push_back(property);
@@ -567,7 +568,7 @@ public:
   /// const sourcemeta::core::Pointer pointer{"foo"};
   /// assert(pointer.concat(0) == sourcemeta::core::Pointer{"foo", 0});
   /// ```
-  [[nodiscard]] auto concat(const typename Token::Index &index) const
+  [[nodiscard]] auto concat(const Token::Index &index) const
       -> GenericPointer<PropertyT, Hash> {
     GenericPointer<PropertyT, Hash> result{*this};
     result.push_back(index);
@@ -587,9 +588,9 @@ public:
   /// ```
   [[nodiscard]] auto
   starts_with(const GenericPointer<PropertyT, Hash> &other) const -> bool {
-    return other.data.size() <= this->data.size() &&
-           std::equal(other.data.cbegin(), other.data.cend(),
-                      this->data.cbegin());
+    return other.data_.size() <= this->data_.size() &&
+           std::equal(other.data_.cbegin(), other.data_.cend(),
+                      this->data_.cbegin());
   }
 
   /// Check whether a JSON Pointer plus a given tail starts with another JSON
@@ -609,9 +610,8 @@ public:
     if (other.size() == this->size() + 1) {
       assert(!other.empty());
       return other.starts_with(*this) && other.back() == tail;
-    } else {
-      return this->starts_with(other);
     }
+    return this->starts_with(other);
   }
 
   /// Check whether a JSON Pointer starts with another JSON Pointer followed
@@ -633,8 +633,8 @@ public:
                                  const StringT &tail) const -> bool {
     const auto prefix_size{other.size()};
     return this->size() > prefix_size && this->starts_with(other) &&
-           this->data[prefix_size].is_property() &&
-           this->data[prefix_size].to_property() == tail;
+           this->data_[prefix_size].is_property() &&
+           this->data_[prefix_size].to_property() == tail;
   }
 
   /// Check whether a JSON Pointer starts with another JSON Pointer followed
@@ -659,8 +659,8 @@ public:
     const auto prefix_size{other.size()};
     return this->size() > prefix_size + 1 &&
            this->starts_with(other, tail_left) &&
-           this->data[prefix_size + 1].is_property() &&
-           this->data[prefix_size + 1].to_property() == tail_right;
+           this->data_[prefix_size + 1].is_property() &&
+           this->data_[prefix_size + 1].to_property() == tail_right;
   }
 
   /// Check whether two JSON Pointers are equal up to a given number of
@@ -677,12 +677,12 @@ public:
   /// ```
   [[nodiscard]] auto shares_prefix(const GenericPointer<PropertyT, Hash> &other,
                                    const size_type prefix_size) const -> bool {
-    return this->data.size() >= prefix_size &&
-           other.data.size() >= prefix_size &&
-           std::equal(this->data.cbegin(),
-                      std::next(this->data.cbegin(),
+    return this->data_.size() >= prefix_size &&
+           other.data_.size() >= prefix_size &&
+           std::equal(this->data_.cbegin(),
+                      std::next(this->data_.cbegin(),
                                 static_cast<difference_type>(prefix_size)),
-                      other.data.cbegin());
+                      other.data_.cbegin());
   }
 
   /// Check whether a JSON Pointer starts with another JSON Pointer without
@@ -700,8 +700,8 @@ public:
   [[nodiscard]] auto
   starts_with_strict(const GenericPointer<PropertyT, Hash> &other) const
       -> bool {
-    return this->data.size() > other.data.size() &&
-           this->shares_prefix(other, other.data.size());
+    return this->data_.size() > other.data_.size() &&
+           this->shares_prefix(other, other.data_.size());
   }
 
   /// Check whether a JSON Pointer starts with the initial part of another JSON
@@ -721,12 +721,13 @@ public:
     const auto prefix_size{other.size()};
     if (prefix_size == 0) {
       return true;
-    } else if (this->size() < prefix_size - 1) {
+    }
+    if (this->size() < prefix_size - 1) {
       return false;
     }
 
     for (std::size_t index = 0; index < prefix_size - 1; index++) {
-      if (this->data[index] != other.data[index]) {
+      if (this->data_[index] != other.data_[index]) {
         return false;
       }
     }
@@ -753,22 +754,21 @@ public:
       -> GenericPointer<PropertyT, Hash> {
     typename Container::size_type index{0};
     while (index < prefix.size()) {
-      if (index >= this->size() || prefix.data[index] != this->data[index]) {
+      if (index >= this->size() || prefix.data_[index] != this->data_[index]) {
         return *this;
-      } else {
-        index++;
       }
+      index++;
     }
 
     assert(index == prefix.size());
     assert(this->starts_with(prefix));
-    auto new_begin{this->data.cbegin()};
+    auto new_begin{this->data_.cbegin()};
     std::advance(new_begin, index);
     GenericPointer<PropertyT, Hash> result{replacement};
 // TODO: Remove once GitHub Actions ship proper C++23 support
 #if __cpp_lib_containers_ranges >= 202202L
-    result.data.append_range(
-        std::ranges::subrange(new_begin, this->data.cend()));
+    result.data_.append_range(
+        std::ranges::subrange(new_begin, this->data_.cend()));
 #else
     std::copy(new_begin, this->data.cend(), std::back_inserter(result.data));
 #endif
@@ -798,24 +798,23 @@ public:
 
     typename Container::size_type index{0};
     while (index < base.size()) {
-      if (index >= this->size() || base.data[index] != this->data[index]) {
+      if (index >= this->size() || base.data_[index] != this->data_[index]) {
         return *this;
-      } else {
-        index++;
       }
+      index++;
     }
 
     // Make a pointer from the remaining tokens
-    auto new_begin{this->data.cbegin()};
+    auto new_begin{this->data_.cbegin()};
     std::advance(new_begin, index);
     GenericPointer<PropertyT, Hash> result;
-    const auto remaining{static_cast<typename Container::size_type>(
-        this->data.cend() - new_begin)};
-    result.data.reserve(remaining);
+    const auto remaining{
+        static_cast<Container::size_type>(this->data_.cend() - new_begin)};
+    result.data_.reserve(remaining);
 // TODO: Remove once GitHub Actions ship proper C++23 support
 #if __cpp_lib_containers_ranges >= 202202L
-    result.data.append_range(
-        std::ranges::subrange(new_begin, this->data.cend()));
+    result.data_.append_range(
+        std::ranges::subrange(new_begin, this->data_.cend()));
 #else
     std::copy(new_begin, this->data.cend(), std::back_inserter(result.data));
 #endif
@@ -826,14 +825,14 @@ public:
   [[nodiscard]] auto
   operator==(const GenericPointer<PropertyT, Hash> &other) const noexcept
       -> bool {
-    return this->data == other.data;
+    return this->data_ == other.data_;
   }
 
   /// Compare with a reference wrapper
   [[nodiscard]] auto
   operator==(const std::reference_wrapper<const GenericPointer<PropertyT, Hash>>
                  &other) const noexcept -> bool {
-    return this->data == other.get().data;
+    return this->data_ == other.get().data;
   }
 
   /// Overload to support ordering of JSON Pointers. Typically for sorting
@@ -841,14 +840,14 @@ public:
   [[nodiscard]] auto
   operator<(const GenericPointer<PropertyT, Hash> &other) const noexcept
       -> bool {
-    return this->data < other.data;
+    return this->data_ < other.data_;
   }
 
   /// Compare with a reference wrapper for ordering
   [[nodiscard]] auto
   operator<(const std::reference_wrapper<const GenericPointer<PropertyT, Hash>>
                 &other) const noexcept -> bool {
-    return this->data < other.get().data;
+    return this->data_ < other.get().data;
   }
 
   /// Hash functor for use with containers
@@ -885,7 +884,7 @@ public:
   private:
     // Intentionally only fold hash.a for performance, as the first
     // 16 bytes already provide sufficient entropy for bucketing
-    static auto property_hash(const typename Hash::hash_type &hash) noexcept
+    static auto property_hash(const Hash::HashType &hash) noexcept
         -> std::size_t {
       return static_cast<std::size_t>(hash.a) ^
              static_cast<std::size_t>(hash.a >> 64);
@@ -928,7 +927,7 @@ public:
   /// Serialise a JSON Pointer as a JSON array of tokens
   [[nodiscard]] auto to_json() const -> Value {
     auto result{Value::make_array()};
-    for (const auto &token : this->data) {
+    for (const auto &token : this->data_) {
       result.push_back(token.to_json());
     }
 
@@ -949,8 +948,7 @@ public:
       if (element.is_string()) {
         result.emplace_back(element.to_string());
       } else if (element.is_integer() && element.to_integer() >= 0) {
-        result.emplace_back(
-            static_cast<typename Token::Index>(element.to_integer()));
+        result.emplace_back(static_cast<Token::Index>(element.to_integer()));
       } else {
         return std::nullopt;
       }
@@ -960,7 +958,7 @@ public:
   }
 
 private:
-  Container data;
+  Container data_;
 };
 
 } // namespace sourcemeta::core

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
@@ -238,8 +238,8 @@ public:
 #if __cpp_lib_containers_ranges >= 202202L
     this->data_.append_range(other.data_);
 #else
-    std::copy(other.data.cbegin(), other.data.cend(),
-              std::back_inserter(this->data));
+    std::copy(other.data_.cbegin(), other.data_.cend(),
+              std::back_inserter(this->data_));
 #endif
   }
 
@@ -481,7 +481,7 @@ public:
     result.data_.append_range(
         std::ranges::subrange(new_begin, this->data_.cend()));
 #else
-    std::copy(new_begin, this->data.cend(), std::back_inserter(result.data));
+    std::copy(new_begin, this->data_.cend(), std::back_inserter(result.data_));
 #endif
     return result;
   }
@@ -517,7 +517,7 @@ public:
 #if __cpp_lib_containers_ranges >= 202202L
     result.data_.append_range(std::ranges::subrange(new_begin, new_end));
 #else
-    std::copy(new_begin, new_end, std::back_inserter(result.data));
+    std::copy(new_begin, new_end, std::back_inserter(result.data_));
 #endif
     return result;
   }
@@ -770,7 +770,7 @@ public:
     result.data_.append_range(
         std::ranges::subrange(new_begin, this->data_.cend()));
 #else
-    std::copy(new_begin, this->data.cend(), std::back_inserter(result.data));
+    std::copy(new_begin, this->data_.cend(), std::back_inserter(result.data_));
 #endif
     return result;
   }
@@ -816,7 +816,7 @@ public:
     result.data_.append_range(
         std::ranges::subrange(new_begin, this->data_.cend()));
 #else
-    std::copy(new_begin, this->data.cend(), std::back_inserter(result.data));
+    std::copy(new_begin, this->data_.cend(), std::back_inserter(result.data_));
 #endif
     return result;
   }
@@ -832,7 +832,7 @@ public:
   [[nodiscard]] auto
   operator==(const std::reference_wrapper<const GenericPointer<PropertyT, Hash>>
                  &other) const noexcept -> bool {
-    return this->data_ == other.get().data;
+    return this->data_ == other.get().data_;
   }
 
   /// Overload to support ordering of JSON Pointers. Typically for sorting
@@ -847,7 +847,7 @@ public:
   [[nodiscard]] auto
   operator<(const std::reference_wrapper<const GenericPointer<PropertyT, Hash>>
                 &other) const noexcept -> bool {
-    return this->data_ < other.get().data;
+    return this->data_ < other.get().data_;
   }
 
   /// Hash functor for use with containers

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
@@ -55,7 +55,7 @@ public:
   /// The start and end line and column numbers of a value
   using Position =
       std::tuple<std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t>;
-  auto operator()(const JSON::ParsePhase phase, const JSON::Type,
+  auto operator()(const JSON::ParsePhase phase, const JSON::Type type,
                   const std::uint64_t line, const std::uint64_t column,
                   const JSON::ParseContext context, const std::size_t index,
                   const JSON::String &property) -> void;
@@ -91,9 +91,9 @@ private:
 #if defined(_MSC_VER)
 #pragma warning(disable : 4251)
 #endif
-  std::vector<Event> events;
-  mutable bool indexed{false};
-  mutable std::vector<TrieNode> trie;
+  std::vector<Event> events_;
+  mutable bool indexed_{false};
+  mutable std::vector<TrieNode> trie_;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251)
 #endif

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_token.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_token.h
@@ -114,7 +114,8 @@ public:
   /// const sourcemeta::core::Pointer::Token token{1};
   /// ```
   GenericToken(const unsigned long value)
-      : as_property{false}, property{DEFAULT_PROPERTY}, hash{0}, index{value} {}
+      : as_property_{false}, property_{DEFAULT_PROPERTY}, hash_{0},
+        index_{value} {}
 #endif
 
   /// Check if a JSON Pointer token represents an object property.

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_token.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_token.h
@@ -17,14 +17,14 @@ public:
   /// The stored type of an object property token
   using Property = PropertyT;
   /// The stored type of an array index token
-  using Index = typename Value::Array::size_type;
+  using Index = Value::Array::size_type;
 
   /// This constructor creates an JSON Pointer token from a string given its
   /// precomputed hash. This is advanced functionality that should be used with
   /// care.
-  GenericToken(Property value, const typename Hash::hash_type property_hash)
-      : as_property{true}, property{std::move(value)}, hash{property_hash},
-        index{0} {}
+  GenericToken(Property value, const Hash::HashType property_hash)
+      : as_property_{true}, property_{std::move(value)}, hash_{property_hash},
+        index_{0} {}
 
   /// This constructor creates an JSON Pointer token from a string. For
   /// example:
@@ -35,7 +35,7 @@ public:
   ///
   /// const sourcemeta::core::Pointer::Token token{"foo"};
   /// ```
-  GenericToken(const Property &value) : GenericToken{value, hasher(value)} {}
+  GenericToken(const Property &value) : GenericToken{value, HASHER(value)} {}
 
   /// This constructor creates an JSON Pointer token by taking ownership of a
   /// string. For example:
@@ -48,8 +48,8 @@ public:
   /// const sourcemeta::core::Pointer::Token token{std::move(name)};
   /// ```
   GenericToken(Property &&value)
-      : as_property{true}, property{std::move(value)}, hash{hasher(property)},
-        index{0} {}
+      : as_property_{true}, property_{std::move(value)},
+        hash_{HASHER(property_)}, index_{0} {}
 
   /// This constructor creates an JSON Pointer token from a string. For
   /// example:
@@ -61,7 +61,7 @@ public:
   /// const sourcemeta::core::Pointer::Token token{"foo"};
   /// ```
   GenericToken(const JSON::Char *const value)
-      : GenericToken{value, hasher(value)} {}
+      : GenericToken{value, HASHER(value)} {}
 
   /// This constructor creates an JSON Pointer token from a character. For
   /// example:
@@ -73,7 +73,7 @@ public:
   /// const sourcemeta::core::Pointer::Token token{'a'};
   /// ```
   GenericToken(const JSON::Char value)
-      : GenericToken{Property{value}, hasher(Property{value})} {}
+      : GenericToken{Property{value}, HASHER(Property{value})} {}
 
   /// This constructor creates an JSON Pointer token from an item index. For
   /// example:
@@ -85,7 +85,8 @@ public:
   /// const sourcemeta::core::Pointer::Token token{1};
   /// ```
   GenericToken(const Index value)
-      : as_property{false}, property{DEFAULT_PROPERTY}, hash{0}, index{value} {}
+      : as_property_{false}, property_{DEFAULT_PROPERTY}, hash_{0},
+        index_{value} {}
 
   /// This constructor creates an JSON Pointer token from an item index. For
   /// example:
@@ -97,8 +98,8 @@ public:
   /// const sourcemeta::core::Pointer::Token token{1};
   /// ```
   GenericToken(const int value)
-      : as_property{false}, property{DEFAULT_PROPERTY}, hash{0},
-        index{static_cast<Index>(value)} {
+      : as_property_{false}, property_{DEFAULT_PROPERTY}, hash_{0},
+        index_{static_cast<Index>(value)} {
     assert(value >= 0);
   }
 
@@ -127,7 +128,7 @@ public:
   /// assert(token.is_property());
   /// ```
   [[nodiscard]] auto is_property() const noexcept -> bool {
-    return this->as_property;
+    return this->as_property_;
   }
 
   /// Check if a JSON Pointer token represents the hyphen constant
@@ -143,8 +144,8 @@ public:
   /// assert(token_2.is_hyphen());
   /// ```
   [[nodiscard]] auto is_hyphen() const noexcept -> bool {
-    return this->as_property && this->property.size() == 1 &&
-           this->property.front() == '\u002D';
+    return this->as_property_ && this->property_.size() == 1 &&
+           this->property_.front() == '\u002D';
   }
 
   /// Check if a JSON Pointer token represents an array index.
@@ -158,7 +159,7 @@ public:
   /// assert(token.is_index());
   /// ```
   [[nodiscard]] auto is_index() const noexcept -> bool {
-    return !this->as_property;
+    return !this->as_property_;
   }
 
   /// Get the underlying value of a JSON Pointer object property token (`const`
@@ -174,10 +175,10 @@ public:
   /// ```
   [[nodiscard]] auto to_property() const noexcept -> const auto & {
     assert(this->is_property());
-    if constexpr (requires { this->property.get(); }) {
-      return this->property.get();
+    if constexpr (requires { this->property_.get(); }) {
+      return this->property_.get();
     } else {
-      return this->property;
+      return this->property_;
     }
   }
 
@@ -192,10 +193,9 @@ public:
   /// assert(token.is_property());
   /// assert(token.property_hash() >= 0);
   /// ```
-  [[nodiscard]] auto property_hash() const noexcept ->
-      typename Hash::hash_type {
+  [[nodiscard]] auto property_hash() const noexcept -> Hash::HashType {
     assert(this->is_property());
-    return this->hash;
+    return this->hash_;
   }
 
   /// Check whether a JSON Pointer property token equals the given string,
@@ -213,21 +213,20 @@ public:
   /// ```
   [[nodiscard]] auto
   property_equals(const JSON::StringView value,
-                  const typename Hash::hash_type value_hash) const noexcept
-      -> bool {
+                  const Hash::HashType value_hash) const noexcept -> bool {
     assert(this->is_property());
-    assert(hasher(value.data(), value.size()) == value_hash);
-    if constexpr (requires { hasher.is_perfect(value_hash); }) {
+    assert(HASHER(value.data(), value.size()) == value_hash);
+    if constexpr (requires { HASHER.is_perfect(value_hash); }) {
       // A perfect hash captures the property bytes but not its length, so
       // two properties that differ only by trailing NUL bytes hash equal.
       // Comparing sizes disambiguates them without the cost of a full
       // string comparison
-      return this->hash == value_hash &&
-             (hasher.is_perfect(value_hash)
+      return this->hash_ == value_hash &&
+             (HASHER.is_perfect(value_hash)
                   ? this->to_property().size() == value.size()
                   : this->to_property() == value);
     } else {
-      return this->hash == value_hash && this->to_property() == value;
+      return this->hash_ == value_hash && this->to_property() == value;
     }
   }
 
@@ -244,10 +243,10 @@ public:
   /// ```
   auto to_property() noexcept -> auto & {
     assert(this->is_property());
-    if constexpr (requires { this->property.get(); }) {
-      return this->property.get();
+    if constexpr (requires { this->property_.get(); }) {
+      return this->property_.get();
     } else {
-      return this->property;
+      return this->property_;
     }
   }
 
@@ -264,7 +263,7 @@ public:
   /// ```
   [[nodiscard]] auto to_index() const noexcept -> Index {
     assert(this->is_index());
-    return this->index;
+    return this->index_;
   }
 
   /// Convert a JSON Pointer token into a JSON document, whether it represents a
@@ -286,59 +285,59 @@ public:
   [[nodiscard]] auto to_json() const -> JSON {
     if (this->is_property()) {
       return JSON{this->to_property()};
-    } else {
-      return JSON{this->to_index()};
     }
+    return JSON{this->to_index()};
   }
 
   /// Compare JSON Pointer tokens
   auto operator==(const GenericToken<PropertyT, Hash> &other) const noexcept
       -> bool {
-    if (this->as_property != other.as_property) {
+    if (this->as_property_ != other.as_property_) {
       return false;
-    } else if (this->as_property) {
-      if constexpr (requires { hasher.is_perfect(this->hash); }) {
+    }
+    if (this->as_property_) {
+      if constexpr (requires { HASHER.is_perfect(this->hash_); }) {
         // A perfect hash captures the property bytes but not its length, so
         // two properties that differ only by trailing NUL bytes hash equal.
         // Comparing sizes disambiguates them without the cost of a full
         // string comparison
-        if (hasher.is_perfect(this->hash) && hasher.is_perfect(other.hash)) {
-          return this->hash == other.hash &&
+        if (HASHER.is_perfect(this->hash_) && HASHER.is_perfect(other.hash_)) {
+          return this->hash_ == other.hash_ &&
                  this->to_property().size() == other.to_property().size();
         }
       }
 
-      return this->hash == other.hash &&
+      return this->hash_ == other.hash_ &&
              this->to_property() == other.to_property();
-    } else {
-      return this->index == other.index;
     }
+    return this->index_ == other.index_;
   }
 
   /// Overload to support ordering of JSON Pointer tokens. Typically for sorting
   /// reasons.
   auto operator<(const GenericToken<PropertyT, Hash> &other) const noexcept
       -> bool {
-    if (this->as_property && !other.as_property) {
+    if (this->as_property_ && !other.as_property_) {
       return true;
-    } else if (!this->as_property && other.as_property) {
-      return false;
-    } else if (this->as_property) {
-      return this->to_property() < other.to_property();
-    } else {
-      return this->index < other.index;
     }
+    if (!this->as_property_ && other.as_property_) {
+      return false;
+    }
+    if (this->as_property_) {
+      return this->to_property() < other.to_property();
+    }
+    return this->index_ < other.index_;
   }
 
 private:
   // We need this as a member for making WeakPointer work
   inline static const Value::String DEFAULT_PROPERTY{};
-  inline static const Hash hasher;
+  inline static const Hash HASHER;
 
-  bool as_property;
-  Property property;
-  typename Hash::hash_type hash;
-  Index index;
+  bool as_property_;
+  Property property_;
+  Hash::HashType hash_;
+  Index index_;
 };
 
 } // namespace sourcemeta::core

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_walker.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_walker.h
@@ -15,7 +15,7 @@ namespace sourcemeta::core {
 /// ordering is guaranteed. If you expect any ordering, sort afterwards.
 template <typename PointerT> class GenericPointerWalker {
 private:
-  using internal = typename std::vector<PointerT>;
+  using internal = std::vector<PointerT>;
 
 public:
   /// Construct a walker over every location in a JSON document
@@ -24,18 +24,18 @@ public:
     this->walk(document, accumulator);
   }
 
-  using const_iterator = typename internal::const_iterator;
+  using const_iterator = internal::const_iterator;
   [[nodiscard]] auto begin() const -> const_iterator {
-    return this->pointers.begin();
+    return this->pointers_.begin();
   };
   [[nodiscard]] auto end() const -> const_iterator {
-    return this->pointers.end();
+    return this->pointers_.end();
   };
   [[nodiscard]] auto cbegin() const -> const_iterator {
-    return this->pointers.cbegin();
+    return this->pointers_.cbegin();
   };
   [[nodiscard]] auto cend() const -> const_iterator {
-    return this->pointers.cend();
+    return this->pointers_.cend();
   };
 
 private:
@@ -68,7 +68,7 @@ private:
 
       std::reverse(pending.begin() + static_cast<std::ptrdiff_t>(start),
                    pending.end());
-      this->pointers.push_back(std::move(entry.second));
+      this->pointers_.push_back(std::move(entry.second));
     }
   }
 
@@ -78,7 +78,7 @@ private:
 #if defined(_MSC_VER)
 #pragma warning(disable : 4251)
 #endif
-  internal pointers;
+  internal pointers_;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251)
 #endif

--- a/src/core/jsonpointer/jsonpointer.cc
+++ b/src/core/jsonpointer/jsonpointer.cc
@@ -194,26 +194,23 @@ auto try_get(const JSON &document, const WeakPointer &pointer) -> const JSON * {
 auto get(const JSON &document, const Pointer::Token &token) -> const JSON & {
   if (token.is_property()) {
     return document.at(token.to_property());
-  } else {
-    return document.at(token.to_index());
   }
+  return document.at(token.to_index());
 }
 
 auto get(const JSON &document, const WeakPointer::Token &token)
     -> const JSON & {
   if (token.is_property()) {
     return document.at(token.to_property());
-  } else {
-    return document.at(token.to_index());
   }
+  return document.at(token.to_index());
 }
 
 auto get(JSON &document, const Pointer::Token &token) -> JSON & {
   if (token.is_property()) {
     return document.at(token.to_property());
-  } else {
-    return document.at(token.to_index());
   }
+  return document.at(token.to_index());
 }
 
 auto set(JSON &document, const Pointer &pointer, const JSON &value) -> void {
@@ -290,25 +287,23 @@ auto remove_pointer(JSON &document, const PointerT &pointer) -> bool {
   if (last.is_property()) {
     const auto current_size{current.size()};
     return current.erase(last.to_property()) < current_size;
-  } else {
-    if (current.is_object()) {
-      DigitsBuffer buffer;
-      const auto current_size{current.size()};
-      return current.erase(digits_view(last.to_index(), buffer)) < current_size;
-    } else {
-      const auto index{last.to_index()};
-      const auto &array{current.as_array()};
-
-      if (index >= array.size()) {
-        return false;
-      }
-
-      auto iterator{array.cbegin()};
-      std::advance(iterator, index);
-      current.erase(iterator);
-      return true;
-    }
   }
+  if (current.is_object()) {
+    DigitsBuffer buffer;
+    const auto current_size{current.size()};
+    return current.erase(digits_view(last.to_index(), buffer)) < current_size;
+  }
+  const auto index{last.to_index()};
+  const auto &array{current.as_array()};
+
+  if (index >= array.size()) {
+    return false;
+  }
+
+  auto iterator{array.cbegin()};
+  std::advance(iterator, index);
+  current.erase(iterator);
+  return true;
 }
 
 auto remove(JSON &document, const Pointer &pointer) -> bool {
@@ -366,7 +361,8 @@ auto fragment_to_pointer(const URI &uri) -> std::optional<Pointer> {
 
   if (input.empty()) {
     return Pointer{};
-  } else if (input.front() != '/') {
+  }
+  if (input.front() != '/') {
     return std::nullopt;
   }
 

--- a/src/core/jsonpointer/parser.h
+++ b/src/core/jsonpointer/parser.h
@@ -83,7 +83,7 @@ parse_token_begin:
   // by a '/' (%x2F) character.
   // See https://www.rfc-editor.org/rfc/rfc6901#section-3
   switch (character) {
-    case internal::token_pointer_slash<JSON::Char>:
+    case internal::TOKEN_POINTER_SLASH<JSON::Char>:
       goto parse_token_content;
     default:
       throw PointerParseError(column);
@@ -103,31 +103,31 @@ parse_token_content:
   switch (character) {
       // Note that leading zeros are not allowed
       // See https://www.rfc-editor.org/rfc/rfc6901#section-4
-    case internal::token_pointer_number_zero<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_ZERO<JSON::Char>:
       column += 1;
       stream.ignore();
       goto parse_token_index_end;
-    case internal::token_pointer_number_one<JSON::Char>:
-    case internal::token_pointer_number_two<JSON::Char>:
-    case internal::token_pointer_number_three<JSON::Char>:
-    case internal::token_pointer_number_four<JSON::Char>:
-    case internal::token_pointer_number_five<JSON::Char>:
-    case internal::token_pointer_number_six<JSON::Char>:
-    case internal::token_pointer_number_seven<JSON::Char>:
-    case internal::token_pointer_number_eight<JSON::Char>:
-    case internal::token_pointer_number_nine<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_ONE<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_TWO<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_THREE<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_FOUR<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_FIVE<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_SIX<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_SEVEN<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_EIGHT<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_NINE<JSON::Char>:
       column += 1;
       stream.ignore();
       if constexpr (!CheckOnly) {
         string.put(character);
       }
       goto parse_token_index_rest_any;
-    case internal::token_pointer_slash<JSON::Char>:
+    case internal::TOKEN_POINTER_SLASH<JSON::Char>:
       if constexpr (!CheckOnly) {
         result.emplace_back("");
       }
       goto parse_token_begin;
-    case internal::token_pointer_tilde<JSON::Char>:
+    case internal::TOKEN_POINTER_TILDE<JSON::Char>:
       column += 1;
       stream.ignore();
       goto parse_token_escape_tilde;
@@ -160,7 +160,7 @@ parse_token_index_end:
   }
   character = JSON::CharTraits::to_char_type(code);
   switch (character) {
-    case internal::token_pointer_slash<JSON::Char>:
+    case internal::TOKEN_POINTER_SLASH<JSON::Char>:
       column += 1;
       stream.ignore();
       if constexpr (!CheckOnly) {
@@ -185,7 +185,7 @@ parse_token_index_rest_any:
   }
   character = JSON::CharTraits::to_char_type(code);
   switch (character) {
-    case internal::token_pointer_slash<JSON::Char>:
+    case internal::TOKEN_POINTER_SLASH<JSON::Char>:
       column += 1;
       stream.ignore();
       if constexpr (!CheckOnly) {
@@ -193,16 +193,16 @@ parse_token_index_rest_any:
         internal::reset(string);
       }
       goto parse_token_content;
-    case internal::token_pointer_number_zero<JSON::Char>:
-    case internal::token_pointer_number_one<JSON::Char>:
-    case internal::token_pointer_number_two<JSON::Char>:
-    case internal::token_pointer_number_three<JSON::Char>:
-    case internal::token_pointer_number_four<JSON::Char>:
-    case internal::token_pointer_number_five<JSON::Char>:
-    case internal::token_pointer_number_six<JSON::Char>:
-    case internal::token_pointer_number_seven<JSON::Char>:
-    case internal::token_pointer_number_eight<JSON::Char>:
-    case internal::token_pointer_number_nine<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_ZERO<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_ONE<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_TWO<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_THREE<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_FOUR<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_FIVE<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_SIX<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_SEVEN<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_EIGHT<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_NINE<JSON::Char>:
       column += 1;
       stream.ignore();
       if constexpr (!CheckOnly) {
@@ -230,13 +230,13 @@ parse_token_property_rest_any:
   }
   character = JSON::CharTraits::to_char_type(code);
   switch (character) {
-    case internal::token_pointer_slash<JSON::Char>:
+    case internal::TOKEN_POINTER_SLASH<JSON::Char>:
       if constexpr (!CheckOnly) {
         result.emplace_back(string.str());
         internal::reset(string);
       }
       goto parse_token_content;
-    case internal::token_pointer_tilde<JSON::Char>:
+    case internal::TOKEN_POINTER_TILDE<JSON::Char>:
       goto parse_token_escape_tilde;
     default:
       if constexpr (!CheckOnly) {
@@ -258,14 +258,14 @@ parse_token_escape_tilde:
   // reference token.
   // See https://www.rfc-editor.org/rfc/rfc6901#section-3
   switch (character) {
-    case internal::token_pointer_number_zero<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_ZERO<JSON::Char>:
       if constexpr (!CheckOnly) {
-        string.put(internal::token_pointer_tilde<JSON::Char>);
+        string.put(internal::TOKEN_POINTER_TILDE<JSON::Char>);
       }
       goto parse_token_property_rest_any;
-    case internal::token_pointer_number_one<JSON::Char>:
+    case internal::TOKEN_POINTER_NUMBER_ONE<JSON::Char>:
       if constexpr (!CheckOnly) {
-        string.put(internal::token_pointer_slash<JSON::Char>);
+        string.put(internal::TOKEN_POINTER_SLASH<JSON::Char>);
       }
       goto parse_token_property_rest_any;
     default:

--- a/src/core/jsonpointer/position.cc
+++ b/src/core/jsonpointer/position.cc
@@ -12,20 +12,20 @@
 namespace sourcemeta::core {
 
 auto PointerPositionTracker::ensure_index() const -> void {
-  if (this->indexed) {
+  if (this->indexed_) {
     return;
   }
 
-  this->indexed = true;
-  this->trie.push_back({.position = std::nullopt,
-                        .index_children = {},
-                        .property_children = {}});
+  this->indexed_ = true;
+  this->trie_.push_back({.position = std::nullopt,
+                         .index_children = {},
+                         .property_children = {}});
 
   std::size_t current_node{0};
   std::vector<std::pair<std::size_t, std::pair<std::uint64_t, std::uint64_t>>>
       node_stack;
 
-  for (const auto &event : this->events) {
+  for (const auto &event : this->events_) {
     switch (event.phase) {
       case JSON::ParsePhase::Pre:
         node_stack.emplace_back(current_node,
@@ -35,14 +35,15 @@ auto PointerPositionTracker::ensure_index() const -> void {
           case JSON::ParseContext::Property: {
             assert(event.property != nullptr);
             const std::string_view key{*event.property};
-            auto iterator{this->trie[current_node].property_children.find(key)};
-            if (iterator == this->trie[current_node].property_children.end()) {
-              const auto node_index{this->trie.size()};
-              this->trie.push_back({.position = std::nullopt,
-                                    .index_children = {},
-                                    .property_children = {}});
-              this->trie[current_node].property_children.emplace(key,
-                                                                 node_index);
+            auto iterator{
+                this->trie_[current_node].property_children.find(key)};
+            if (iterator == this->trie_[current_node].property_children.end()) {
+              const auto node_index{this->trie_.size()};
+              this->trie_.push_back({.position = std::nullopt,
+                                     .index_children = {},
+                                     .property_children = {}});
+              this->trie_[current_node].property_children.emplace(key,
+                                                                  node_index);
               current_node = node_index;
             } else {
               current_node = iterator->second;
@@ -51,14 +52,14 @@ auto PointerPositionTracker::ensure_index() const -> void {
           }
           case JSON::ParseContext::Index: {
             auto iterator{
-                this->trie[current_node].index_children.find(event.index)};
-            if (iterator == this->trie[current_node].index_children.end()) {
-              const auto node_index{this->trie.size()};
-              this->trie.push_back({.position = std::nullopt,
-                                    .index_children = {},
-                                    .property_children = {}});
-              this->trie[current_node].index_children.emplace(event.index,
-                                                              node_index);
+                this->trie_[current_node].index_children.find(event.index)};
+            if (iterator == this->trie_[current_node].index_children.end()) {
+              const auto node_index{this->trie_.size()};
+              this->trie_.push_back({.position = std::nullopt,
+                                     .index_children = {},
+                                     .property_children = {}});
+              this->trie_[current_node].index_children.emplace(event.index,
+                                                               node_index);
               current_node = node_index;
             } else {
               current_node = iterator->second;
@@ -72,7 +73,7 @@ auto PointerPositionTracker::ensure_index() const -> void {
         break;
       case JSON::ParsePhase::Post:
         assert(!node_stack.empty());
-        this->trie[current_node].position =
+        this->trie_[current_node].position =
             Position{node_stack.back().second.first,
                      node_stack.back().second.second, event.line, event.column};
         current_node = node_stack.back().first;
@@ -85,18 +86,21 @@ auto PointerPositionTracker::ensure_index() const -> void {
   }
 }
 
-auto PointerPositionTracker::operator()(
-    const JSON::ParsePhase phase, const JSON::Type, const std::uint64_t line,
-    const std::uint64_t column, const JSON::ParseContext context,
-    const std::size_t index, const JSON::String &property) -> void {
-  this->events.push_back({.phase = phase,
-                          .context = context,
-                          .index = index,
-                          .property = context == JSON::ParseContext::Property
-                                          ? &property
-                                          : nullptr,
-                          .line = line,
-                          .column = column});
+auto PointerPositionTracker::operator()(const JSON::ParsePhase phase,
+                                        [[maybe_unused]] const JSON::Type type,
+                                        const std::uint64_t line,
+                                        const std::uint64_t column,
+                                        const JSON::ParseContext context,
+                                        const std::size_t index,
+                                        const JSON::String &property) -> void {
+  this->events_.push_back({.phase = phase,
+                           .context = context,
+                           .index = index,
+                           .property = context == JSON::ParseContext::Property
+                                           ? &property
+                                           : nullptr,
+                           .line = line,
+                           .column = column});
 }
 
 auto PointerPositionTracker::get(const Pointer &pointer) const
@@ -105,21 +109,21 @@ auto PointerPositionTracker::get(const Pointer &pointer) const
   std::size_t node{0};
   for (const auto &token : pointer) {
     if (token.is_property()) {
-      const auto &children{this->trie[node].property_children};
+      const auto &children{this->trie_[node].property_children};
       const auto iterator{children.find(std::string_view{token.to_property()})};
       if (iterator == children.end()) {
         return std::nullopt;
       }
       node = iterator->second;
     } else {
-      const auto &children{this->trie[node].index_children};
+      const auto &children{this->trie_[node].index_children};
       const auto iterator{children.find(token.to_index())};
       if (iterator == children.end()) {
         // If the currently referenced value is a JSON object, the new
         // referenced value is the object member with the name identified by the
         // reference token.
         // See https://www.rfc-editor.org/rfc/rfc6901#section-4
-        const auto &properties{this->trie[node].property_children};
+        const auto &properties{this->trie_[node].property_children};
         DigitsBuffer buffer;
         const auto property_iterator{
             properties.find(digits_view(token.to_index(), buffer))};
@@ -133,12 +137,12 @@ auto PointerPositionTracker::get(const Pointer &pointer) const
     }
   }
 
-  return this->trie[node].position;
+  return this->trie_[node].position;
 }
 
 auto PointerPositionTracker::size() const -> std::size_t {
   return static_cast<std::size_t>(
-      std::count_if(this->events.cbegin(), this->events.cend(),
+      std::count_if(this->events_.cbegin(), this->events_.cend(),
                     [](const Event &event) -> bool {
                       return event.phase == JSON::ParsePhase::Post;
                     }));
@@ -149,7 +153,7 @@ auto PointerPositionTracker::to_json() const -> JSON {
   Pointer current;
   std::vector<std::pair<std::uint64_t, std::uint64_t>> start_stack;
 
-  for (const auto &event : this->events) {
+  for (const auto &event : this->events_) {
     switch (event.phase) {
       case JSON::ParsePhase::Pre:
         start_stack.emplace_back(event.line, event.column);

--- a/src/core/jsonpointer/stringify.h
+++ b/src/core/jsonpointer/stringify.h
@@ -32,7 +32,7 @@ auto stringify_token(const TokenT &token,
   // containing a sequence of zero or more reference tokens, each prefixed
   // by a '/' (%x2F) character.
   // See https://www.rfc-editor.org/rfc/rfc6901#section-3
-  stream.put(internal::token_pointer_slash<CharT>);
+  stream.put(internal::TOKEN_POINTER_SLASH<CharT>);
   if (token.is_property()) {
     for (const auto &character : token.to_property()) {
       // Because the characters '~' (%x7E) and '/' (%x2F) have special
@@ -41,13 +41,13 @@ auto stringify_token(const TokenT &token,
       // reference token. Every other character is written verbatim.
       // See https://www.rfc-editor.org/rfc/rfc6901#section-3
       switch (character) {
-        case internal::token_pointer_slash<CharT>:
-          stream.put(internal::token_pointer_tilde<CharT>);
-          stream.put(internal::token_pointer_one<CharT>);
+        case internal::TOKEN_POINTER_SLASH<CharT>:
+          stream.put(internal::TOKEN_POINTER_TILDE<CharT>);
+          stream.put(internal::TOKEN_POINTER_ONE<CharT>);
           break;
-        case internal::token_pointer_tilde<CharT>:
-          stream.put(internal::token_pointer_tilde<CharT>);
-          stream.put(internal::token_pointer_zero<CharT>);
+        case internal::TOKEN_POINTER_TILDE<CharT>:
+          stream.put(internal::TOKEN_POINTER_TILDE<CharT>);
+          stream.put(internal::TOKEN_POINTER_ZERO<CharT>);
           break;
         default:
           internal::write_character(stream, character);
@@ -66,8 +66,8 @@ auto stringify(const PointerT &pointer,
     for (const auto &token : pointer) {
       if (std::holds_alternative<typename PointerT::Wildcard>(token)) {
         // Represent wildcards using an impossible JSON Pointer token
-        stream.put(internal::token_pointer_slash<CharT>);
-        stream.put(internal::token_pointer_tilde<CharT>);
+        stream.put(internal::TOKEN_POINTER_SLASH<CharT>);
+        stream.put(internal::TOKEN_POINTER_TILDE<CharT>);
 
         switch (std::get<typename PointerT::Wildcard>(token)) {
           case PointerT::Wildcard::Property:
@@ -84,18 +84,18 @@ auto stringify(const PointerT &pointer,
             break;
         }
 
-        stream.put(internal::token_pointer_tilde<CharT>);
+        stream.put(internal::TOKEN_POINTER_TILDE<CharT>);
       } else if (std::holds_alternative<typename PointerT::Regex>(token)) {
         // Represent wildcards using an impossible JSON Pointer token
-        stream.put(internal::token_pointer_slash<CharT>);
-        stream.put(internal::token_pointer_tilde<CharT>);
+        stream.put(internal::TOKEN_POINTER_SLASH<CharT>);
+        stream.put(internal::TOKEN_POINTER_TILDE<CharT>);
         stream.put('R');
         const auto &value{std::get<typename PointerT::Regex>(token)};
         stream.write(value.c_str(), static_cast<std::streamsize>(value.size()));
-        stream.put(internal::token_pointer_tilde<CharT>);
+        stream.put(internal::TOKEN_POINTER_TILDE<CharT>);
       } else if (std::holds_alternative<typename PointerT::Condition>(token)) {
-        stream.put(internal::token_pointer_slash<CharT>);
-        stream.put(internal::token_pointer_tilde<CharT>);
+        stream.put(internal::TOKEN_POINTER_SLASH<CharT>);
+        stream.put(internal::TOKEN_POINTER_TILDE<CharT>);
         stream.put('?');
         const auto &value{std::get<typename PointerT::Condition>(token)};
         if (value.suffix.has_value()) {
@@ -103,12 +103,12 @@ auto stringify(const PointerT &pointer,
                        static_cast<std::streamsize>(value.suffix->size()));
         }
 
-        stream.put(internal::token_pointer_tilde<CharT>);
+        stream.put(internal::TOKEN_POINTER_TILDE<CharT>);
       } else if (std::holds_alternative<typename PointerT::Negation>(token)) {
-        stream.put(internal::token_pointer_slash<CharT>);
-        stream.put(internal::token_pointer_tilde<CharT>);
+        stream.put(internal::TOKEN_POINTER_SLASH<CharT>);
+        stream.put(internal::TOKEN_POINTER_TILDE<CharT>);
         stream.put('!');
-        stream.put(internal::token_pointer_tilde<CharT>);
+        stream.put(internal::TOKEN_POINTER_TILDE<CharT>);
       } else {
         stringify_token<CharT, Traits, Allocator, typename PointerT::Token>(
             std::get<typename PointerT::Token>(token), stream);

--- a/src/core/jsonrpc/jsonrpc.cc
+++ b/src/core/jsonrpc/jsonrpc.cc
@@ -166,9 +166,9 @@ auto jsonrpc_make_error(const sourcemeta::core::JSON *identifier,
 }
 
 auto jsonrpc_make_error_parse() -> const sourcemeta::core::JSON & {
-  static const auto envelope{
+  static const auto ENVELOPE{
       jsonrpc_make_error(nullptr, JSONRPC_CODE_PARSE, "Parse error")};
-  return envelope;
+  return ENVELOPE;
 }
 
 auto jsonrpc_make_error_invalid_request(

--- a/src/core/langtag/langtag.cc
+++ b/src/core/langtag/langtag.cc
@@ -12,7 +12,7 @@ namespace {
 // langtag grammar and must be matched literally. The regular grandfathered
 // tags are intentionally omitted, as they are already accepted by the langtag
 // grammar.
-constexpr std::array<std::string_view, 17> irregular_grandfathered{
+constexpr std::array<std::string_view, 17> IRREGULAR_GRANDFATHERED{
     {"en-GB-oed", "i-ami", "i-bnn", "i-default", "i-enochian", "i-hak",
      "i-klingon", "i-lux", "i-mingo", "i-navajo", "i-pwn", "i-tao", "i-tay",
      "i-tsu", "sgn-BE-FR", "sgn-BE-NL", "sgn-CH-DE"}};
@@ -221,7 +221,7 @@ auto valid_privateuse(const std::string_view value) -> bool {
 }
 
 auto is_irregular_grandfathered(const std::string_view value) -> bool {
-  for (const auto entry : irregular_grandfathered) {
+  for (const auto entry : IRREGULAR_GRANDFATHERED) {
     if (sourcemeta::core::equals_ignore_case(value, entry)) {
       return true;
     }

--- a/src/core/markdown/markdown.cc
+++ b/src/core/markdown/markdown.cc
@@ -13,7 +13,7 @@ namespace sourcemeta::core {
 
 auto markdown_to_html(const std::string_view input, const bool safe)
     -> std::string {
-  [[maybe_unused]] static const bool cmark_initialized{
+  [[maybe_unused]] static const bool CMARK_INITIALIZED{
       (cmark_gfm_core_extensions_ensure_registered(), true)};
 
   // cmark-gfm toggles process-global special-character tables when syntax
@@ -22,18 +22,18 @@ auto markdown_to_html(const std::string_view input, const bool safe)
   static std::mutex cmark_mutex;
   const std::scoped_lock lock{cmark_mutex};
 
-  static constexpr auto base_options{
+  static constexpr auto BASE_OPTIONS{
       CMARK_OPT_VALIDATE_UTF8 | CMARK_OPT_FOOTNOTES |
       CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE | CMARK_OPT_GITHUB_PRE_LANG};
   // This cmark-gfm suppresses raw HTML and unsafe links by default, so raw
   // output requires explicitly opting out through CMARK_OPT_UNSAFE
-  const int options{safe ? base_options : (base_options | CMARK_OPT_UNSAFE)};
+  const int options{safe ? BASE_OPTIONS : (BASE_OPTIONS | CMARK_OPT_UNSAFE)};
 
   auto *parser{cmark_parser_new(options)};
 
-  static constexpr std::array<const char *, 5> extension_names{
+  static constexpr std::array<const char *, 5> EXTENSION_NAMES{
       {"table", "autolink", "strikethrough", "tagfilter", "tasklist"}};
-  for (const auto *name : extension_names) {
+  for (const auto *name : EXTENSION_NAMES) {
     auto *extension{cmark_find_syntax_extension(name)};
     if (extension != nullptr) {
       cmark_parser_attach_syntax_extension(parser, extension);

--- a/src/core/oauth/oauth_authorization.cc
+++ b/src/core/oauth/oauth_authorization.cc
@@ -26,12 +26,12 @@ struct HttpAuthority {
 // discarding the port, without constructing a URI (RFC 3986 Section 3.2)
 auto split_http_authority(const std::string_view value)
     -> std::optional<HttpAuthority> {
-  static constexpr std::string_view prefix{"http://"};
-  if (!value.starts_with(prefix)) {
+  static constexpr std::string_view PREFIX{"http://"};
+  if (!value.starts_with(PREFIX)) {
     return std::nullopt;
   }
 
-  const auto after{value.substr(prefix.size())};
+  const auto after{value.substr(PREFIX.size())};
   // RFC 3986 Section 3.2: the authority ends at the next "/", "?", or "#", or
   // the end of the URI, so the query and fragment are part of the compared
   // remainder rather than folded into the authority
@@ -46,7 +46,7 @@ auto split_http_authority(const std::string_view value)
   // confusion, since a redirect like "http://127.0.0.1:2@evil/cb" has its real
   // host after the "@" yet its authority begins with the loopback literal, so
   // an authority with userinfo does not qualify for the loopback exception
-  if (authority.find('@') != std::string_view::npos) {
+  if (authority.contains('@')) {
     return std::nullopt;
   }
 
@@ -103,7 +103,7 @@ auto oauth_build_authorization_url(const std::string_view endpoint,
   sink.append(endpoint);
   // '?' opens a query the endpoint lacks, and the parameter appender continues
   // one the endpoint already carries (RFC 6749 Section 3.1)
-  if (endpoint.find('?') == std::string_view::npos) {
+  if (!endpoint.contains('?')) {
     sink.push_back('?');
   }
 
@@ -243,7 +243,7 @@ auto oauth_build_authorization_redirect(
   // RFC 6749 Section 3.1.2: a redirection endpoint "MUST NOT include a fragment
   // component", and appending the query after one would place the parameters
   // inside the fragment rather than the query
-  if (redirect_uri.find('#') != std::string_view::npos) {
+  if (redirect_uri.contains('#')) {
     return false;
   }
 
@@ -258,8 +258,7 @@ auto oauth_build_authorization_redirect(
   // In the fragment response mode the parameters are "encoded in the fragment
   // added to the redirect_uri when redirecting back to the Client" (OAuth 2.0
   // Multiple Response Types Section 2.1), while a query joins any existing one
-  if (mode == OAuthResponseMode::Fragment ||
-      redirect_uri.find('?') == std::string_view::npos) {
+  if (mode == OAuthResponseMode::Fragment || !redirect_uri.contains('?')) {
     sink.push_back(opener);
   }
 
@@ -305,7 +304,7 @@ auto oauth_build_authorization_error_redirect(
   // RFC 6749 Section 3.1.2: a redirection endpoint "MUST NOT include a fragment
   // component", and appending the query after one would place the parameters
   // inside the fragment rather than the query
-  if (redirect_uri.find('#') != std::string_view::npos) {
+  if (redirect_uri.contains('#')) {
     return false;
   }
 
@@ -321,8 +320,7 @@ auto oauth_build_authorization_error_redirect(
   // In the fragment response mode the parameters are "encoded in the fragment
   // added to the redirect_uri when redirecting back to the Client" (OAuth 2.0
   // Multiple Response Types Section 2.1), while a query joins any existing one
-  if (mode == OAuthResponseMode::Fragment ||
-      redirect_uri.find('?') == std::string_view::npos) {
+  if (mode == OAuthResponseMode::Fragment || !redirect_uri.contains('?')) {
     sink.push_back(opener);
   }
 
@@ -430,7 +428,7 @@ auto oauth_build_authorization_form_post(
 
   // RFC 6749 Section 3.1.2: a redirection endpoint "MUST NOT include a
   // fragment component"
-  if (redirect_uri.find('#') != std::string_view::npos) {
+  if (redirect_uri.contains('#')) {
     return false;
   }
 
@@ -471,7 +469,7 @@ auto oauth_build_authorization_error_form_post(
 
   // RFC 6749 Section 3.1.2: a redirection endpoint "MUST NOT include a
   // fragment component"
-  if (redirect_uri.find('#') != std::string_view::npos) {
+  if (redirect_uri.contains('#')) {
     return false;
   }
 

--- a/src/core/oauth/oauth_bearer.cc
+++ b/src/core/oauth/oauth_bearer.cc
@@ -41,9 +41,9 @@ auto oauth_bearer_header(const std::string_view token, std::string &sink)
     return false;
   }
 
-  static constexpr std::string_view prefix{"Bearer "};
-  sink.reserve(sink.size() + prefix.size() + token.size());
-  sink.append(prefix);
+  static constexpr std::string_view PREFIX{"Bearer "};
+  sink.reserve(sink.size() + PREFIX.size() + token.size());
+  sink.append(PREFIX);
   sink.append(token);
   return true;
 }

--- a/src/core/oauth/oauth_error.cc
+++ b/src/core/oauth/oauth_error.cc
@@ -102,88 +102,110 @@ auto to_oauth_authorization_error(const std::string_view code) noexcept
     -> std::optional<OAuthAuthorizationError> {
   if (code == "invalid_request") {
     return OAuthAuthorizationError::InvalidRequest;
-  } else if (code == "unauthorized_client") {
-    return OAuthAuthorizationError::UnauthorizedClient;
-  } else if (code == "access_denied") {
-    return OAuthAuthorizationError::AccessDenied;
-  } else if (code == "unsupported_response_type") {
-    return OAuthAuthorizationError::UnsupportedResponseType;
-  } else if (code == "invalid_scope") {
-    return OAuthAuthorizationError::InvalidScope;
-  } else if (code == "server_error") {
-    return OAuthAuthorizationError::ServerError;
-  } else if (code == "temporarily_unavailable") {
-    return OAuthAuthorizationError::TemporarilyUnavailable;
-  } else {
-    return std::nullopt;
   }
+  if (code == "unauthorized_client") {
+    return OAuthAuthorizationError::UnauthorizedClient;
+  }
+  if (code == "access_denied") {
+    return OAuthAuthorizationError::AccessDenied;
+  }
+  if (code == "unsupported_response_type") {
+    return OAuthAuthorizationError::UnsupportedResponseType;
+  }
+  if (code == "invalid_scope") {
+    return OAuthAuthorizationError::InvalidScope;
+  }
+  if (code == "server_error") {
+    return OAuthAuthorizationError::ServerError;
+  }
+  if (code == "temporarily_unavailable") {
+    return OAuthAuthorizationError::TemporarilyUnavailable;
+  }
+  return std::nullopt;
 }
 
 auto to_oauth_token_error(const std::string_view code) noexcept
     -> std::optional<OAuthTokenError> {
   if (code == "invalid_request") {
     return OAuthTokenError::InvalidRequest;
-  } else if (code == "invalid_client") {
-    return OAuthTokenError::InvalidClient;
-  } else if (code == "invalid_grant") {
-    return OAuthTokenError::InvalidGrant;
-  } else if (code == "unauthorized_client") {
-    return OAuthTokenError::UnauthorizedClient;
-  } else if (code == "unsupported_grant_type") {
-    return OAuthTokenError::UnsupportedGrantType;
-  } else if (code == "invalid_scope") {
-    return OAuthTokenError::InvalidScope;
-  } else if (code == "authorization_pending") {
-    return OAuthTokenError::AuthorizationPending;
-  } else if (code == "slow_down") {
-    return OAuthTokenError::SlowDown;
-  } else if (code == "access_denied") {
-    return OAuthTokenError::AccessDenied;
-  } else if (code == "expired_token") {
-    return OAuthTokenError::ExpiredToken;
-  } else if (code == "invalid_target") {
-    return OAuthTokenError::InvalidTarget;
-  } else if (code == "invalid_dpop_proof") {
-    return OAuthTokenError::InvalidDPoPProof;
-  } else if (code == "use_dpop_nonce") {
-    return OAuthTokenError::UseDPoPNonce;
-  } else if (code == "unsupported_token_type") {
-    return OAuthTokenError::UnsupportedTokenType;
-  } else {
-    return std::nullopt;
   }
+  if (code == "invalid_client") {
+    return OAuthTokenError::InvalidClient;
+  }
+  if (code == "invalid_grant") {
+    return OAuthTokenError::InvalidGrant;
+  }
+  if (code == "unauthorized_client") {
+    return OAuthTokenError::UnauthorizedClient;
+  }
+  if (code == "unsupported_grant_type") {
+    return OAuthTokenError::UnsupportedGrantType;
+  }
+  if (code == "invalid_scope") {
+    return OAuthTokenError::InvalidScope;
+  }
+  if (code == "authorization_pending") {
+    return OAuthTokenError::AuthorizationPending;
+  }
+  if (code == "slow_down") {
+    return OAuthTokenError::SlowDown;
+  }
+  if (code == "access_denied") {
+    return OAuthTokenError::AccessDenied;
+  }
+  if (code == "expired_token") {
+    return OAuthTokenError::ExpiredToken;
+  }
+  if (code == "invalid_target") {
+    return OAuthTokenError::InvalidTarget;
+  }
+  if (code == "invalid_dpop_proof") {
+    return OAuthTokenError::InvalidDPoPProof;
+  }
+  if (code == "use_dpop_nonce") {
+    return OAuthTokenError::UseDPoPNonce;
+  }
+  if (code == "unsupported_token_type") {
+    return OAuthTokenError::UnsupportedTokenType;
+  }
+  return std::nullopt;
 }
 
 auto to_oauth_bearer_error(const std::string_view code) noexcept
     -> std::optional<OAuthBearerError> {
   if (code == "invalid_request") {
     return OAuthBearerError::InvalidRequest;
-  } else if (code == "invalid_token") {
-    return OAuthBearerError::InvalidToken;
-  } else if (code == "insufficient_scope") {
-    return OAuthBearerError::InsufficientScope;
-  } else if (code == "invalid_dpop_proof") {
-    return OAuthBearerError::InvalidDPoPProof;
-  } else if (code == "use_dpop_nonce") {
-    return OAuthBearerError::UseDPoPNonce;
-  } else {
-    return std::nullopt;
   }
+  if (code == "invalid_token") {
+    return OAuthBearerError::InvalidToken;
+  }
+  if (code == "insufficient_scope") {
+    return OAuthBearerError::InsufficientScope;
+  }
+  if (code == "invalid_dpop_proof") {
+    return OAuthBearerError::InvalidDPoPProof;
+  }
+  if (code == "use_dpop_nonce") {
+    return OAuthBearerError::UseDPoPNonce;
+  }
+  return std::nullopt;
 }
 
 auto to_oauth_registration_error(const std::string_view code) noexcept
     -> std::optional<OAuthRegistrationError> {
   if (code == "invalid_redirect_uri") {
     return OAuthRegistrationError::InvalidRedirectURI;
-  } else if (code == "invalid_client_metadata") {
-    return OAuthRegistrationError::InvalidClientMetadata;
-  } else if (code == "invalid_software_statement") {
-    return OAuthRegistrationError::InvalidSoftwareStatement;
-  } else if (code == "unapproved_software_statement") {
-    return OAuthRegistrationError::UnapprovedSoftwareStatement;
-  } else {
-    return std::nullopt;
   }
+  if (code == "invalid_client_metadata") {
+    return OAuthRegistrationError::InvalidClientMetadata;
+  }
+  if (code == "invalid_software_statement") {
+    return OAuthRegistrationError::InvalidSoftwareStatement;
+  }
+  if (code == "unapproved_software_statement") {
+    return OAuthRegistrationError::UnapprovedSoftwareStatement;
+  }
+  return std::nullopt;
 }
 
 auto oauth_token_error_status(const OAuthTokenError error,

--- a/src/core/oauth/oauth_metadata.cc
+++ b/src/core/oauth/oauth_metadata.cc
@@ -383,12 +383,11 @@ auto oauth_is_issuer_identifier(const std::string_view value) -> bool {
 auto oauth_well_known_url(const std::string_view identifier,
                           const OAuthWellKnownKind kind, std::string &sink)
     -> bool {
-  static constexpr std::string_view scheme{"https://"};
+  static constexpr std::string_view SCHEME{"https://"};
   // Reject a missing scheme or a fragment, then require a non-empty host so an
   // authority such as ":443" with no host is not accepted (RFC 3986
   // Section 3.2)
-  if (!identifier.starts_with(scheme) ||
-      identifier.find('#') != std::string_view::npos) {
+  if (!identifier.starts_with(SCHEME) || identifier.contains('#')) {
     return false;
   }
 
@@ -419,7 +418,7 @@ auto oauth_well_known_url(const std::string_view identifier,
       break;
   }
 
-  static constexpr std::string_view infix{"/.well-known/"};
+  static constexpr std::string_view INFIX{"/.well-known/"};
   if (kind == OAuthWellKnownKind::OpenIDConfigurationAppended) {
     // RFC 8414 Section 5: the legacy OpenID Connect form appends the well-known
     // string after the path rather than inserting it
@@ -428,9 +427,9 @@ auto oauth_well_known_url(const std::string_view identifier,
       base.remove_suffix(1);
     }
 
-    sink.reserve(sink.size() + base.size() + infix.size() + suffix.size());
+    sink.reserve(sink.size() + base.size() + INFIX.size() + suffix.size());
     sink.append(base);
-    sink.append(infix);
+    sink.append(INFIX);
     sink.append(suffix);
     return true;
   }
@@ -446,7 +445,7 @@ auto oauth_well_known_url(const std::string_view identifier,
   // and the path, with any terminating slash on the path removed first
   auto authority{without_query};
   std::string_view path;
-  const auto path_position{without_query.find('/', scheme.size())};
+  const auto path_position{without_query.find('/', SCHEME.size())};
   if (path_position != std::string_view::npos) {
     authority = without_query.substr(0, path_position);
     path = without_query.substr(path_position);
@@ -456,10 +455,10 @@ auto oauth_well_known_url(const std::string_view identifier,
     path.remove_suffix(1);
   }
 
-  sink.reserve(sink.size() + authority.size() + infix.size() + suffix.size() +
+  sink.reserve(sink.size() + authority.size() + INFIX.size() + suffix.size() +
                path.size() + query.size());
   sink.append(authority);
-  sink.append(infix);
+  sink.append(INFIX);
   sink.append(suffix);
   sink.append(path);
   sink.append(query);

--- a/src/core/oauth/oauth_par.cc
+++ b/src/core/oauth/oauth_par.cc
@@ -96,7 +96,7 @@ auto oauth_build_par_authorization_url(const std::string_view endpoint,
   // lacks, nothing when the endpoint already ends its query, and '&' continues
   // one (RFC 6749 Section 3.1)
   char separator{'?'};
-  if (endpoint.find('?') != std::string_view::npos) {
+  if (endpoint.contains('?')) {
     separator =
         (endpoint.empty() || endpoint.back() == '?' || endpoint.back() == '&')
             ? '\0'

--- a/src/core/oauth/oauth_pkce.cc
+++ b/src/core/oauth/oauth_pkce.cc
@@ -32,11 +32,11 @@ auto to_oauth_pkce_method(const std::string_view value) noexcept
     -> std::optional<OAuthPKCEMethod> {
   if (value == "S256") {
     return OAuthPKCEMethod::S256;
-  } else if (value == "plain") {
-    return OAuthPKCEMethod::Plain;
-  } else {
-    return std::nullopt;
   }
+  if (value == "plain") {
+    return OAuthPKCEMethod::Plain;
+  }
+  return std::nullopt;
 }
 
 auto oauth_pkce_verifier() -> std::array<char, 43> {

--- a/src/core/oidc/oidc_discovery.cc
+++ b/src/core/oidc/oidc_discovery.cc
@@ -69,7 +69,7 @@ auto identifier_has_scheme(const std::string_view identifier) -> bool {
 // read as "[ userinfo "@" ] host [ ":" port ]", so this shape carries an "@"
 // and none of the port, path, query, or fragment delimiters
 auto identifier_is_acct_shaped(const std::string_view identifier) -> bool {
-  return identifier.find('@') != std::string_view::npos &&
+  return identifier.contains('@') &&
          identifier.find_first_of(":/?#") == std::string_view::npos;
 }
 

--- a/src/core/oidc/oidc_error.cc
+++ b/src/core/oidc/oidc_error.cc
@@ -36,25 +36,32 @@ auto to_oidc_authentication_error(const std::string_view code) noexcept
     -> std::optional<OIDCAuthenticationError> {
   if (code == "interaction_required") {
     return OIDCAuthenticationError::InteractionRequired;
-  } else if (code == "login_required") {
-    return OIDCAuthenticationError::LoginRequired;
-  } else if (code == "account_selection_required") {
-    return OIDCAuthenticationError::AccountSelectionRequired;
-  } else if (code == "consent_required") {
-    return OIDCAuthenticationError::ConsentRequired;
-  } else if (code == "invalid_request_uri") {
-    return OIDCAuthenticationError::InvalidRequestURI;
-  } else if (code == "invalid_request_object") {
-    return OIDCAuthenticationError::InvalidRequestObject;
-  } else if (code == "request_not_supported") {
-    return OIDCAuthenticationError::RequestNotSupported;
-  } else if (code == "request_uri_not_supported") {
-    return OIDCAuthenticationError::RequestURINotSupported;
-  } else if (code == "registration_not_supported") {
-    return OIDCAuthenticationError::RegistrationNotSupported;
-  } else {
-    return std::nullopt;
   }
+  if (code == "login_required") {
+    return OIDCAuthenticationError::LoginRequired;
+  }
+  if (code == "account_selection_required") {
+    return OIDCAuthenticationError::AccountSelectionRequired;
+  }
+  if (code == "consent_required") {
+    return OIDCAuthenticationError::ConsentRequired;
+  }
+  if (code == "invalid_request_uri") {
+    return OIDCAuthenticationError::InvalidRequestURI;
+  }
+  if (code == "invalid_request_object") {
+    return OIDCAuthenticationError::InvalidRequestObject;
+  }
+  if (code == "request_not_supported") {
+    return OIDCAuthenticationError::RequestNotSupported;
+  }
+  if (code == "request_uri_not_supported") {
+    return OIDCAuthenticationError::RequestURINotSupported;
+  }
+  if (code == "registration_not_supported") {
+    return OIDCAuthenticationError::RegistrationNotSupported;
+  }
+  return std::nullopt;
 }
 
 } // namespace sourcemeta::core

--- a/src/core/oidc/oidc_logout.cc
+++ b/src/core/oidc/oidc_logout.cc
@@ -41,7 +41,7 @@ auto append_logout_parameter(std::string &sink, const std::string_view endpoint,
   }
 
   if (!query_opened) {
-    if (endpoint.find('?') == std::string_view::npos) {
+    if (!endpoint.contains('?')) {
       sink.push_back('?');
     } else if (sink.back() != '?' && sink.back() != '&') {
       sink.push_back('&');

--- a/src/core/oidc/oidc_subject.cc
+++ b/src/core/oidc/oidc_subject.cc
@@ -25,11 +25,11 @@ auto to_oidc_subject_type(const std::string_view name) noexcept
     -> std::optional<OIDCSubjectType> {
   if (name == "public") {
     return OIDCSubjectType::Public;
-  } else if (name == "pairwise") {
-    return OIDCSubjectType::Pairwise;
-  } else {
-    return std::nullopt;
   }
+  if (name == "pairwise") {
+    return OIDCSubjectType::Pairwise;
+  }
+  return std::nullopt;
 }
 
 auto oidc_pairwise_subject(const std::string_view sector_identifier,

--- a/src/core/punycode/punycode.cc
+++ b/src/core/punycode/punycode.cc
@@ -37,9 +37,11 @@ static constexpr auto encode_digit(const std::uint32_t digit) -> char {
 static auto decode_digit(const char code_point) -> std::uint32_t {
   if (code_point >= 'a' && code_point <= 'z') {
     return static_cast<std::uint32_t>(code_point - 'a');
-  } else if (code_point >= 'A' && code_point <= 'Z') {
+  }
+  if (code_point >= 'A' && code_point <= 'Z') {
     return static_cast<std::uint32_t>(code_point - 'A');
-  } else if (code_point >= '0' && code_point <= '9') {
+  }
+  if (code_point >= '0' && code_point <= '9') {
     return static_cast<std::uint32_t>(code_point - '0' + 26);
   }
 
@@ -67,7 +69,8 @@ static constexpr auto compute_threshold(const std::uint32_t step,
     -> std::uint32_t {
   if (step <= bias) {
     return TMIN;
-  } else if (step >= bias + TMAX) {
+  }
+  if (step >= bias + TMAX) {
     return TMAX;
   }
 

--- a/src/core/regex/permissive.h
+++ b/src/core/regex/permissive.h
@@ -16,7 +16,7 @@ namespace sourcemeta::core {
 namespace {
 
 constexpr std::array<std::pair<std::string_view, std::string_view>, 42>
-    unicode_property_map{{{"digit", "Nd"},
+    UNICODE_PROPERTY_MAP{{{"digit", "Nd"},
                           {"Decimal_Number", "Nd"},
                           {"space", "White_Space"},
                           {"White_Space", "White_Space"},
@@ -59,10 +59,10 @@ constexpr std::array<std::pair<std::string_view, std::string_view>, 42>
                           {"Unassigned", "Cn"},
                           {"Private_Use", "Co"}}};
 
-constexpr std::string_view shorthand_chars{"dDwWsS"};
-constexpr std::string_view simple_escapes{"btnrfv0"};
-constexpr std::string_view simple_escape_values{"\b\t\n\r\f\v"};
-constexpr std::string_view v_flag_syntax{"-][(){}/'|!#%&*+,.:;<=>?@`~^$"};
+constexpr std::string_view SHORTHAND_CHARS{"dDwWsS"};
+constexpr std::string_view SIMPLE_ESCAPES{"btnrfv0"};
+constexpr std::string_view SIMPLE_ESCAPE_VALUES{"\b\t\n\r\f\v"};
+constexpr std::string_view V_FLAG_SYNTAX{"-][(){}/'|!#%&*+,.:;<=>?@`~^$"};
 
 inline auto all_hex(const std::string &content, std::size_t start,
                     std::size_t count) -> bool {
@@ -135,33 +135,33 @@ constexpr auto negate_class(const std::bitset<128> &base) -> std::bitset<128> {
   return result;
 }
 
-constexpr auto digit_class = make_digit_class();
-constexpr auto word_class = make_word_class();
-constexpr auto space_class = make_space_class();
-constexpr auto non_digit_class = negate_class(digit_class);
-constexpr auto non_word_class = negate_class(word_class);
-constexpr auto non_space_class = negate_class(space_class);
+constexpr auto DIGIT_CLASS = make_digit_class();
+constexpr auto WORD_CLASS = make_word_class();
+constexpr auto SPACE_CLASS = make_space_class();
+constexpr auto NON_DIGIT_CLASS = negate_class(DIGIT_CLASS);
+constexpr auto NON_WORD_CLASS = negate_class(WORD_CLASS);
+constexpr auto NON_SPACE_CLASS = negate_class(SPACE_CLASS);
 
 inline auto set_shorthand_class(std::bitset<128> &characters,
                                 const char shorthand) -> void {
   switch (shorthand) {
     case 'd':
-      characters |= digit_class;
+      characters |= DIGIT_CLASS;
       return;
     case 'D':
-      characters |= non_digit_class;
+      characters |= NON_DIGIT_CLASS;
       return;
     case 'w':
-      characters |= word_class;
+      characters |= WORD_CLASS;
       return;
     case 'W':
-      characters |= non_word_class;
+      characters |= NON_WORD_CLASS;
       return;
     case 's':
-      characters |= space_class;
+      characters |= SPACE_CLASS;
       return;
     case 'S':
-      characters |= non_space_class;
+      characters |= NON_SPACE_CLASS;
       return;
     default:
       return;
@@ -245,12 +245,12 @@ inline auto parse_escape(const std::string &content, std::size_t position,
   }
 
   end = position + 2;
-  const auto escape_index = simple_escapes.find(next);
+  const auto escape_index = SIMPLE_ESCAPES.find(next);
   if (escape_index < 6) {
-    code_point = static_cast<unsigned char>(simple_escape_values[escape_index]);
+    code_point = static_cast<unsigned char>(SIMPLE_ESCAPE_VALUES[escape_index]);
   } else if (next == '0') {
     code_point = 0;
-  } else if (shorthand_chars.contains(next)) {
+  } else if (SHORTHAND_CHARS.contains(next)) {
     code_point = -1;
   } else {
     code_point = static_cast<unsigned char>(next);
@@ -317,7 +317,7 @@ inline auto parse_class_to_bitset(const std::string &content, std::size_t start,
 
   while (position < content.size() && content[position] != ']') {
     if (content[position] == '\\' && position + 1 < content.size() &&
-        shorthand_chars.contains(content[position + 1])) {
+        SHORTHAND_CHARS.contains(content[position + 1])) {
       set_shorthand_class(characters, content[position + 1]);
       position += 2;
       continue;
@@ -379,14 +379,13 @@ inline auto parse_class_to_bitset(const std::string &content, std::size_t start,
 }
 
 inline auto append_char(std::string &result, std::size_t value) -> void {
-  constexpr std::string_view hex{"0123456789abcdef"};
+  constexpr std::string_view HEX{"0123456789abcdef"};
   if (value < 32 || value == 127) {
     result += "\\x";
-    result += hex[(value >> 4) & 0xF];
-    result += hex[value & 0xF];
+    result += HEX[(value >> 4) & 0xF];
+    result += HEX[value & 0xF];
   } else {
-    if (std::string_view{"-]\\^"}.find(static_cast<char>(value)) !=
-        std::string_view::npos) {
+    if (std::string_view{"-]\\^"}.contains(static_cast<char>(value))) {
       result += '\\';
     }
 
@@ -429,8 +428,7 @@ inline auto is_valid_escape(const std::string &content, std::size_t position)
   }
 
   const char next = content[position + 1];
-  if (std::string_view{"dDwWsSnrtfvb0\\"}.find(next) !=
-      std::string_view::npos) {
+  if (std::string_view{"dDwWsSnrtfvb0\\"}.contains(next)) {
     return true;
   }
 
@@ -443,7 +441,8 @@ inline auto is_valid_escape(const std::string &content, std::size_t position)
       for (auto end = position + 3; end < content.size(); ++end) {
         if (content[end] == '}') {
           return true;
-        } else if (hex_digit_value(content[end]) < 0) {
+        }
+        if (hex_digit_value(content[end]) < 0) {
           return false;
         }
       }
@@ -459,7 +458,7 @@ inline auto is_valid_escape(const std::string &content, std::size_t position)
     return (ctrl >= 'A' && ctrl <= 'Z') || (ctrl >= 'a' && ctrl <= 'z');
   }
 
-  return v_flag_syntax.contains(next);
+  return V_FLAG_SYNTAX.contains(next);
 }
 
 inline auto is_valid_operand(const std::string &operand) -> bool {
@@ -489,7 +488,7 @@ inline auto is_valid_operand(const std::string &operand) -> bool {
   }
 
   if (operand.size() == 2 && operand[0] == '\\' &&
-      shorthand_chars.contains(operand[1])) {
+      SHORTHAND_CHARS.contains(operand[1])) {
     return true;
   }
 
@@ -580,7 +579,7 @@ inline auto expand_char_class(const std::string &content)
 
 inline auto translate_property(const std::string_view name, const bool negated)
     -> std::optional<std::string> {
-  for (const auto &[prop_name, pcre_name] : unicode_property_map) {
+  for (const auto &[prop_name, pcre_name] : UNICODE_PROPERTY_MAP) {
     if (name == prop_name) {
       return std::string("\\") + (negated ? 'P' : 'p') + '{' +
              std::string(pcre_name) + '}';
@@ -631,7 +630,7 @@ struct ShorthandExpansion {
 };
 
 // clang-format off
-constexpr std::array<ShorthandExpansion, 8> shorthand_expansions{{
+constexpr std::array<ShorthandExpansion, 8> SHORTHAND_EXPANSIONS{{
     {.escape = 'd', .inside_class = "0-9", .outside_class = "[0-9]"},
     {.escape = 'D', .inside_class = "", .outside_class = "[^0-9]"},
     {.escape = 'w', .inside_class = "a-zA-Z0-9_", .outside_class = "[a-zA-Z0-9_]"},
@@ -645,7 +644,7 @@ constexpr std::array<ShorthandExpansion, 8> shorthand_expansions{{
 // clang-format on
 
 inline auto find_shorthand(char escape) -> const ShorthandExpansion * {
-  for (const auto &expansion : shorthand_expansions) {
+  for (const auto &expansion : SHORTHAND_EXPANSIONS) {
     if (expansion.escape == escape) {
       return &expansion;
     }
@@ -890,9 +889,9 @@ inline auto translate_permissive(const std::string &pattern)
       ++position;
     } else {
       // Escape sequences that are not valid in ECMA-262 strict mode
-      constexpr std::string_view ecma_remaining_escapes{"tnrfvcx0"};
-      const bool is_ecma_escape{ecma_remaining_escapes.contains(next) ||
-                                v_flag_syntax.contains(next) ||
+      constexpr std::string_view ECMA_REMAINING_ESCAPES{"tnrfvcx0"};
+      const bool is_ecma_escape{ECMA_REMAINING_ESCAPES.contains(next) ||
+                                V_FLAG_SYNTAX.contains(next) ||
                                 (next >= '1' && next <= '9')};
       if (!is_ecma_escape) {
         ecma_valid = false;

--- a/src/core/regex/regex.cc
+++ b/src/core/regex/regex.cc
@@ -121,24 +121,25 @@ auto to_regex(const std::string_view pattern, const RegexDialect dialect,
       // Note that the JSON Schema specification does not impose the use of any
       // regular expression flag. Given popular adoption, we assume `.` matches
       // new line characters (as in the `DOTALL`) option
-    } else if (pattern == ".+" || pattern == "^.+$" || pattern == "^(.+)$" ||
-               pattern == ".") {
+    }
+    if (pattern == ".+" || pattern == "^.+$" || pattern == "^(.+)$" ||
+        pattern == ".") {
       return RegexTypeNonEmpty{};
     }
 
     const char *const pattern_data{pattern.empty() ? "" : pattern.data()};
 
-    const std::regex PREFIX_REGEX{R"(^\^([a-zA-Z0-9-_/@]+)(\.\*)?)"};
+    const std::regex prefix_regex{R"(^\^([a-zA-Z0-9-_/@]+)(\.\*)?)"};
     std::cmatch matches_prefix;
     if (std::regex_match(pattern_data, pattern_data + pattern.size(),
-                         matches_prefix, PREFIX_REGEX)) {
+                         matches_prefix, prefix_regex)) {
       return RegexTypePrefix{matches_prefix[1].str()};
     }
 
-    const std::regex RANGE_REGEX{R"(^\^\.\{(\d+),(\d+)\}\$$)"};
+    const std::regex range_regex{R"(^\^\.\{(\d+),(\d+)\}\$$)"};
     std::cmatch matches_range;
     if (std::regex_match(pattern_data, pattern_data + pattern.size(),
-                         matches_range, RANGE_REGEX)) {
+                         matches_range, range_regex)) {
       const auto minimum_string = matches_range[1].str();
       const auto maximum_string = matches_range[2].str();
       std::size_t minimum{};
@@ -220,7 +221,7 @@ auto replace_all(const Regex &regex, const std::string_view subject,
   const RegexTypePCRE2 *pcre2_regex{std::get_if<RegexTypePCRE2>(&regex)};
   auto *pcre2_code_ptr{static_cast<pcre2_code *>(pcre2_regex->code.get())};
 
-  constexpr std::uint32_t options{
+  constexpr std::uint32_t OPTIONS{
       PCRE2_SUBSTITUTE_GLOBAL | PCRE2_SUBSTITUTE_LITERAL |
       PCRE2_SUBSTITUTE_OVERFLOW_LENGTH | PCRE2_NO_UTF_CHECK};
 
@@ -230,7 +231,7 @@ auto replace_all(const Regex &regex, const std::string_view subject,
   PCRE2_SIZE result_size{result.size()};
   int substitute_result{pcre2_substitute(
       pcre2_code_ptr, reinterpret_cast<PCRE2_SPTR>(subject.data()),
-      subject.size(), 0, options, nullptr, nullptr,
+      subject.size(), 0, OPTIONS, nullptr, nullptr,
       reinterpret_cast<PCRE2_SPTR>(replacement.data()), replacement.size(),
       reinterpret_cast<PCRE2_UCHAR *>(result.data()), &result_size)};
 
@@ -242,7 +243,7 @@ auto replace_all(const Regex &regex, const std::string_view subject,
     result_size = result.size();
     substitute_result = pcre2_substitute(
         pcre2_code_ptr, reinterpret_cast<PCRE2_SPTR>(subject.data()),
-        subject.size(), 0, options, nullptr, nullptr,
+        subject.size(), 0, OPTIONS, nullptr, nullptr,
         reinterpret_cast<PCRE2_SPTR>(replacement.data()), replacement.size(),
         reinterpret_cast<PCRE2_UCHAR *>(result.data()), &result_size);
   }

--- a/src/core/semver/include/sourcemeta/core/semver.h
+++ b/src/core/semver/include/sourcemeta/core/semver.h
@@ -55,31 +55,31 @@ public:
       -> std::optional<SemVer>;
 
   /// The major version number.
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto major() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto major() const noexcept
       -> std::uint64_t {
     return this->major_;
   }
 
   /// The minor version number.
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto minor() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto minor() const noexcept
       -> std::uint64_t {
     return this->minor_;
   }
 
   /// The patch version number.
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto patch() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto patch() const noexcept
       -> std::uint64_t {
     return this->patch_;
   }
 
   /// The pre-release identifier, or empty if none is present.
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto pre_release() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto pre_release() const noexcept
       -> std::string_view {
     return this->pre_release_;
   }
 
   /// The build metadata, or empty if none is present.
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto build() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto build() const noexcept
       -> std::string_view {
     return this->build_;
   }
@@ -89,8 +89,8 @@ public:
   // determining version *precedence*, but two versions with different build
   // metadata are distinct versions.
   // See https://semver.org/spec/v2.0.0.html#spec-item-10
-  SOURCEMETA_FORCEINLINE inline auto
-  operator==(const SemVer &other) const noexcept -> bool {
+  SOURCEMETA_FORCEINLINE auto operator==(const SemVer &other) const noexcept
+      -> bool {
     return this->major_ == other.major_ && this->minor_ == other.minor_ &&
            this->patch_ == other.patch_ &&
            this->pre_release_ == other.pre_release_ &&
@@ -99,23 +99,23 @@ public:
 
   auto operator<(const SemVer &other) const noexcept -> bool;
 
-  SOURCEMETA_FORCEINLINE inline auto
-  operator!=(const SemVer &other) const noexcept -> bool {
+  SOURCEMETA_FORCEINLINE auto operator!=(const SemVer &other) const noexcept
+      -> bool {
     return !(*this == other);
   }
 
-  SOURCEMETA_FORCEINLINE inline auto
-  operator>(const SemVer &other) const noexcept -> bool {
+  SOURCEMETA_FORCEINLINE auto operator>(const SemVer &other) const noexcept
+      -> bool {
     return other < *this;
   }
 
-  SOURCEMETA_FORCEINLINE inline auto
-  operator<=(const SemVer &other) const noexcept -> bool {
+  SOURCEMETA_FORCEINLINE auto operator<=(const SemVer &other) const noexcept
+      -> bool {
     return !(other < *this);
   }
 
-  SOURCEMETA_FORCEINLINE inline auto
-  operator>=(const SemVer &other) const noexcept -> bool {
+  SOURCEMETA_FORCEINLINE auto operator>=(const SemVer &other) const noexcept
+      -> bool {
     return !(*this < other);
   }
 

--- a/src/core/semver/semver.cc
+++ b/src/core/semver/semver.cc
@@ -15,19 +15,19 @@ constexpr auto UINT64_MAX_VALUE = std::numeric_limits<std::uint64_t>::max();
 constexpr auto UINT64_MAX_DIV_10 = UINT64_MAX_VALUE / 10;
 constexpr auto UINT64_MAX_MOD_10 = UINT64_MAX_VALUE % 10;
 
-enum class NumericParseResult : std::uint8_t { success, invalid, overflow };
+enum class NumericParseResult : std::uint8_t { Success, Invalid, Overflow };
 
 auto parse_numeric_identifier(const std::string_view input,
                               std::size_t &position, std::uint64_t &result)
     -> NumericParseResult {
   if (position >= input.size() ||
       !sourcemeta::core::is_digit(input[position])) {
-    return NumericParseResult::invalid;
+    return NumericParseResult::Invalid;
   }
 
   if (input[position] == '0' && position + 1 < input.size() &&
       sourcemeta::core::is_digit(input[position + 1])) {
-    return NumericParseResult::invalid;
+    return NumericParseResult::Invalid;
   }
 
   std::uint64_t value = 0;
@@ -36,15 +36,15 @@ auto parse_numeric_identifier(const std::string_view input,
     const auto digit = static_cast<std::uint64_t>(input[position] - '0');
     if (value > UINT64_MAX_DIV_10 ||
         (value == UINT64_MAX_DIV_10 && digit > UINT64_MAX_MOD_10)) {
-      return NumericParseResult::overflow;
+      return NumericParseResult::Overflow;
     }
 
-    value = value * 10 + digit;
+    value = (value * 10) + digit;
     ++position;
   }
 
   result = value;
-  return NumericParseResult::success;
+  return NumericParseResult::Success;
 }
 
 auto validate_pre_release_identifier(const std::string_view identifier)
@@ -85,7 +85,7 @@ auto validate_build_identifier(const std::string_view identifier) -> bool {
   return true;
 }
 
-template <auto validator>
+template <auto Validator>
 auto validate_dot_separated(const std::string_view input) -> bool {
   if (input.empty()) {
     return false;
@@ -98,7 +98,7 @@ auto validate_dot_separated(const std::string_view input) -> bool {
       dot_position = input.size();
     }
 
-    if (!validator(
+    if (!Validator(
             std::string_view{input.data() + start, dot_position - start})) {
       return false;
     }
@@ -132,7 +132,7 @@ auto classify_identifier(const std::string_view identifier) noexcept
       return {.is_numeric = true, .overflowed = true, .numeric_value = 0};
     }
 
-    value = value * 10 + digit;
+    value = (value * 10) + digit;
   }
 
   return {.is_numeric = true, .overflowed = false, .numeric_value = value};
@@ -229,14 +229,14 @@ auto compare_pre_release(const std::string_view left,
   return 0;
 }
 
-template <bool should_throw, bool loose>
+template <bool ShouldThrow, bool Loose>
 auto parse_semver(const std::string_view input, std::uint64_t &major,
                   std::uint64_t &minor, std::uint64_t &patch,
                   std::string_view &pre_release, std::string_view &build)
     -> bool {
   std::size_t position = 0;
 
-  if constexpr (loose) {
+  if constexpr (Loose) {
     if (position < input.size() &&
         (input[position] == 'v' || input[position] == 'V')) {
       ++position;
@@ -244,16 +244,16 @@ auto parse_semver(const std::string_view input, std::uint64_t &major,
   }
 
   const auto major_result = parse_numeric_identifier(input, position, major);
-  if (major_result == NumericParseResult::overflow) {
-    if constexpr (should_throw) {
+  if (major_result == NumericParseResult::Overflow) {
+    if constexpr (ShouldThrow) {
       throw sourcemeta::core::SemVerOverflowError(position + 1);
     }
 
     return false;
   }
 
-  if (major_result == NumericParseResult::invalid) {
-    if constexpr (should_throw) {
+  if (major_result == NumericParseResult::Invalid) {
+    if constexpr (ShouldThrow) {
       throw sourcemeta::core::SemVerParseError(position + 1);
     }
 
@@ -263,14 +263,14 @@ auto parse_semver(const std::string_view input, std::uint64_t &major,
   auto can_end_core = [&]() -> bool {
     if (position >= input.size() || input[position] == '-' ||
         input[position] == '+') {
-      return loose;
+      return Loose;
     }
 
     return input[position] == '.';
   };
 
   if (!can_end_core()) {
-    if constexpr (should_throw) {
+    if constexpr (ShouldThrow) {
       throw sourcemeta::core::SemVerParseError(position + 1);
     }
 
@@ -281,16 +281,16 @@ auto parse_semver(const std::string_view input, std::uint64_t &major,
     ++position;
 
     const auto minor_result = parse_numeric_identifier(input, position, minor);
-    if (minor_result == NumericParseResult::overflow) {
-      if constexpr (should_throw) {
+    if (minor_result == NumericParseResult::Overflow) {
+      if constexpr (ShouldThrow) {
         throw sourcemeta::core::SemVerOverflowError(position + 1);
       }
 
       return false;
     }
 
-    if (minor_result == NumericParseResult::invalid) {
-      if constexpr (should_throw) {
+    if (minor_result == NumericParseResult::Invalid) {
+      if constexpr (ShouldThrow) {
         throw sourcemeta::core::SemVerParseError(position + 1);
       }
 
@@ -298,7 +298,7 @@ auto parse_semver(const std::string_view input, std::uint64_t &major,
     }
 
     if (!can_end_core()) {
-      if constexpr (should_throw) {
+      if constexpr (ShouldThrow) {
         throw sourcemeta::core::SemVerParseError(position + 1);
       }
 
@@ -310,16 +310,16 @@ auto parse_semver(const std::string_view input, std::uint64_t &major,
 
       const auto patch_result =
           parse_numeric_identifier(input, position, patch);
-      if (patch_result == NumericParseResult::overflow) {
-        if constexpr (should_throw) {
+      if (patch_result == NumericParseResult::Overflow) {
+        if constexpr (ShouldThrow) {
           throw sourcemeta::core::SemVerOverflowError(position + 1);
         }
 
         return false;
       }
 
-      if (patch_result == NumericParseResult::invalid) {
-        if constexpr (should_throw) {
+      if (patch_result == NumericParseResult::Invalid) {
+        if constexpr (ShouldThrow) {
           throw sourcemeta::core::SemVerParseError(position + 1);
         }
 
@@ -339,7 +339,7 @@ auto parse_semver(const std::string_view input, std::uint64_t &major,
     // directly to keep this path non-throwing
     pre_release = std::string_view{input.data() + start, position - start};
     if (!validate_dot_separated<validate_pre_release_identifier>(pre_release)) {
-      if constexpr (should_throw) {
+      if constexpr (ShouldThrow) {
         throw sourcemeta::core::SemVerParseError(start + 1);
       }
 
@@ -354,7 +354,7 @@ auto parse_semver(const std::string_view input, std::uint64_t &major,
 
     build = std::string_view{input.data() + start, position - start};
     if (!validate_dot_separated<validate_build_identifier>(build)) {
-      if constexpr (should_throw) {
+      if constexpr (ShouldThrow) {
         throw sourcemeta::core::SemVerParseError(start + 1);
       }
 
@@ -363,7 +363,7 @@ auto parse_semver(const std::string_view input, std::uint64_t &major,
   }
 
   if (position != input.size()) {
-    if constexpr (should_throw) {
+    if constexpr (ShouldThrow) {
       throw sourcemeta::core::SemVerParseError(position + 1);
     }
 

--- a/src/core/time/asctime.cc
+++ b/src/core/time/asctime.cc
@@ -41,18 +41,18 @@ auto from_asctime(const std::string_view value) noexcept
     return std::nullopt;
   }
   if ((value[8] != ' ' &&
-       !std::isdigit(static_cast<unsigned char>(value[8]))) ||
-      !std::isdigit(static_cast<unsigned char>(value[9])) ||
-      !std::isdigit(static_cast<unsigned char>(value[11])) ||
-      !std::isdigit(static_cast<unsigned char>(value[12])) ||
-      !std::isdigit(static_cast<unsigned char>(value[14])) ||
-      !std::isdigit(static_cast<unsigned char>(value[15])) ||
-      !std::isdigit(static_cast<unsigned char>(value[17])) ||
-      !std::isdigit(static_cast<unsigned char>(value[18])) ||
-      !std::isdigit(static_cast<unsigned char>(value[20])) ||
-      !std::isdigit(static_cast<unsigned char>(value[21])) ||
-      !std::isdigit(static_cast<unsigned char>(value[22])) ||
-      !std::isdigit(static_cast<unsigned char>(value[23]))) {
+       (std::isdigit(static_cast<unsigned char>(value[8])) == 0)) ||
+      (std::isdigit(static_cast<unsigned char>(value[9])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[11])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[12])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[14])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[15])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[17])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[18])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[20])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[21])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[22])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[23])) == 0)) {
     return std::nullopt;
   }
   std::string normalised{value};

--- a/src/core/time/clock_shift.cc
+++ b/src/core/time/clock_shift.cc
@@ -20,10 +20,10 @@ static_assert(std::ratio_less_equal_v<Clock::period, std::ratio<1>>);
 // shifting the wrong way would be worse than ignoring it
 auto bounded_ticks(const std::chrono::seconds span) noexcept
     -> Clock::duration {
-  constexpr auto limit{
+  constexpr auto LIMIT{
       std::chrono::duration_cast<std::chrono::seconds>(Clock::duration::max())};
   return std::chrono::duration_cast<Clock::duration>(
-      std::clamp(span, std::chrono::seconds::zero(), limit));
+      std::clamp(span, std::chrono::seconds::zero(), LIMIT));
 }
 
 } // namespace

--- a/src/core/time/helpers.h
+++ b/src/core/time/helpers.h
@@ -36,11 +36,11 @@ inline auto broken_down_time_to_time_point(const std::tm &parts)
   using TimePoint = std::chrono::system_clock::time_point;
   // The bounds round inwards so the value cast back to the finer duration stays
   // within range
-  constexpr auto minimum{std::chrono::ceil<std::chrono::seconds>(
+  constexpr auto MINIMUM{std::chrono::ceil<std::chrono::seconds>(
       TimePoint::min().time_since_epoch())};
-  constexpr auto maximum{std::chrono::floor<std::chrono::seconds>(
+  constexpr auto MAXIMUM{std::chrono::floor<std::chrono::seconds>(
       TimePoint::max().time_since_epoch())};
-  if (since_epoch < minimum || since_epoch > maximum) {
+  if (since_epoch < MINIMUM || since_epoch > MAXIMUM) {
     return std::nullopt;
   }
 
@@ -92,19 +92,19 @@ inline auto format_four_digit_year(const int year) -> std::string {
 // implementations, so the exact spelling is verified against the parsed index
 inline auto is_case_sensitive_day_abbreviation(const std::string_view name,
                                                const int weekday) -> bool {
-  static constexpr std::array<std::string_view, 7> names{
+  static constexpr std::array<std::string_view, 7> NAMES{
       {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}};
   return weekday >= 0 && weekday < 7 &&
-         name == names[static_cast<std::size_t>(weekday)];
+         name == NAMES[static_cast<std::size_t>(weekday)];
 }
 
 inline auto is_case_sensitive_month_abbreviation(const std::string_view name,
                                                  const int month) -> bool {
-  static constexpr std::array<std::string_view, 12> names{
+  static constexpr std::array<std::string_view, 12> NAMES{
       {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct",
        "Nov", "Dec"}};
   return month >= 0 && month < 12 &&
-         name == names[static_cast<std::size_t>(month)];
+         name == NAMES[static_cast<std::size_t>(month)];
 }
 
 // Validate the calendar fields of a broken-down time, since the conversion to

--- a/src/core/time/imf_fixdate.cc
+++ b/src/core/time/imf_fixdate.cc
@@ -43,18 +43,18 @@ auto from_imf_fixdate(const std::string_view value) noexcept
       value[22] != ':' || value[25] != ' ' || value.substr(26) != "GMT") {
     return std::nullopt;
   }
-  if (!std::isdigit(static_cast<unsigned char>(value[5])) ||
-      !std::isdigit(static_cast<unsigned char>(value[6])) ||
-      !std::isdigit(static_cast<unsigned char>(value[12])) ||
-      !std::isdigit(static_cast<unsigned char>(value[13])) ||
-      !std::isdigit(static_cast<unsigned char>(value[14])) ||
-      !std::isdigit(static_cast<unsigned char>(value[15])) ||
-      !std::isdigit(static_cast<unsigned char>(value[17])) ||
-      !std::isdigit(static_cast<unsigned char>(value[18])) ||
-      !std::isdigit(static_cast<unsigned char>(value[20])) ||
-      !std::isdigit(static_cast<unsigned char>(value[21])) ||
-      !std::isdigit(static_cast<unsigned char>(value[23])) ||
-      !std::isdigit(static_cast<unsigned char>(value[24]))) {
+  if ((std::isdigit(static_cast<unsigned char>(value[5])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[6])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[12])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[13])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[14])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[15])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[17])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[18])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[20])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[21])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[23])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(value[24])) == 0)) {
     return std::nullopt;
   }
   std::istringstream stream{std::string{value}};

--- a/src/core/time/include/sourcemeta/core/time.h
+++ b/src/core/time/include/sourcemeta/core/time.h
@@ -386,7 +386,7 @@ auto is_rfc3339_duration(const std::string_view value) -> bool;
 /// assert(!sourcemeta::core::is_leap_year(1900));
 /// assert(!sourcemeta::core::is_leap_year(2021));
 /// ```
-inline constexpr auto is_leap_year(const std::uint16_t year) -> bool {
+constexpr auto is_leap_year(const std::uint16_t year) -> bool {
   return (year % 4 == 0) && (year % 100 != 0 || year % 400 == 0);
 }
 
@@ -404,16 +404,15 @@ inline constexpr auto is_leap_year(const std::uint16_t year) -> bool {
 /// assert(sourcemeta::core::max_day_in_month(2, 2021) == 28);
 /// assert(sourcemeta::core::max_day_in_month(4, 2024) == 30);
 /// ```
-inline constexpr auto max_day_in_month(const std::uint8_t month,
-                                       const std::uint16_t year)
-    -> std::uint8_t {
+constexpr auto max_day_in_month(const std::uint8_t month,
+                                const std::uint16_t year) -> std::uint8_t {
   assert(month >= 1 && month <= 12);
-  constexpr std::array<std::uint8_t, 13> days{
+  constexpr std::array<std::uint8_t, 13> DAYS{
       {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}};
   if (month == 2 && is_leap_year(year)) {
     return 29;
   }
-  return days[month];
+  return DAYS[month];
 }
 
 } // namespace sourcemeta::core

--- a/src/core/time/rfc3339_datetime.cc
+++ b/src/core/time/rfc3339_datetime.cc
@@ -33,22 +33,22 @@ auto is_rfc3339_datetime(const std::string_view value) -> bool {
   // time-of-day after offset is 23:59. We additionally need to confirm that
   // the UTC date (after any day-rollback from the offset) is June 30 or
   // December 31. If second != 60, no further check is needed
-  const auto second{static_cast<unsigned int>(value[17] - '0') * 10 +
+  const auto second{(static_cast<unsigned int>(value[17] - '0') * 10) +
                     static_cast<unsigned int>(value[18] - '0')};
   if (second != 60) {
     return true;
   }
 
   const auto year{static_cast<std::uint16_t>(
-      (value[0] - '0') * 1000 + (value[1] - '0') * 100 + (value[2] - '0') * 10 +
-      (value[3] - '0'))};
+      ((value[0] - '0') * 1000) + ((value[1] - '0') * 100) +
+      ((value[2] - '0') * 10) + (value[3] - '0'))};
   const auto month{
-      static_cast<std::uint8_t>((value[5] - '0') * 10 + (value[6] - '0'))};
+      static_cast<std::uint8_t>(((value[5] - '0') * 10) + (value[6] - '0'))};
   const auto day{
-      static_cast<std::uint8_t>((value[8] - '0') * 10 + (value[9] - '0'))};
-  const auto hour{static_cast<unsigned int>(value[11] - '0') * 10 +
+      static_cast<std::uint8_t>(((value[8] - '0') * 10) + (value[9] - '0'))};
+  const auto hour{(static_cast<unsigned int>(value[11] - '0') * 10) +
                   static_cast<unsigned int>(value[12] - '0')};
-  const auto minute{static_cast<unsigned int>(value[14] - '0') * 10 +
+  const auto minute{(static_cast<unsigned int>(value[14] - '0') * 10) +
                     static_cast<unsigned int>(value[15] - '0')};
 
   // Locate the offset. After is_rfc3339_fulltime validation, the input ends
@@ -61,10 +61,10 @@ auto is_rfc3339_datetime(const std::string_view value) -> bool {
     const auto offset_start{size - 6};
     offset_sign = value[offset_start];
     offset_hour =
-        static_cast<unsigned int>(value[offset_start + 1] - '0') * 10 +
+        (static_cast<unsigned int>(value[offset_start + 1] - '0') * 10) +
         static_cast<unsigned int>(value[offset_start + 2] - '0');
     offset_minute =
-        static_cast<unsigned int>(value[offset_start + 4] - '0') * 10 +
+        (static_cast<unsigned int>(value[offset_start + 4] - '0') * 10) +
         static_cast<unsigned int>(value[offset_start + 5] - '0');
   }
 
@@ -72,8 +72,8 @@ auto is_rfc3339_datetime(const std::string_view value) -> bool {
   // Only a "+" offset can shift the UTC date backward; a "-" offset cannot
   // shift it forward while UTC time stays at 23:59, since
   // max(local) + max(offset) = 1439 + 1439 = 2878 < 1440 + 1439
-  const auto local_minute_of_day{hour * 60 + minute};
-  const auto offset_total_minutes{offset_hour * 60 + offset_minute};
+  const auto local_minute_of_day{(hour * 60) + minute};
+  const auto offset_total_minutes{(offset_hour * 60) + offset_minute};
   const bool previous_utc_day{offset_sign == '+' &&
                               local_minute_of_day < offset_total_minutes};
 

--- a/src/core/time/rfc3339_fulldate.cc
+++ b/src/core/time/rfc3339_fulldate.cc
@@ -18,8 +18,8 @@ auto is_rfc3339_fulldate(const std::string_view value) -> bool {
     return false;
   }
   const auto year{static_cast<std::uint16_t>(
-      (value[0] - '0') * 1000 + (value[1] - '0') * 100 + (value[2] - '0') * 10 +
-      (value[3] - '0'))};
+      ((value[0] - '0') * 1000) + ((value[1] - '0') * 100) +
+      ((value[2] - '0') * 10) + (value[3] - '0'))};
 
   if (value[4] != '-') {
     return false;
@@ -30,7 +30,7 @@ auto is_rfc3339_fulldate(const std::string_view value) -> bool {
     return false;
   }
   const auto month{
-      static_cast<std::uint8_t>((value[5] - '0') * 10 + (value[6] - '0'))};
+      static_cast<std::uint8_t>(((value[5] - '0') * 10) + (value[6] - '0'))};
   if (month < 1 || month > 12) {
     return false;
   }
@@ -44,7 +44,7 @@ auto is_rfc3339_fulldate(const std::string_view value) -> bool {
     return false;
   }
   const auto day{
-      static_cast<std::uint8_t>((value[8] - '0') * 10 + (value[9] - '0'))};
+      static_cast<std::uint8_t>(((value[8] - '0') * 10) + (value[9] - '0'))};
   if (day < 1 || day > max_day_in_month(month, year)) {
     return false;
   }

--- a/src/core/time/rfc3339_fulltime.cc
+++ b/src/core/time/rfc3339_fulltime.cc
@@ -19,7 +19,7 @@ auto is_rfc3339_fulltime(const std::string_view value) -> bool {
   if (!is_digit(value[0]) || !is_digit(value[1])) {
     return false;
   }
-  const auto hour{static_cast<unsigned int>(value[0] - '0') * 10 +
+  const auto hour{(static_cast<unsigned int>(value[0] - '0') * 10) +
                   static_cast<unsigned int>(value[1] - '0')};
   if (hour > 23) {
     return false;
@@ -36,7 +36,7 @@ auto is_rfc3339_fulltime(const std::string_view value) -> bool {
   if (!is_digit(value[position]) || !is_digit(value[position + 1])) {
     return false;
   }
-  const auto minute{static_cast<unsigned int>(value[position] - '0') * 10 +
+  const auto minute{(static_cast<unsigned int>(value[position] - '0') * 10) +
                     static_cast<unsigned int>(value[position + 1] - '0')};
   if (minute > 59) {
     return false;
@@ -53,7 +53,7 @@ auto is_rfc3339_fulltime(const std::string_view value) -> bool {
   if (!is_digit(value[position]) || !is_digit(value[position + 1])) {
     return false;
   }
-  const auto second{static_cast<unsigned int>(value[position] - '0') * 10 +
+  const auto second{(static_cast<unsigned int>(value[position] - '0') * 10) +
                     static_cast<unsigned int>(value[position + 1] - '0')};
   if (second > 60) {
     return false;
@@ -96,7 +96,7 @@ auto is_rfc3339_fulltime(const std::string_view value) -> bool {
     if (!is_digit(value[position]) || !is_digit(value[position + 1])) {
       return false;
     }
-    offset_hour = static_cast<unsigned int>(value[position] - '0') * 10 +
+    offset_hour = (static_cast<unsigned int>(value[position] - '0') * 10) +
                   static_cast<unsigned int>(value[position + 1] - '0');
     if (offset_hour > 23) {
       return false;
@@ -113,7 +113,7 @@ auto is_rfc3339_fulltime(const std::string_view value) -> bool {
     if (!is_digit(value[position]) || !is_digit(value[position + 1])) {
       return false;
     }
-    offset_minute = static_cast<unsigned int>(value[position] - '0') * 10 +
+    offset_minute = (static_cast<unsigned int>(value[position] - '0') * 10) +
                     static_cast<unsigned int>(value[position + 1] - '0');
     if (offset_minute > 59) {
       return false;
@@ -135,8 +135,8 @@ auto is_rfc3339_fulltime(const std::string_view value) -> bool {
   // offset, the UTC time-of-day is exactly 23:59 — the only moment a leap
   // second may legally appear
   if (second == 60) {
-    const auto local_minute_of_day{hour * 60 + minute};
-    const auto offset_total_minutes{offset_hour * 60 + offset_minute};
+    const auto local_minute_of_day{(hour * 60) + minute};
+    const auto offset_total_minutes{(offset_hour * 60) + offset_minute};
 
     unsigned int utc_minute_of_day{0};
     if (offset_sign == '+') {
@@ -149,7 +149,7 @@ auto is_rfc3339_fulltime(const std::string_view value) -> bool {
       utc_minute_of_day = (local_minute_of_day + offset_total_minutes) % 1440;
     }
 
-    if (utc_minute_of_day != 23 * 60 + 59) {
+    if (utc_minute_of_day != (23 * 60) + 59) {
       return false;
     }
   }

--- a/src/core/time/rfc3339_partialtime_no_secfrac.cc
+++ b/src/core/time/rfc3339_partialtime_no_secfrac.cc
@@ -13,7 +13,7 @@ auto is_rfc3339_partialtime_no_secfrac(const std::string_view value) -> bool {
   if (!is_digit(value[0]) || !is_digit(value[1])) {
     return false;
   }
-  const auto hour{static_cast<unsigned int>(value[0] - '0') * 10 +
+  const auto hour{(static_cast<unsigned int>(value[0] - '0') * 10) +
                   static_cast<unsigned int>(value[1] - '0')};
   if (hour > 23) {
     return false;
@@ -27,7 +27,7 @@ auto is_rfc3339_partialtime_no_secfrac(const std::string_view value) -> bool {
   if (!is_digit(value[3]) || !is_digit(value[4])) {
     return false;
   }
-  const auto minute{static_cast<unsigned int>(value[3] - '0') * 10 +
+  const auto minute{(static_cast<unsigned int>(value[3] - '0') * 10) +
                     static_cast<unsigned int>(value[4] - '0')};
   if (minute > 59) {
     return false;
@@ -41,7 +41,7 @@ auto is_rfc3339_partialtime_no_secfrac(const std::string_view value) -> bool {
   if (!is_digit(value[6]) || !is_digit(value[7])) {
     return false;
   }
-  const auto second{static_cast<unsigned int>(value[6] - '0') * 10 +
+  const auto second{(static_cast<unsigned int>(value[6] - '0') * 10) +
                     static_cast<unsigned int>(value[7] - '0')};
   if (second > 60) {
     return false;

--- a/src/core/time/rfc850_date.cc
+++ b/src/core/time/rfc850_date.cc
@@ -56,19 +56,19 @@ auto from_rfc850_date(const std::string_view value) noexcept
       rest[10] != ' ' || rest.substr(19) != " GMT") {
     return std::nullopt;
   }
-  if (!std::isdigit(static_cast<unsigned char>(rest[1])) ||
-      !std::isdigit(static_cast<unsigned char>(rest[2])) ||
-      !std::isdigit(static_cast<unsigned char>(rest[8])) ||
-      !std::isdigit(static_cast<unsigned char>(rest[9])) ||
-      !std::isdigit(static_cast<unsigned char>(rest[11])) ||
-      !std::isdigit(static_cast<unsigned char>(rest[12])) ||
-      !std::isdigit(static_cast<unsigned char>(rest[14])) ||
-      !std::isdigit(static_cast<unsigned char>(rest[15])) ||
-      !std::isdigit(static_cast<unsigned char>(rest[17])) ||
-      !std::isdigit(static_cast<unsigned char>(rest[18]))) {
+  if ((std::isdigit(static_cast<unsigned char>(rest[1])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(rest[2])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(rest[8])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(rest[9])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(rest[11])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(rest[12])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(rest[14])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(rest[15])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(rest[17])) == 0) ||
+      (std::isdigit(static_cast<unsigned char>(rest[18])) == 0)) {
     return std::nullopt;
   }
-  const int two_digit_year{(rest[8] - '0') * 10 + (rest[9] - '0')};
+  const int two_digit_year{((rest[8] - '0') * 10) + (rest[9] - '0')};
   const auto current_year{current_utc_year()};
   if (!current_year.has_value()) {
     return std::nullopt;

--- a/src/core/time/unix_timestamp.cc
+++ b/src/core/time/unix_timestamp.cc
@@ -15,15 +15,15 @@ auto from_unix_timestamp(const std::chrono::duration<double> seconds) noexcept
   // Reject timestamps outside the clock's representable window, leaving a one
   // second guard so that the conversion to the clock's native tick cannot
   // overflow at the boundary
-  constexpr auto maximum{
+  constexpr auto MAXIMUM{
       std::chrono::duration_cast<std::chrono::duration<double>>(
           std::chrono::system_clock::duration::max()) -
       std::chrono::duration<double>{1}};
-  constexpr auto minimum{
+  constexpr auto MINIMUM{
       std::chrono::duration_cast<std::chrono::duration<double>>(
           std::chrono::system_clock::duration::min()) +
       std::chrono::duration<double>{1}};
-  if (seconds < minimum || seconds > maximum) {
+  if (seconds < MINIMUM || seconds > MAXIMUM) {
     return std::nullopt;
   }
 

--- a/src/core/unicode/codegen.cc
+++ b/src/core/unicode/codegen.cc
@@ -117,9 +117,9 @@ auto canonical_index(const std::span<const std::string_view> order,
 
 template <typename Callback>
 auto for_each_ucd_entry(std::istream &stream, Callback callback) -> void {
-  static const std::regex line_re{
+  static const std::regex LINE_RE{
       R"(^([0-9A-Fa-f]+)(?:\.\.([0-9A-Fa-f]+))?\s*;\s*(.*)$)"};
-  static const std::regex missing_re{R"(^#\s*@missing:\s*(.+?)\s*$)"};
+  static const std::regex MISSING_RE{R"(^#\s*@missing:\s*(.+?)\s*$)"};
 
   sourcemeta::core::for_each_line(stream, [&](const std::string_view raw_line) {
     const auto trimmed{sourcemeta::core::trim(raw_line)};
@@ -131,7 +131,7 @@ auto for_each_ucd_entry(std::istream &stream, Callback callback) -> void {
     if (trimmed.front() == '#') {
       std::cmatch match;
       if (!std::regex_match(trimmed.data(), trimmed.data() + trimmed.size(),
-                            match, missing_re)) {
+                            match, MISSING_RE)) {
         return;
       }
       content = match[1].str();
@@ -141,7 +141,7 @@ auto for_each_ucd_entry(std::istream &stream, Callback callback) -> void {
           sourcemeta::core::trim(sourcemeta::core::take_until(trimmed, '#'))};
     }
     std::smatch match;
-    if (!std::regex_match(content, match, line_re)) {
+    if (!std::regex_match(content, match, LINE_RE)) {
       throw std::runtime_error{
           std::string{"Unparseable UCD line: "}.append(content)};
     }
@@ -183,7 +183,9 @@ auto parse_property_file(const std::filesystem::path &input_path,
           std::string{"Unknown property value: "}.append(value_token)};
     }
     (entry.is_missing ? missing : data)
-        .push_back({entry.first, entry.last, value_it->second});
+        .push_back({.first = entry.first,
+                    .last = entry.last,
+                    .value = value_it->second});
   });
   std::vector<PropertyEntry> result;
   result.reserve(missing.size() + data.size());
@@ -346,14 +348,15 @@ auto build_canonical_compositions(
         ccc_of(decomposition[0]) != 0 || full_exclusions.contains(composed)) {
       continue;
     }
-    triples.push_back({decomposition[0], decomposition[1], composed});
+    triples.push_back({.starter = decomposition[0],
+                       .combining = decomposition[1],
+                       .composed = composed});
   }
-  std::sort(triples.begin(), triples.end(),
-            [](const CanonicalCompositionTriple &left,
-               const CanonicalCompositionTriple &right) {
-              return std::tie(left.starter, left.combining, left.composed) <
-                     std::tie(right.starter, right.combining, right.composed);
-            });
+  std::ranges::sort(triples, [](const CanonicalCompositionTriple &left,
+                                const CanonicalCompositionTriple &right) {
+    return std::tie(left.starter, left.combining, left.composed) <
+           std::tie(right.starter, right.combining, right.composed);
+  });
   return triples;
 }
 
@@ -404,7 +407,9 @@ auto build_canonical_decomposition_pages(
         (decomposition.size() << DECOMPOSITION_OFFSET_BITS) | offset);
   }
   auto [stage1, stage2] = build_page_table<std::uint16_t>(std::span{packed});
-  return {std::move(blob), std::move(stage1), std::move(stage2)};
+  return {.blob = std::move(blob),
+          .stage1 = std::move(stage1),
+          .stage2 = std::move(stage2)};
 }
 
 auto build_pages(const std::vector<PropertyEntry> &entries) -> TwoStageTable {
@@ -416,7 +421,7 @@ auto build_pages(const std::vector<PropertyEntry> &entries) -> TwoStageTable {
     }
   }
   auto [stage1, stage2] = build_page_table<std::uint8_t>(std::span{values});
-  return {std::move(stage1), std::move(stage2)};
+  return {.stage1 = std::move(stage1), .stage2 = std::move(stage2)};
 }
 
 template <typename T, typename Format>
@@ -436,11 +441,11 @@ auto emit_row(std::ostream &stream, const std::span<const T> items,
   }
 }
 
-constexpr auto emit_decimal{[](std::ostream &stream, const auto value) {
+constexpr auto EMIT_DECIMAL{[](std::ostream &stream, const auto value) {
   stream << static_cast<std::uint64_t>(value);
 }};
 
-constexpr auto emit_hex{[](std::ostream &stream, const auto value) {
+constexpr auto EMIT_HEX{[](std::ostream &stream, const auto value) {
   stream << "0x" << std::hex << std::uppercase
          << static_cast<std::uint64_t>(value) << std::dec;
 }};
@@ -449,11 +454,11 @@ auto emit_property(std::ostream &stream, const std::string_view prefix,
                    const TwoStageTable &table) -> void {
   stream << "constexpr std::uint16_t " << prefix << "_STAGE1["
          << table.stage1.size() << "] = {\n";
-  emit_row<std::uint16_t>(stream, table.stage1, 16, emit_decimal);
+  emit_row<std::uint16_t>(stream, table.stage1, 16, EMIT_DECIMAL);
   stream << "};\n\n";
   stream << "constexpr std::uint8_t " << prefix << "_STAGE2["
          << table.stage2.size() << "] = {\n";
-  emit_row<std::uint8_t>(stream, table.stage2, 16, emit_decimal);
+  emit_row<std::uint8_t>(stream, table.stage2, 16, EMIT_DECIMAL);
   stream << "};\n\n";
 }
 
@@ -461,15 +466,15 @@ auto emit_canonical_decomposition(std::ostream &stream,
                                   const DecompositionTable &table) -> void {
   stream << "constexpr char32_t CANONICAL_DECOMPOSITION_BLOB["
          << table.blob.size() << "] = {\n";
-  emit_row<char32_t>(stream, table.blob, 8, emit_hex);
+  emit_row<char32_t>(stream, table.blob, 8, EMIT_HEX);
   stream << "};\n\n";
   stream << "constexpr std::uint16_t CANONICAL_DECOMPOSITION_STAGE1["
          << table.stage1.size() << "] = {\n";
-  emit_row<std::uint16_t>(stream, table.stage1, 16, emit_decimal);
+  emit_row<std::uint16_t>(stream, table.stage1, 16, EMIT_DECIMAL);
   stream << "};\n\n";
   stream << "constexpr std::uint16_t CANONICAL_DECOMPOSITION_STAGE2["
          << table.stage2.size() << "] = {\n";
-  emit_row<std::uint16_t>(stream, table.stage2, 16, emit_decimal);
+  emit_row<std::uint16_t>(stream, table.stage2, 16, EMIT_DECIMAL);
   stream << "};\n\n";
 }
 
@@ -565,15 +570,30 @@ auto main(const int argc, const char *const argv[]) -> int {
     };
 
     const std::array<PropertySpec, 6> properties{
-        {{"COMBINING_CLASS", positional.at(2), std::nullopt,
-          combining_class_map},
-         {"JOINING_TYPE", positional.at(3), std::nullopt, joining_type_map},
-         {"BIDI_CLASS", positional.at(4), std::nullopt, bidi_class_map},
-         {"UNICODE_SCRIPT", positional.at(5), std::nullopt, script_map},
-         {"IS_COMBINING_MARK", positional.at(6), std::nullopt,
-          combining_mark_map},
-         {"NFC_QUICK_CHECK", normalization_props_path,
-          std::optional<std::string_view>{"NFC_QC"}, nfc_quick_check_map}}};
+        {{.prefix = "COMBINING_CLASS",
+          .input_path = positional.at(2),
+          .property_filter = std::nullopt,
+          .value_map = combining_class_map},
+         {.prefix = "JOINING_TYPE",
+          .input_path = positional.at(3),
+          .property_filter = std::nullopt,
+          .value_map = joining_type_map},
+         {.prefix = "BIDI_CLASS",
+          .input_path = positional.at(4),
+          .property_filter = std::nullopt,
+          .value_map = bidi_class_map},
+         {.prefix = "UNICODE_SCRIPT",
+          .input_path = positional.at(5),
+          .property_filter = std::nullopt,
+          .value_map = script_map},
+         {.prefix = "IS_COMBINING_MARK",
+          .input_path = positional.at(6),
+          .property_filter = std::nullopt,
+          .value_map = combining_mark_map},
+         {.prefix = "NFC_QUICK_CHECK",
+          .input_path = normalization_props_path,
+          .property_filter = std::optional<std::string_view>{"NFC_QC"},
+          .value_map = nfc_quick_check_map}}};
 
     const auto unicode_data{parse_unicode_data(unicode_data_path)};
     const auto full_exclusions{

--- a/src/core/unicode/include/sourcemeta/core/unicode.h
+++ b/src/core/unicode/include/sourcemeta/core/unicode.h
@@ -206,8 +206,7 @@ auto wide_to_utf8(const std::wstring_view input) -> std::string;
 /// assert(sourcemeta::core::utf8_lead_byte_size(0xF0) == 4);
 /// assert(sourcemeta::core::utf8_lead_byte_size(0x80) == 0);
 /// ```
-inline constexpr auto utf8_lead_byte_size(const unsigned char byte)
-    -> std::uint8_t {
+constexpr auto utf8_lead_byte_size(const unsigned char byte) -> std::uint8_t {
   if (byte < 0x80) {
     return 1;
   }
@@ -245,9 +244,9 @@ inline constexpr auto utf8_lead_byte_size(const unsigned char byte)
 /// // A surrogate lead admits no byte above %x9F
 /// assert(!sourcemeta::core::is_utf8_tail(0xED, 1, 0xA0));
 /// ```
-inline constexpr auto is_utf8_tail(const unsigned char lead,
-                                   const std::size_t position,
-                                   const unsigned char byte) -> bool {
+constexpr auto is_utf8_tail(const unsigned char lead,
+                            const std::size_t position,
+                            const unsigned char byte) -> bool {
   const unsigned char lower{static_cast<unsigned char>(
       position > 1 ? 0x80
                    : (lead == 0xE0 ? 0xA0 : (lead == 0xF0 ? 0x90 : 0x80)))};
@@ -270,8 +269,7 @@ inline constexpr auto is_utf8_tail(const unsigned char lead,
 /// // A surrogate is not a scalar value, so it is not well-formed
 /// assert(sourcemeta::core::utf8_sequence_size("\xED\xA0\x80") == 0);
 /// ```
-inline constexpr auto utf8_sequence_size(const std::string_view input)
-    -> std::size_t {
+constexpr auto utf8_sequence_size(const std::string_view input) -> std::size_t {
   if (input.empty()) {
     return 0;
   }
@@ -304,7 +302,7 @@ inline constexpr auto utf8_sequence_size(const std::string_view input)
 /// assert(!sourcemeta::core::is_utf8_continuation(0x7F));
 /// assert(!sourcemeta::core::is_utf8_continuation(0xC0));
 /// ```
-inline constexpr auto is_utf8_continuation(const unsigned char byte) -> bool {
+constexpr auto is_utf8_continuation(const unsigned char byte) -> bool {
   return byte >= 0x80 && byte <= 0xBF;
 }
 
@@ -320,7 +318,7 @@ inline constexpr auto is_utf8_continuation(const unsigned char byte) -> bool {
 /// assert(sourcemeta::core::utf8_codepoint_count("abc") == 3);
 /// assert(sourcemeta::core::utf8_codepoint_count("caf\xc3\xa9") == 4);
 /// ```
-inline constexpr auto utf8_codepoint_count(const std::string_view input)
+constexpr auto utf8_codepoint_count(const std::string_view input)
     -> std::size_t {
   std::size_t count{0};
   for (const auto byte : input) {
@@ -347,9 +345,9 @@ inline constexpr auto utf8_codepoint_count(const std::string_view input)
 /// assert(sourcemeta::core::utf8_codepoint_within("abc", 1, 5));
 /// assert(!sourcemeta::core::utf8_codepoint_within("abc", 4, 5));
 /// ```
-inline constexpr auto utf8_codepoint_within(const std::string_view input,
-                                            const std::size_t minimum,
-                                            const std::size_t maximum) -> bool {
+constexpr auto utf8_codepoint_within(const std::string_view input,
+                                     const std::size_t minimum,
+                                     const std::size_t maximum) -> bool {
   const auto bytes{input.size()};
 
   // A code point is at least one byte, so the count never exceeds the byte
@@ -401,7 +399,7 @@ inline constexpr auto utf8_codepoint_within(const std::string_view input,
 /// assert(!sourcemeta::core::is_surrogate(0xD7FF));
 /// assert(!sourcemeta::core::is_surrogate(0xE000));
 /// ```
-inline constexpr auto is_surrogate(const char32_t codepoint) -> bool {
+constexpr auto is_surrogate(const char32_t codepoint) -> bool {
   return codepoint >= 0xD800 && codepoint <= 0xDFFF;
 }
 
@@ -419,7 +417,7 @@ inline constexpr auto is_surrogate(const char32_t codepoint) -> bool {
 /// assert(!sourcemeta::core::is_valid_codepoint(0xD800));
 /// assert(!sourcemeta::core::is_valid_codepoint(0x110000));
 /// ```
-inline constexpr auto is_valid_codepoint(const char32_t codepoint) -> bool {
+constexpr auto is_valid_codepoint(const char32_t codepoint) -> bool {
   return codepoint <= 0x10FFFF && !is_surrogate(codepoint);
 }
 
@@ -438,7 +436,7 @@ inline constexpr auto is_valid_codepoint(const char32_t codepoint) -> bool {
 /// assert(!sourcemeta::core::is_ucschar(0x0041));
 /// assert(!sourcemeta::core::is_ucschar(0xE000));
 /// ```
-inline constexpr auto is_ucschar(const char32_t codepoint) -> bool {
+constexpr auto is_ucschar(const char32_t codepoint) -> bool {
   if (codepoint >= 0xA0 && codepoint <= 0xD7FF) {
     return true;
   }
@@ -474,7 +472,7 @@ inline constexpr auto is_ucschar(const char32_t codepoint) -> bool {
 /// assert(!sourcemeta::core::is_iprivate(0x0041));
 /// assert(!sourcemeta::core::is_iprivate(0xF8FF + 1));
 /// ```
-inline constexpr auto is_iprivate(const char32_t codepoint) -> bool {
+constexpr auto is_iprivate(const char32_t codepoint) -> bool {
   if (codepoint >= 0xE000 && codepoint <= 0xF8FF) {
     return true;
   }
@@ -502,7 +500,7 @@ inline constexpr auto is_iprivate(const char32_t codepoint) -> bool {
 /// assert(sourcemeta::core::utf8_codepoint_byte_count(0x4E2D) == 3);
 /// assert(sourcemeta::core::utf8_codepoint_byte_count(0x1F600) == 4);
 /// ```
-inline constexpr auto utf8_codepoint_byte_count(const char32_t codepoint)
+constexpr auto utf8_codepoint_byte_count(const char32_t codepoint)
     -> std::uint8_t {
   if (codepoint < 0x80) {
     return 1;
@@ -717,9 +715,8 @@ auto is_nfc(const std::u32string_view input) -> bool;
 /// assert(sourcemeta::core::utf8_codepoint_length("\xf0\x9f\x98\x80", 0) == 4);
 /// assert(sourcemeta::core::utf8_codepoint_length("\xed\xa0\x80", 0) == 0);
 /// ```
-inline constexpr auto
-utf8_codepoint_length(const std::string_view input,
-                      const std::string_view::size_type position)
+constexpr auto utf8_codepoint_length(const std::string_view input,
+                                     const std::string_view::size_type position)
     -> std::size_t {
   if (position >= input.size()) {
     return 0;
@@ -791,8 +788,8 @@ utf8_codepoint_length(const std::string_view input,
 /// assert(result.value().second == 2);
 /// assert(!sourcemeta::core::utf8_decode("\xED\xA0\x80", 0).has_value());
 /// ```
-inline constexpr auto utf8_decode(const std::string_view input,
-                                  const std::string_view::size_type position)
+constexpr auto utf8_decode(const std::string_view input,
+                           const std::string_view::size_type position)
     -> std::optional<std::pair<char32_t, std::size_t>> {
   const auto size{utf8_codepoint_length(input, position)};
   if (size == 0) {

--- a/src/core/unicode/nfc.cc
+++ b/src/core/unicode/nfc.cc
@@ -29,9 +29,9 @@ auto canonical_decompose_recursive(const char32_t codepoint,
   if (codepoint >= HANGUL_SBASE && codepoint < HANGUL_SBASE + HANGUL_SCOUNT) {
     const auto index{static_cast<std::size_t>(codepoint - HANGUL_SBASE)};
     output.push_back(
-        static_cast<char32_t>(HANGUL_LBASE + index / HANGUL_NCOUNT));
+        static_cast<char32_t>(HANGUL_LBASE + (index / HANGUL_NCOUNT)));
     output.push_back(static_cast<char32_t>(
-        HANGUL_VBASE + (index % HANGUL_NCOUNT) / HANGUL_TCOUNT));
+        HANGUL_VBASE + ((index % HANGUL_NCOUNT) / HANGUL_TCOUNT)));
     const auto t_index{index % HANGUL_TCOUNT};
     if (t_index != 0) {
       output.push_back(static_cast<char32_t>(HANGUL_TBASE + t_index));
@@ -80,7 +80,7 @@ auto try_compose(const char32_t starter, const char32_t combining) noexcept
     const auto l_index{static_cast<std::size_t>(starter - HANGUL_LBASE)};
     const auto v_index{static_cast<std::size_t>(combining - HANGUL_VBASE)};
     return static_cast<char32_t>(
-        HANGUL_SBASE + (l_index * HANGUL_VCOUNT + v_index) * HANGUL_TCOUNT);
+        HANGUL_SBASE + (((l_index * HANGUL_VCOUNT) + v_index) * HANGUL_TCOUNT));
   }
 
   if (starter >= HANGUL_SBASE && starter < HANGUL_SBASE + HANGUL_SCOUNT &&

--- a/src/core/uri/accessors.cc
+++ b/src/core/uri/accessors.cc
@@ -84,16 +84,16 @@ auto URI::is_localhost() const -> bool {
     host.remove_suffix(1);
   }
 
-  constexpr std::string_view name{"localhost"};
-  if (host.size() < name.size()) {
+  constexpr std::string_view NAME{"localhost"};
+  if (host.size() < NAME.size()) {
     return false;
   }
 
-  if (host.size() > name.size() && host[host.size() - name.size() - 1] != '.') {
+  if (host.size() > NAME.size() && host[host.size() - NAME.size() - 1] != '.') {
     return false;
   }
 
-  return equals_ignore_case(host.substr(host.size() - name.size()), name);
+  return equals_ignore_case(host.substr(host.size() - NAME.size()), NAME);
 }
 
 auto URI::is_fragment_only() const -> bool {

--- a/src/core/uri/filesystem.cc
+++ b/src/core/uri/filesystem.cc
@@ -13,9 +13,9 @@
 namespace {
 
 auto is_localhost_host(const std::string_view host) -> bool {
-  constexpr std::string_view localhost{"localhost"};
+  constexpr std::string_view LOCALHOST{"localhost"};
   return std::ranges::equal(
-      host, localhost, [](const char left, const char right) -> bool {
+      host, LOCALHOST, [](const char left, const char right) -> bool {
         return std::tolower(static_cast<unsigned char>(left)) == right;
       });
 }

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -871,7 +871,7 @@ public:
   template <typename Output>
   static auto escape(const std::string_view input, Output &output,
                      const bool maybe_encoded = false) -> void {
-    output.reserve(output.size() + input.size() * 3);
+    output.reserve(output.size() + (input.size() * 3));
     for (std::size_t position = 0; position < input.size();) {
       auto byte{static_cast<unsigned char>(input[position])};
       std::size_t advance{1};

--- a/src/core/uri/parse.cc
+++ b/src/core/uri/parse.cc
@@ -661,7 +661,12 @@ auto URI::is_gen_delim(const char character) noexcept -> bool {
 
 auto URI::is_uri(const std::string_view input) noexcept -> bool {
   try {
-    std::optional<std::string> scheme, userinfo, host, path, query, fragment;
+    std::optional<std::string> scheme;
+    std::optional<std::string> userinfo;
+    std::optional<std::string> host;
+    std::optional<std::string> path;
+    std::optional<std::string> query;
+    std::optional<std::string> fragment;
     std::optional<std::uint32_t> port;
     bool ip_literal{false};
     return do_parse<true, false>(input, scheme, userinfo, host, port, path,
@@ -673,7 +678,12 @@ auto URI::is_uri(const std::string_view input) noexcept -> bool {
 
 auto URI::is_uri_reference(const std::string_view input) noexcept -> bool {
   try {
-    std::optional<std::string> scheme, userinfo, host, path, query, fragment;
+    std::optional<std::string> scheme;
+    std::optional<std::string> userinfo;
+    std::optional<std::string> host;
+    std::optional<std::string> path;
+    std::optional<std::string> query;
+    std::optional<std::string> fragment;
     std::optional<std::uint32_t> port;
     bool ip_literal{false};
     do_parse<true, false>(input, scheme, userinfo, host, port, path, query,
@@ -686,7 +696,12 @@ auto URI::is_uri_reference(const std::string_view input) noexcept -> bool {
 
 auto URI::is_iri(const std::string_view input) noexcept -> bool {
   try {
-    std::optional<std::string> scheme, userinfo, host, path, query, fragment;
+    std::optional<std::string> scheme;
+    std::optional<std::string> userinfo;
+    std::optional<std::string> host;
+    std::optional<std::string> path;
+    std::optional<std::string> query;
+    std::optional<std::string> fragment;
     std::optional<std::uint32_t> port;
     bool ip_literal{false};
     return do_parse<true, true>(input, scheme, userinfo, host, port, path,
@@ -698,7 +713,12 @@ auto URI::is_iri(const std::string_view input) noexcept -> bool {
 
 auto URI::is_iri_reference(const std::string_view input) noexcept -> bool {
   try {
-    std::optional<std::string> scheme, userinfo, host, path, query, fragment;
+    std::optional<std::string> scheme;
+    std::optional<std::string> userinfo;
+    std::optional<std::string> host;
+    std::optional<std::string> path;
+    std::optional<std::string> query;
+    std::optional<std::string> fragment;
     std::optional<std::uint32_t> port;
     bool ip_literal{false};
     do_parse<true, true>(input, scheme, userinfo, host, port, path, query,

--- a/src/core/uri/recompose.cc
+++ b/src/core/uri/recompose.cc
@@ -16,7 +16,7 @@ namespace {
 auto escape_component_to_string(std::string &output, std::string_view input,
                                 const URIEscapeMode mode, const bool iri,
                                 const bool allow_iprivate = false) -> void {
-  output.reserve(output.size() + input.size() * 3);
+  output.reserve(output.size() + (input.size() * 3));
 
   for (std::string_view::size_type index = 0; index < input.size(); ++index) {
     const char character = input[index];
@@ -144,8 +144,7 @@ auto append_disambiguated_path(std::string &output,
     // a dot-segment". Percent encoding the colon would avoid the same misparse
     // but would name a different path, since Section 6.2.2.2 only equates
     // percent-encoded unreserved characters
-    if (path_value.substr(0, first_segment_length).find(':') !=
-        std::string_view::npos) {
+    if (path_value.substr(0, first_segment_length).contains(':')) {
       output += "./";
     }
   }
@@ -167,7 +166,7 @@ auto URI::recompose() const -> std::string {
     result = *std::move(uri);
   }
 
-  result.reserve(result.size() + this->fragment_.value().size() * 3 + 1);
+  result.reserve(result.size() + (this->fragment_.value().size() * 3) + 1);
   result += '#';
   escape_component_to_string(result, this->fragment_.value(),
                              URIEscapeMode::Fragment, this->iri_);

--- a/src/core/uritemplate/helpers.h
+++ b/src/core/uritemplate/helpers.h
@@ -4,6 +4,7 @@
 #include <sourcemeta/core/text.h>
 #include <sourcemeta/core/uritemplate.h>
 
+#include <algorithm>   // std::min
 #include <array>       // std::array
 #include <cstddef>     // std::size_t
 #include <cstdint>     // std::uint16_t
@@ -14,18 +15,18 @@
 namespace sourcemeta::core {
 
 // Type traits to detect optional static members
-template <typename T, typename = void> struct has_op : std::false_type {};
+template <typename T, typename = void> struct HasOp : std::false_type {};
 template <typename T>
-struct has_op<T, std::void_t<decltype(T::op)>> : std::true_type {};
+struct HasOp<T, std::void_t<decltype(T::OPERATOR)>> : std::true_type {};
 
-template <typename T, typename = void> struct has_prefix : std::false_type {};
+template <typename T, typename = void> struct HasPrefix : std::false_type {};
 template <typename T>
-struct has_prefix<T, std::void_t<decltype(T::prefix)>> : std::true_type {};
+struct HasPrefix<T, std::void_t<decltype(T::PREFIX)>> : std::true_type {};
 
 template <typename T, typename = void>
-struct has_empty_suffix : std::false_type {};
+struct HasEmptySuffix : std::false_type {};
 template <typename T>
-struct has_empty_suffix<T, std::void_t<decltype(T::empty_suffix)>>
+struct HasEmptySuffix<T, std::void_t<decltype(T::EMPTY_SUFFIX)>>
     : std::true_type {};
 
 inline auto is_unreserved(const char character) -> bool {
@@ -74,9 +75,7 @@ inline auto prefix_by_characters(const std::string_view input,
     taken++;
   }
 
-  if (position > input.size()) {
-    position = input.size();
-  }
+  position = std::min(position, input.size());
 
   return input.substr(0, position);
 }
@@ -106,7 +105,7 @@ inline auto passes_through_unencoded(const char character,
 
 inline auto percent_encode(std::string &output, const std::string_view input,
                            const URITemplateExpansionMode mode) -> void {
-  output.reserve(output.size() + input.size() * 3);
+  output.reserve(output.size() + (input.size() * 3));
   for (const char character : input) {
     if (is_unreserved(character) || passes_through_unencoded(character, mode)) {
       output += character;
@@ -120,7 +119,7 @@ inline auto percent_encode_reserved(std::string &output,
                                     const std::string_view input,
                                     const URITemplateExpansionMode mode)
     -> void {
-  output.reserve(output.size() + input.size() * 3);
+  output.reserve(output.size() + (input.size() * 3));
   for (std::size_t index = 0; index < input.size(); ++index) {
     const char character = input[index];
     if (is_unreserved(character) || is_reserved(character) ||
@@ -137,7 +136,7 @@ inline auto percent_encode_reserved(std::string &output,
 template <typename T>
 inline auto encode(std::string &output, const std::string_view input,
                    const URITemplateExpansionMode mode) -> void {
-  if constexpr (T::allow_reserved) {
+  if constexpr (T::ALLOW_RESERVED) {
     percent_encode_reserved(output, input, mode);
   } else {
     percent_encode(output, input, mode);
@@ -147,11 +146,11 @@ inline auto encode(std::string &output, const std::string_view input,
 template <typename T>
 inline auto append_name(std::string &result, const std::string_view name,
                         const bool value_empty, const bool has_more) -> void {
-  if constexpr (T::named) {
+  if constexpr (T::NAMED) {
     result += name;
     if (value_empty && !has_more) {
-      if constexpr (has_empty_suffix<T>::value) {
-        result += T::empty_suffix;
+      if constexpr (HasEmptySuffix<T>::value) {
+        result += T::EMPTY_SUFFIX;
       }
     } else {
       result += '=';
@@ -294,7 +293,7 @@ parse_variable_list(const std::string_view input, std::size_t position,
       std::uint16_t value = 0;
       for (const char character : prefix_str) {
         value = static_cast<std::uint16_t>(
-            value * 10 + static_cast<std::uint16_t>(character - '0'));
+            (value * 10) + static_cast<std::uint16_t>(character - '0'));
       }
 
       if (value > 9999 || value == 0) {
@@ -384,8 +383,8 @@ auto parse_expression(const std::string_view input)
     }
 
     std::size_t var_start;
-    if constexpr (has_op<T>::value) {
-      if (input.size() < 3 || input[1] != T::op) {
+    if constexpr (HasOp<T>::value) {
+      if (input.size() < 3 || input[1] != T::OPERATOR) {
         return std::nullopt;
       }
       var_start = 2;
@@ -446,29 +445,29 @@ auto expand_expression(
 
       if (variable.explode) {
         if (first_var && first_value) {
-          if constexpr (has_prefix<T>::value) {
-            result += T::prefix;
+          if constexpr (HasPrefix<T>::value) {
+            result += T::PREFIX;
           }
           first_var = false;
         } else {
-          result += T::separator;
+          result += T::SEPARATOR;
         }
 
         if (object_key.has_value()) {
           encode<T>(result, object_key.value(), mode);
           if (actual_value.empty()) {
-            if constexpr (has_empty_suffix<T>::value) {
-              result += T::empty_suffix;
+            if constexpr (HasEmptySuffix<T>::value) {
+              result += T::EMPTY_SUFFIX;
             }
           } else {
             result += '=';
             encode<T>(result, actual_value, mode);
           }
-        } else if constexpr (T::named) {
+        } else if constexpr (T::NAMED) {
           result += variable.name;
           if (actual_value.empty()) {
-            if constexpr (has_empty_suffix<T>::value) {
-              result += T::empty_suffix;
+            if constexpr (HasEmptySuffix<T>::value) {
+              result += T::EMPTY_SUFFIX;
             }
           } else {
             result += '=';
@@ -482,13 +481,13 @@ auto expand_expression(
         // empty even when the pair value is the empty string
         const bool value_empty{!object_key.has_value() && actual_value.empty()};
         if (first_var && first_value) {
-          if constexpr (has_prefix<T>::value) {
-            result += T::prefix;
+          if constexpr (HasPrefix<T>::value) {
+            result += T::PREFIX;
           }
           first_var = false;
           append_name<T>(result, variable.name, value_empty, has_more);
         } else if (first_value) {
-          result += T::separator;
+          result += T::SEPARATOR;
           append_name<T>(result, variable.name, value_empty, has_more);
         } else {
           result += ',';

--- a/src/core/uritemplate/include/sourcemeta/core/uritemplate.h
+++ b/src/core/uritemplate/include/sourcemeta/core/uritemplate.h
@@ -128,10 +128,9 @@ public:
           const auto iterator{find_variable(variables, name)};
           if (iterator == variables.end()) {
             return std::nullopt;
-          } else {
-            return std::make_tuple(std::string_view{iterator->second},
-                                   std::nullopt, false);
           }
+          return std::make_tuple(std::string_view{iterator->second},
+                                 std::nullopt, false);
         },
         mode);
   }

--- a/src/core/uritemplate/include/sourcemeta/core/uritemplate_token.h
+++ b/src/core/uritemplate/include/sourcemeta/core/uritemplate_token.h
@@ -45,11 +45,11 @@ struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenVariable {
   /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
   /// The character that separates expanded values
-  static constexpr char separator = ',';
+  static constexpr char SEPARATOR = ',';
   /// Whether the expansion includes variable names
-  static constexpr bool named = false;
+  static constexpr bool NAMED = false;
   /// Whether reserved characters are preserved unencoded
-  static constexpr bool allow_reserved = false;
+  static constexpr bool ALLOW_RESERVED = false;
 };
 
 /// @ingroup uritemplate
@@ -58,13 +58,13 @@ struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenReservedExpansion {
   /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
   /// The operator character that introduces the expression
-  static constexpr char op = '+';
+  static constexpr char OPERATOR = '+';
   /// The character that separates expanded values
-  static constexpr char separator = ',';
+  static constexpr char SEPARATOR = ',';
   /// Whether the expansion includes variable names
-  static constexpr bool named = false;
+  static constexpr bool NAMED = false;
   /// Whether reserved characters are preserved unencoded
-  static constexpr bool allow_reserved = true;
+  static constexpr bool ALLOW_RESERVED = true;
 };
 
 /// @ingroup uritemplate
@@ -73,15 +73,15 @@ struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenFragmentExpansion {
   /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
   /// The operator character that introduces the expression
-  static constexpr char op = '#';
+  static constexpr char OPERATOR = '#';
   /// The character that separates expanded values
-  static constexpr char separator = ',';
+  static constexpr char SEPARATOR = ',';
   /// The character prepended to the expansion output
-  static constexpr char prefix = '#';
+  static constexpr char PREFIX = '#';
   /// Whether the expansion includes variable names
-  static constexpr bool named = false;
+  static constexpr bool NAMED = false;
   /// Whether reserved characters are preserved unencoded
-  static constexpr bool allow_reserved = true;
+  static constexpr bool ALLOW_RESERVED = true;
 };
 
 /// @ingroup uritemplate
@@ -90,15 +90,15 @@ struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenLabelExpansion {
   /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
   /// The operator character that introduces the expression
-  static constexpr char op = '.';
+  static constexpr char OPERATOR = '.';
   /// The character that separates expanded values
-  static constexpr char separator = '.';
+  static constexpr char SEPARATOR = '.';
   /// The character prepended to the expansion output
-  static constexpr char prefix = '.';
+  static constexpr char PREFIX = '.';
   /// Whether the expansion includes variable names
-  static constexpr bool named = false;
+  static constexpr bool NAMED = false;
   /// Whether reserved characters are preserved unencoded
-  static constexpr bool allow_reserved = false;
+  static constexpr bool ALLOW_RESERVED = false;
 };
 
 /// @ingroup uritemplate
@@ -107,15 +107,15 @@ struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenPathExpansion {
   /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
   /// The operator character that introduces the expression
-  static constexpr char op = '/';
+  static constexpr char OPERATOR = '/';
   /// The character that separates expanded values
-  static constexpr char separator = '/';
+  static constexpr char SEPARATOR = '/';
   /// The character prepended to the expansion output
-  static constexpr char prefix = '/';
+  static constexpr char PREFIX = '/';
   /// Whether the expansion includes variable names
-  static constexpr bool named = false;
+  static constexpr bool NAMED = false;
   /// Whether reserved characters are preserved unencoded
-  static constexpr bool allow_reserved = false;
+  static constexpr bool ALLOW_RESERVED = false;
 };
 
 /// @ingroup uritemplate
@@ -125,15 +125,15 @@ struct SOURCEMETA_CORE_URITEMPLATE_EXPORT
   /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
   /// The operator character that introduces the expression
-  static constexpr char op = ';';
+  static constexpr char OPERATOR = ';';
   /// The character that separates expanded values
-  static constexpr char separator = ';';
+  static constexpr char SEPARATOR = ';';
   /// The character prepended to the expansion output
-  static constexpr char prefix = ';';
+  static constexpr char PREFIX = ';';
   /// Whether the expansion includes variable names
-  static constexpr bool named = true;
+  static constexpr bool NAMED = true;
   /// Whether reserved characters are preserved unencoded
-  static constexpr bool allow_reserved = false;
+  static constexpr bool ALLOW_RESERVED = false;
 };
 
 /// @ingroup uritemplate
@@ -142,17 +142,17 @@ struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenQueryExpansion {
   /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
   /// The operator character that introduces the expression
-  static constexpr char op = '?';
+  static constexpr char OPERATOR = '?';
   /// The character that separates expanded values
-  static constexpr char separator = '&';
+  static constexpr char SEPARATOR = '&';
   /// The character prepended to the expansion output
-  static constexpr char prefix = '?';
+  static constexpr char PREFIX = '?';
   /// Whether the expansion includes variable names
-  static constexpr bool named = true;
+  static constexpr bool NAMED = true;
   /// Whether reserved characters are preserved unencoded
-  static constexpr bool allow_reserved = false;
+  static constexpr bool ALLOW_RESERVED = false;
   /// The character appended to names with empty values
-  static constexpr char empty_suffix = '=';
+  static constexpr char EMPTY_SUFFIX = '=';
 };
 
 /// @ingroup uritemplate
@@ -162,17 +162,17 @@ struct SOURCEMETA_CORE_URITEMPLATE_EXPORT
   /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
   /// The operator character that introduces the expression
-  static constexpr char op = '&';
+  static constexpr char OPERATOR = '&';
   /// The character that separates expanded values
-  static constexpr char separator = '&';
+  static constexpr char SEPARATOR = '&';
   /// The character prepended to the expansion output
-  static constexpr char prefix = '&';
+  static constexpr char PREFIX = '&';
   /// Whether the expansion includes variable names
-  static constexpr bool named = true;
+  static constexpr bool NAMED = true;
   /// Whether reserved characters are preserved unencoded
-  static constexpr bool allow_reserved = false;
+  static constexpr bool ALLOW_RESERVED = false;
   /// The character appended to names with empty values
-  static constexpr char empty_suffix = '=';
+  static constexpr char EMPTY_SUFFIX = '=';
 };
 
 #if defined(_MSC_VER)

--- a/src/core/uritemplate/uritemplate_router.cc
+++ b/src/core/uritemplate/uritemplate_router.cc
@@ -16,7 +16,7 @@ namespace {
 using Node = URITemplateRouter::Node;
 using NodeType = URITemplateRouter::NodeType;
 
-constexpr auto node_value =
+constexpr auto NODE_VALUE =
     [](const std::unique_ptr<Node> &child) -> decltype(auto) {
   return child->value;
 };
@@ -24,7 +24,7 @@ constexpr auto node_value =
 auto find_literal_child(const std::vector<std::unique_ptr<Node>> &literals,
                         const std::string_view segment) -> Node * {
   const auto iterator =
-      std::ranges::lower_bound(literals, segment, {}, node_value);
+      std::ranges::lower_bound(literals, segment, {}, NODE_VALUE);
   if (iterator != literals.end() && (*iterator)->value == segment) {
     return iterator->get();
   }
@@ -33,7 +33,7 @@ auto find_literal_child(const std::vector<std::unique_ptr<Node>> &literals,
 
 auto find_or_create_literal_child(std::vector<std::unique_ptr<Node>> &literals,
                                   const std::string_view value) -> Node & {
-  auto iterator = std::ranges::lower_bound(literals, value, {}, node_value);
+  auto iterator = std::ranges::lower_bound(literals, value, {}, NODE_VALUE);
   if (iterator != literals.end() && (*iterator)->value == value) {
     return **iterator;
   }
@@ -81,8 +81,10 @@ auto walk_describe_fragment(const Node *&current, const Node &root,
     const std::string_view segment{
         segment_start, static_cast<std::size_t>(position - segment_start)};
 
-    const auto &literal_children = current ? current->literals : root.literals;
-    const auto &variable_child = current ? current->variable : root.variable;
+    const auto &literal_children =
+        (current != nullptr) ? current->literals : root.literals;
+    const auto &variable_child =
+        (current != nullptr) ? current->variable : root.variable;
 
     const Node *next = find_literal_child(literal_children, segment);
     if (next == nullptr) {
@@ -289,10 +291,10 @@ auto URITemplateRouter::add(const std::string_view uri_template,
                             const std::span<const Argument> arguments) -> void {
   assert(identifier > 0);
 
-  static const Regex operation_id_regex =
+  static const Regex OPERATION_ID_REGEX =
       to_regex("^[a-zA-Z][a-zA-Z0-9_-]{0,63}$").value();
 
-  if (!matches(operation_id_regex, operation_id)) {
+  if (!matches(OPERATION_ID_REGEX, operation_id)) {
     throw URITemplateRouterInvalidOperationIdError{operation_id};
   }
 
@@ -320,7 +322,8 @@ auto URITemplateRouter::add(const std::string_view uri_template,
       const std::string_view segment{
           segment_start,
           static_cast<std::size_t>(base_position - segment_start)};
-      auto &literals = current ? current->literals : this->root_.literals;
+      auto &literals =
+          (current != nullptr) ? current->literals : this->root_.literals;
       current = &find_or_create_literal_child(literals, segment);
       if (base_position >= base_end) {
         break;
@@ -330,7 +333,7 @@ auto URITemplateRouter::add(const std::string_view uri_template,
   }
 
   if (uri_template.empty()) {
-    auto &target = current ? *current : this->root_;
+    auto &target = (current != nullptr) ? *current : this->root_;
     const auto previous_identifier = target.identifier;
     if (previous_identifier == 0) {
       this->entries_.emplace_back(identifier, context, uri_template);
@@ -375,7 +378,8 @@ auto URITemplateRouter::add(const std::string_view uri_template,
 
   while (true) {
     if (position >= end || *position == '/') {
-      auto &literals = current ? current->literals : this->root_.literals;
+      auto &literals =
+          (current != nullptr) ? current->literals : this->root_.literals;
       current = &find_or_create_literal_child(literals, "");
       if (position >= end) {
         break;
@@ -512,7 +516,8 @@ auto URITemplateRouter::add(const std::string_view uri_template,
             "Expansion operator must be the last segment", expression};
       }
 
-      auto &variable = current ? current->variable : this->root_.variable;
+      auto &variable =
+          (current != nullptr) ? current->variable : this->root_.variable;
       auto *result =
           find_or_create_variable_child(variable, varname, type, expression);
       if (result == nullptr) {
@@ -543,7 +548,8 @@ auto URITemplateRouter::add(const std::string_view uri_template,
       if (position + 1 < end && *(position + 1) == '/') {
         const std::string_view segment{
             segment_start, static_cast<std::size_t>(position - segment_start)};
-        auto &literals = current ? current->literals : this->root_.literals;
+        auto &literals =
+            (current != nullptr) ? current->literals : this->root_.literals;
         current = &find_or_create_literal_child(literals, segment);
         continue;
       }
@@ -561,7 +567,8 @@ auto URITemplateRouter::add(const std::string_view uri_template,
     const std::string_view segment{
         segment_start, static_cast<std::size_t>(position - segment_start)};
 
-    auto &literals = current ? current->literals : this->root_.literals;
+    auto &literals =
+        (current != nullptr) ? current->literals : this->root_.literals;
     current = &find_or_create_literal_child(literals, segment);
 
     if (position >= end) {
@@ -720,7 +727,7 @@ auto URITemplateRouter::match(const std::string_view path,
     ++position;
   }
 
-  if (current && current->identifier == 0 && current->variable &&
+  if ((current != nullptr) && current->identifier == 0 && current->variable &&
       current->variable->type == NodeType::OptionalExpansion) {
     assert(variable_index <=
            std::numeric_limits<URITemplateRouter::Index>::max());
@@ -730,10 +737,11 @@ auto URITemplateRouter::match(const std::string_view path,
                           current->variable->context);
   }
 
-  return current ? finalize_match(this->otherwise_, current->identifier,
-                                  current->context)
-                 : finalize_match(this->otherwise_, this->root_.identifier,
-                                  this->root_.context);
+  return (current != nullptr)
+             ? finalize_match(this->otherwise_, current->identifier,
+                              current->context)
+             : finalize_match(this->otherwise_, this->root_.identifier,
+                              this->root_.context);
 }
 
 } // namespace sourcemeta::core

--- a/src/core/uritemplate/uritemplate_router_view.cc
+++ b/src/core/uritemplate/uritemplate_router_view.cc
@@ -134,7 +134,7 @@ inline auto binary_search_literal_children(
   std::uint32_t high = child_count;
 
   while (low < high) {
-    const auto middle = low + (high - low) / 2;
+    const auto middle = low + ((high - low) / 2);
     const auto child_index = first_child + middle;
     const auto &child = nodes[child_index];
 
@@ -446,13 +446,14 @@ auto URITemplateRouterView::save(const URITemplateRouter &router,
   header.version = ROUTER_VERSION;
   header.node_count = static_cast<std::uint32_t>(nodes.size());
   header.string_table_offset = static_cast<std::uint32_t>(
-      sizeof(RouterHeader) + nodes.size() * sizeof(SerializedNode));
+      sizeof(RouterHeader) + (nodes.size() * sizeof(SerializedNode)));
   header.arguments_offset = static_cast<std::uint32_t>(
       header.string_table_offset + string_table.size());
   header.operations_offset = static_cast<std::uint32_t>(
       header.arguments_offset + sizeof(std::uint16_t) +
-      argument_entries.size() * (sizeof(std::uint16_t) + sizeof(std::uint32_t) +
-                                 sizeof(std::uint32_t)) +
+      (argument_entries.size() *
+       (sizeof(std::uint16_t) + sizeof(std::uint32_t) +
+        sizeof(std::uint32_t))) +
       argument_blob.size());
   header.base_path_offset = base_path_string_offset;
   header.base_path_length = static_cast<std::uint32_t>(base_path_value.size());
@@ -461,7 +462,7 @@ auto URITemplateRouterView::save(const URITemplateRouter &router,
   header.base_url_length = static_cast<std::uint32_t>(base_url_value.size());
   header.paths_offset = static_cast<std::uint32_t>(
       header.operations_offset + sizeof(std::uint16_t) +
-      operation_entries.size() * OPERATION_ENTRY_SIZE);
+      (operation_entries.size() * OPERATION_ENTRY_SIZE));
 
   std::ofstream file(path, std::ios::binary);
   if (!file) {
@@ -541,7 +542,7 @@ URITemplateRouterView::URITemplateRouterView(const std::uint8_t *data,
   // mirror it into aligned storage that outlives the view
   if (data != nullptr && size > 0 &&
       (reinterpret_cast<std::uintptr_t>(data) % alignof(SerializedNode)) != 0) {
-    this->owned_.resize(size / sizeof(std::uint64_t) +
+    this->owned_.resize((size / sizeof(std::uint64_t)) +
                         (size % sizeof(std::uint64_t) != 0 ? 1 : 0));
     std::memcpy(this->owned_.data(), data, size);
     this->data_ = reinterpret_cast<const std::uint8_t *>(this->owned_.data());
@@ -811,7 +812,7 @@ auto URITemplateRouterView::arguments(
   const auto blob_area_offset = entries_offset + entries_size;
 
   for (std::uint16_t index = 0; index < entry_count; ++index) {
-    const auto entry_offset = entries_offset + index * ENTRY_SIZE;
+    const auto entry_offset = entries_offset + (index * ENTRY_SIZE);
 
     std::uint16_t entry_identifier = 0;
     std::memcpy(&entry_identifier, this->data_ + entry_offset,
@@ -1008,42 +1009,42 @@ auto URITemplateRouterView::operation(const std::string_view operation_id) const
     -> std::pair<URITemplateRouter::Identifier, URITemplateRouter::Identifier> {
   constexpr std::pair<URITemplateRouter::Identifier,
                       URITemplateRouter::Identifier>
-      miss{URITemplateRouter::Identifier{0}, URITemplateRouter::Identifier{0}};
+      MISS{URITemplateRouter::Identifier{0}, URITemplateRouter::Identifier{0}};
 
   if (this->size_ < sizeof(RouterHeader)) {
-    return miss;
+    return MISS;
   }
 
   const auto *header = reinterpret_cast<const RouterHeader *>(this->data_);
   if (header->magic != ROUTER_MAGIC || header->version != ROUTER_VERSION) {
-    return miss;
+    return MISS;
   }
 
   const auto operations_start =
       static_cast<std::size_t>(header->operations_offset);
   if (operations_start > this->size_ ||
       this->size_ - operations_start < sizeof(std::uint16_t)) {
-    return miss;
+    return MISS;
   }
 
   std::uint16_t entry_count = 0;
   std::memcpy(&entry_count, this->data_ + operations_start,
               sizeof(entry_count));
   if (entry_count == 0) {
-    return miss;
+    return MISS;
   }
 
   const auto entries_offset = operations_start + sizeof(entry_count);
   const auto entries_size =
       static_cast<std::size_t>(entry_count) * OPERATION_ENTRY_SIZE;
   if (entries_size > this->size_ - entries_offset) {
-    return miss;
+    return MISS;
   }
 
   if (header->string_table_offset > this->size_ ||
       header->arguments_offset < header->string_table_offset ||
       header->arguments_offset > this->size_) {
-    return miss;
+    return MISS;
   }
 
   const auto *string_table =
@@ -1054,10 +1055,10 @@ auto URITemplateRouterView::operation(const std::string_view operation_id) const
   std::uint32_t low = 0;
   std::uint32_t high = entry_count;
   while (low < high) {
-    const auto middle = low + (high - low) / 2;
+    const auto middle = low + ((high - low) / 2);
     const auto entry_offset =
         entries_offset +
-        static_cast<std::size_t>(middle) * OPERATION_ENTRY_SIZE;
+        (static_cast<std::size_t>(middle) * OPERATION_ENTRY_SIZE);
 
     OperationEntry entry{};
     std::memcpy(&entry.string_offset, this->data_ + entry_offset,
@@ -1076,7 +1077,7 @@ auto URITemplateRouterView::operation(const std::string_view operation_id) const
 
     if (entry.string_offset > string_table_size ||
         entry.string_length > string_table_size - entry.string_offset) {
-      return miss;
+      return MISS;
     }
 
     const auto min_length = operation_id.size() < entry.string_length
@@ -1098,7 +1099,7 @@ auto URITemplateRouterView::operation(const std::string_view operation_id) const
     }
   }
 
-  return miss;
+  return MISS;
 }
 
 auto URITemplateRouterView::at(const std::size_t index) const
@@ -1131,7 +1132,7 @@ auto URITemplateRouterView::at(const std::size_t index) const
     return URITemplateRouter::Identifier{0};
   }
 
-  const auto entry_offset = entries_offset + index * PATH_ENTRY_SIZE;
+  const auto entry_offset = entries_offset + (index * PATH_ENTRY_SIZE);
   const auto entry = read_path_entry(this->data_, entry_offset);
   return entry.identifier;
 }
@@ -1165,7 +1166,7 @@ auto URITemplateRouterView::context(
   }
 
   for (std::uint16_t index = 0; index < path_count; ++index) {
-    const auto entry_offset = entries_offset + index * PATH_ENTRY_SIZE;
+    const auto entry_offset = entries_offset + (index * PATH_ENTRY_SIZE);
     const auto entry = read_path_entry(this->data_, entry_offset);
     if (entry.identifier == identifier) {
       return entry.context;
@@ -1214,7 +1215,7 @@ auto URITemplateRouterView::path(
   }
 
   for (std::uint16_t index = 0; index < path_count; ++index) {
-    const auto entry_offset = entries_offset + index * PATH_ENTRY_SIZE;
+    const auto entry_offset = entries_offset + (index * PATH_ENTRY_SIZE);
     const auto entry = read_path_entry(this->data_, entry_offset);
     if (entry.identifier == identifier) {
       if (entry.string_offset > string_table_size ||
@@ -1278,7 +1279,8 @@ auto URITemplateRouterView::operation_id(
 
   for (std::uint16_t index = 0; index < entry_count; ++index) {
     const auto entry_offset =
-        entries_offset + static_cast<std::size_t>(index) * OPERATION_ENTRY_SIZE;
+        entries_offset +
+        (static_cast<std::size_t>(index) * OPERATION_ENTRY_SIZE);
 
     OperationEntry entry{};
     std::memcpy(&entry.string_offset, this->data_ + entry_offset,

--- a/src/core/yaml/lexer.h
+++ b/src/core/yaml/lexer.h
@@ -5,6 +5,7 @@
 #include <sourcemeta/core/unicode.h>
 #include <sourcemeta/core/yaml_error.h>
 
+#include <algorithm>    // std::max
 #include <charconv>     // std::from_chars
 #include <cstdint>      // std::uint8_t, std::uint64_t
 #include <deque>        // std::deque
@@ -313,7 +314,6 @@ public:
     return this->scan_plain_scalar();
   }
 
-public:
   [[nodiscard]] auto line() const noexcept -> std::uint64_t {
     if (this->position_ >= this->input_.size() && this->column_ > 1) {
       return this->line_ + 1;
@@ -1157,9 +1157,8 @@ private:
           current_empty_indent++;
           this->advance(1);
         } else if (this->peek() == '\n' || this->peek() == '\r') {
-          if (current_empty_indent > max_leading_empty_indent) {
-            max_leading_empty_indent = current_empty_indent;
-          }
+          max_leading_empty_indent =
+              std::max(current_empty_indent, max_leading_empty_indent);
           content_indent = 0;
           current_empty_indent = 0;
           this->advance(1);
@@ -1313,7 +1312,7 @@ private:
           trailing_newlines += '\n';
         } else {
           blank_line_count++;
-          if (original) {
+          if (original != nullptr) {
             if (line_indent > content_indent) {
               *original += original_trailing;
               original_trailing.clear();
@@ -1380,7 +1379,7 @@ private:
         had_line_break = false;
         previous_started_with_whitespace = starts_with_whitespace;
 
-        if (original) {
+        if (original != nullptr) {
           *original += original_trailing;
           original_trailing.clear();
         }
@@ -1388,7 +1387,7 @@ private:
 
       for (std::size_t index = content_indent; index < line_indent; ++index) {
         buffer += ' ';
-        if (original) {
+        if (original != nullptr) {
           *original += ' ';
         }
       }
@@ -1397,7 +1396,7 @@ private:
              this->peek() != '\r') {
         const auto character{this->peek()};
         buffer += character;
-        if (original) {
+        if (original != nullptr) {
           *original += character;
         }
         this->advance(1);
@@ -1412,7 +1411,7 @@ private:
           trailing_newlines += '\n';
         } else {
           had_line_break = true;
-          if (original) {
+          if (original != nullptr) {
             original_trailing += '\n';
           }
         }
@@ -1433,7 +1432,7 @@ private:
         for (std::size_t count = 0; count < blank_line_count; ++count) {
           buffer += '\n';
         }
-        if (original) {
+        if (original != nullptr) {
           *original += original_trailing;
         }
       }
@@ -1451,7 +1450,7 @@ private:
         }
       } else if (had_line_break || blank_line_count > 0) {
         buffer += '\n';
-        if (original && !original_trailing.empty()) {
+        if ((original != nullptr) && !original_trailing.empty()) {
           *original += '\n';
         }
       }
@@ -1470,8 +1469,9 @@ private:
                  .column = start_column,
                  .scalar_style = style,
                  .chomping = block_chomping,
-                 .block_original = original ? std::string_view{*original}
-                                            : std::string_view{},
+                 .block_original = (original != nullptr)
+                                       ? std::string_view{*original}
+                                       : std::string_view{},
                  .explicit_indent = explicit_indent,
                  .indent_before_chomping = indent_first};
   }

--- a/src/core/yaml/parser.h
+++ b/src/core/yaml/parser.h
@@ -74,7 +74,7 @@ public:
     }
 
     if (token->type == TokenType::DocumentStart) {
-      if (this->roundtrip_) {
+      if (this->roundtrip_ != nullptr) {
         this->roundtrip_->leading_comments =
             this->lexer_->take_preceding_comments();
         this->roundtrip_->explicit_document_start = true;
@@ -82,7 +82,7 @@ public:
       this->document_start_line_ = token->line;
       const auto pos_before_next{this->lexer_->position()};
       token = this->lexer_->next();
-      if (this->roundtrip_) {
+      if (this->roundtrip_ != nullptr) {
         this->roundtrip_->document_start_comment =
             this->lexer_->take_inline_comment();
       }
@@ -112,7 +112,7 @@ public:
       return JSON{nullptr};
     }
 
-    if (this->roundtrip_) {
+    if (this->roundtrip_ != nullptr) {
       auto comments{this->lexer_->take_preceding_comments()};
       this->lexer_->take_inline_comment();
       if (this->roundtrip_->explicit_document_start) {
@@ -123,11 +123,11 @@ public:
     }
 
     auto result{this->parse_value(token.value(), JSON::ParseContext::Root, 0,
-                                  empty_property_)};
+                                  EMPTY_PROPERTY)};
 
     auto pos_before_token{this->lexer_->position()};
     token = this->next_token();
-    if (this->roundtrip_) {
+    if (this->roundtrip_ != nullptr) {
       auto root_inline{this->lexer_->take_inline_comment()};
       if (root_inline.has_value()) {
         this->roundtrip_->styles[this->pointer_stack_].comment_inline =
@@ -136,20 +136,20 @@ public:
     }
     while (token.has_value() && token->type == TokenType::DocumentEnd) {
       this->document_ended_ = true;
-      if (this->roundtrip_) {
+      if (this->roundtrip_ != nullptr) {
         this->roundtrip_->pre_end_comments =
             this->lexer_->take_preceding_comments();
         this->roundtrip_->explicit_document_end = true;
       }
       pos_before_token = this->lexer_->position();
       token = this->next_token();
-      if (this->roundtrip_) {
+      if (this->roundtrip_ != nullptr) {
         this->roundtrip_->document_end_comment =
             this->lexer_->take_inline_comment();
       }
     }
 
-    if (this->roundtrip_) {
+    if (this->roundtrip_ != nullptr) {
       auto trailing{this->lexer_->take_preceding_comments()};
       if (!trailing.empty()) {
         this->roundtrip_->trailing_comments = std::move(trailing);
@@ -221,7 +221,7 @@ public:
                              "Unexpected content after document"};
       }
       this->parse_value(token.value(), JSON::ParseContext::Root, 0,
-                        empty_property_);
+                        EMPTY_PROPERTY);
       saw_document_end = false;
       token = this->next_token();
       while (token.has_value() && token->type == TokenType::DocumentEnd) {
@@ -235,13 +235,13 @@ public:
   }
 
 private:
-  static constexpr std::size_t maximum_expanded_nodes{10000000};
+  static constexpr std::size_t MAXIMUM_EXPANDED_NODES{10000000};
 
   // Cap the recursion depth of the value parser so that a deeply nested
   // document cannot overflow the stack on attacker-controlled input. The bound
   // is conservative so that it holds on platforms with a small default stack
   // such as Windows, and is still far above any realistic nesting
-  static constexpr std::size_t maximum_depth{100};
+  static constexpr std::size_t MAXIMUM_DEPTH{100};
   std::size_t depth_{0};
 
   struct DepthScope {
@@ -282,7 +282,7 @@ private:
         }
         seen_yaml_directive = true;
         const auto content{token.value};
-        auto cursor{5uz};
+        auto cursor{5UZ};
         while (cursor < content.size() &&
                (content[cursor] == ' ' || content[cursor] == '\t')) {
           cursor++;
@@ -323,7 +323,7 @@ private:
         }
       } else if (token.type == TokenType::DirectiveTag) {
         const auto content{token.value};
-        auto cursor{4uz};
+        auto cursor{4UZ};
         while (cursor < content.size() &&
                (content[cursor] == ' ' || content[cursor] == '\t')) {
           cursor++;
@@ -405,7 +405,7 @@ private:
                        const JSON::ParseContext context,
                        const std::size_t index, const std::string &property)
       -> void {
-    if (this->callback_ && *this->callback_) {
+    if ((this->callback_ != nullptr) && *this->callback_) {
       (*this->callback_)(phase, type, line, column, context, index, property);
     }
 
@@ -468,7 +468,7 @@ private:
                            const std::optional<std::string> &tag = std::nullopt)
       -> JSON {
     // Round-trip mode preserves the original key text, so it is not resolved
-    if (this->roundtrip_) {
+    if (this->roundtrip_ != nullptr) {
       return JSON{std::string{token.value}};
     }
 
@@ -491,12 +491,12 @@ private:
                    const std::uint64_t key_line = 0,
                    const std::uint64_t key_column = 0) -> JSON {
     const DepthScope scope{this->depth_};
-    if (this->depth_ > maximum_depth) {
+    if (this->depth_ > MAXIMUM_DEPTH) {
       throw YAMLParseError{token.line, token.column,
                            "Maximum nesting depth exceeded"};
     }
 
-    if (this->roundtrip_) {
+    if (this->roundtrip_ != nullptr) {
       if (context == JSON::ParseContext::Property) {
         this->pointer_stack_.push_back(std::string{property});
       } else if (context == JSON::ParseContext::Index) {
@@ -521,7 +521,7 @@ private:
         const auto value_indent{
             current_token.column > 0
                 ? static_cast<std::size_t>(current_token.column - 1)
-                : 0uz};
+                : 0UZ};
         const auto parent_indent{this->lexer_->block_indent()};
         if (parent_indent != SIZE_MAX && value_indent <= parent_indent)
             [[unlikely]] {
@@ -538,7 +538,7 @@ private:
       }
 
       auto next{this->lexer_->next()};
-      if (this->roundtrip_ && anchor_name.has_value()) {
+      if ((this->roundtrip_ != nullptr) && anchor_name.has_value()) {
         anchor_inline_comment = this->lexer_->take_inline_comment();
       }
       if (!next.has_value() || next->type == TokenType::StreamEnd ||
@@ -553,14 +553,15 @@ private:
         if (next.has_value()) {
           this->pending_tokens_.push_back(next.value());
         }
-        if (this->roundtrip_ && anchor_name.has_value()) {
+        if ((this->roundtrip_ != nullptr) && anchor_name.has_value()) {
           auto &style{this->roundtrip_->styles[this->pointer_stack_]};
           style.anchor = std::string{anchor_name.value()};
           if (anchor_inline_comment.has_value()) {
             style.comment_inline = std::move(anchor_inline_comment);
           }
         }
-        if (this->roundtrip_ && context != JSON::ParseContext::Root) {
+        if ((this->roundtrip_ != nullptr) &&
+            context != JSON::ParseContext::Root) {
           this->pointer_stack_.pop_back();
         }
         return empty_value;
@@ -578,7 +579,8 @@ private:
                                          index, property,
                                          anchor_inline_comment);
           }
-          if (this->roundtrip_ && context != JSON::ParseContext::Root) {
+          if ((this->roundtrip_ != nullptr) &&
+              context != JSON::ParseContext::Root) {
             this->pointer_stack_.pop_back();
           }
           return JSON{nullptr};
@@ -594,12 +596,13 @@ private:
         const auto entry_indent{
             current_token.column > 0
                 ? static_cast<std::size_t>(current_token.column - 1)
-                : 0uz};
+                : 0UZ};
         if (block_indent != SIZE_MAX && entry_indent <= block_indent) {
           this->pending_tokens_.push_back(current_token);
           this->register_anchored_null(anchor_name.value(), token, context,
                                        index, property, anchor_inline_comment);
-          if (this->roundtrip_ && context != JSON::ParseContext::Root) {
+          if ((this->roundtrip_ != nullptr) &&
+              context != JSON::ParseContext::Root) {
             this->pointer_stack_.pop_back();
           }
           return JSON{nullptr};
@@ -615,7 +618,8 @@ private:
         empty_value = JSON{std::string{}};
       }
       this->pending_tokens_.push_back(current_token);
-      if (this->roundtrip_ && context != JSON::ParseContext::Root) {
+      if ((this->roundtrip_ != nullptr) &&
+          context != JSON::ParseContext::Root) {
         this->pointer_stack_.pop_back();
       }
       return empty_value;
@@ -743,7 +747,7 @@ private:
           }
           result = this->resolve_alias(current_token, context, index, property,
                                        key_line, key_column);
-          if (this->roundtrip_) {
+          if (this->roundtrip_ != nullptr) {
             this->roundtrip_->aliases[this->pointer_stack_] =
                 std::string{current_token.value};
           }
@@ -767,7 +771,7 @@ private:
                             std::move(this->current_anchor_callbacks_)});
       this->current_anchor_callbacks_.clear();
 
-      if (this->roundtrip_) {
+      if (this->roundtrip_ != nullptr) {
         auto &style{this->roundtrip_->styles[this->pointer_stack_]};
         style.anchor = std::string{anchor_name.value()};
         if (anchor_inline_comment.has_value()) {
@@ -776,7 +780,7 @@ private:
       }
     }
 
-    if (this->roundtrip_ && context != JSON::ParseContext::Root) {
+    if ((this->roundtrip_ != nullptr) && context != JSON::ParseContext::Root) {
       this->pointer_stack_.pop_back();
     }
 
@@ -807,7 +811,7 @@ private:
 
     this->invoke_callback(JSON::ParsePhase::Post, result.type(), token.line,
                           end_column, JSON::ParseContext::Root, 0,
-                          empty_property_);
+                          EMPTY_PROPERTY);
 
     return result;
   }
@@ -844,7 +848,7 @@ private:
         // explicitly floated infinity or not-a-number has no JSON
         // representation. Round-trip mode preserves the original text instead
         if (is_special_float(value)) [[unlikely]] {
-          if (!this->roundtrip_) {
+          if (this->roundtrip_ == nullptr) {
             throw YAMLParseError{this->lexer_->line(), this->lexer_->column(),
                                  "Infinity and NaN are not permitted"};
           }
@@ -880,7 +884,7 @@ private:
       // JSON grammar, such as Infinity and NaN, are not permitted, so a YAML
       // infinity or not-a-number float has no JSON representation. Round-trip
       // mode preserves the original text instead, so it keeps the string
-      if (!this->roundtrip_) [[unlikely]] {
+      if (this->roundtrip_ == nullptr) [[unlikely]] {
         throw YAMLParseError{this->lexer_->line(), this->lexer_->column(),
                              "Infinity and NaN are not permitted"};
       }
@@ -954,7 +958,7 @@ private:
   }
 
   auto parse_number(const std::string_view value) -> JSON {
-    const std::size_t prefix{(value[0] == '-' || value[0] == '+') ? 1u : 0u};
+    const std::size_t prefix{(value[0] == '-' || value[0] == '+') ? 1U : 0U};
     // YAML 1.2.2 Section 10.3.2: the hexadecimal and octal integer forms carry
     // no sign and use a lowercase indicator
     if (prefix == 0 && value.size() > 1 && value[0] == '0') {
@@ -1022,8 +1026,8 @@ private:
       }
     }
 
-    constexpr std::size_t double_precision_limit{15};
-    if (significant_digits > double_precision_limit) {
+    constexpr std::size_t DOUBLE_PRECISION_LIMIT{15};
+    if (significant_digits > DOUBLE_PRECISION_LIMIT) {
       return JSON{Decimal{value}};
     }
 
@@ -1163,9 +1167,9 @@ private:
                                             : this->lexer_->column()};
     this->invoke_callback(JSON::ParsePhase::Post, JSON::Type::Object, end_line,
                           end_column, JSON::ParseContext::Root, 0,
-                          empty_property_);
+                          EMPTY_PROPERTY);
 
-    if (this->roundtrip_ && found_compact_separator) {
+    if ((this->roundtrip_ != nullptr) && found_compact_separator) {
       this->roundtrip_->styles[this->pointer_stack_].compact_flow = true;
     }
 
@@ -1194,7 +1198,7 @@ private:
       if (parent_block_indent != SIZE_MAX && token->line != start_token.line) {
         const auto token_indent{
             token->column > 0 ? static_cast<std::size_t>(token->column - 1)
-                              : 0uz};
+                              : 0UZ};
         if (token_indent <= parent_block_indent) [[unlikely]] {
           throw YAMLParseError{
               token->line, token->column,
@@ -1235,7 +1239,7 @@ private:
           const auto explicit_key_column{token->column};
           auto key_value{this->parse_value(token.value(),
                                            JSON::ParseContext::Index,
-                                           element_index, empty_property_)};
+                                           element_index, EMPTY_PROPERTY)};
           key_string = this->json_to_key_string(key_value, explicit_key_line,
                                                 explicit_key_column);
           token = this->next_token();
@@ -1261,7 +1265,7 @@ private:
       }
 
       auto value{this->parse_value(token.value(), JSON::ParseContext::Index,
-                                   element_index, empty_property_)};
+                                   element_index, EMPTY_PROPERTY)};
       result.push_back(std::move(value));
       element_index++;
 
@@ -1282,9 +1286,9 @@ private:
                                             : this->lexer_->column()};
     this->invoke_callback(JSON::ParsePhase::Post, JSON::Type::Array, end_line,
                           end_column, JSON::ParseContext::Root, 0,
-                          empty_property_);
+                          EMPTY_PROPERTY);
 
-    if (this->roundtrip_ && found_compact_separator) {
+    if ((this->roundtrip_ != nullptr) && found_compact_separator) {
       this->roundtrip_->styles[this->pointer_stack_].compact_flow = true;
     }
 
@@ -1307,7 +1311,7 @@ private:
     std::size_t element_index{0};
     const auto base_column{start_token.column};
     const auto sequence_indent{
-        base_column > 0 ? static_cast<std::size_t>(base_column - 1) : 0uz};
+        base_column > 0 ? static_cast<std::size_t>(base_column - 1) : 0UZ};
     this->detect_indent_width(key_column, base_column);
     this->lexer_->set_block_indent(sequence_indent);
     this->record_preceding_comments_for_index(0);
@@ -1322,7 +1326,7 @@ private:
         token->type != TokenType::DocumentEnd &&
         token->type != TokenType::DocumentStart) {
       auto value{this->parse_value(token.value(), JSON::ParseContext::Index,
-                                   element_index, empty_property_)};
+                                   element_index, EMPTY_PROPERTY)};
       result.push_back(std::move(value));
       element_index++;
       token = this->next_token();
@@ -1352,7 +1356,7 @@ private:
                                "Wrong indentation for sequence entry"};
         }
         auto value{this->parse_value(token.value(), JSON::ParseContext::Index,
-                                     element_index, empty_property_)};
+                                     element_index, EMPTY_PROPERTY)};
         result.push_back(std::move(value));
         element_index++;
         token = this->next_token();
@@ -1374,7 +1378,7 @@ private:
         result.push_back(JSON{nullptr});
       } else {
         auto value{this->parse_value(token.value(), JSON::ParseContext::Index,
-                                     element_index, empty_property_)};
+                                     element_index, EMPTY_PROPERTY)};
         result.push_back(std::move(value));
         token = this->next_token();
       }
@@ -1397,7 +1401,7 @@ private:
 
     this->invoke_callback(JSON::ParsePhase::Post, JSON::Type::Array, end_line,
                           end_column, JSON::ParseContext::Root, 0,
-                          empty_property_);
+                          EMPTY_PROPERTY);
 
     return result;
   }
@@ -1420,7 +1424,7 @@ private:
     const auto mapping_indent{
         start_token.column > 0
             ? static_cast<std::size_t>(start_token.column - 1)
-            : 0uz};
+            : 0UZ};
 
     while (true) {
       this->lexer_->set_block_indent(mapping_indent);
@@ -1552,7 +1556,8 @@ private:
         // as ~ stays non-empty and the historical empty-string sentinel still
         // marks the absence of a key. In conversion mode a null-like key
         // resolves to an empty string, so a dedicated flag marks its presence
-        const bool key_absent{this->roundtrip_ ? key.empty() : !key_present};
+        const bool key_absent{(this->roundtrip_ != nullptr) ? key.empty()
+                                                            : !key_present};
         if (next->type == TokenType::BlockMappingValue ||
             next->type == TokenType::BlockMappingKey) {
           if (key_absent && next->type == TokenType::BlockMappingKey) {
@@ -1592,7 +1597,7 @@ private:
 
     this->invoke_callback(JSON::ParsePhase::Post, JSON::Type::Object,
                           this->lexer_->line(), this->lexer_->column(),
-                          JSON::ParseContext::Root, 0, empty_property_);
+                          JSON::ParseContext::Root, 0, EMPTY_PROPERTY);
 
     return result;
   }
@@ -1651,7 +1656,7 @@ private:
     }
 
     this->expanded_nodes_ += this->count_expanded_nodes(anchored.value);
-    if (this->expanded_nodes_ > maximum_expanded_nodes) [[unlikely]] {
+    if (this->expanded_nodes_ > MAXIMUM_EXPANDED_NODES) [[unlikely]] {
       throw YAMLParseError{token.line, token.column,
                            "Maximum YAML alias expansion exceeded"};
     }
@@ -1731,7 +1736,7 @@ private:
                                     static_cast<std::uint64_t>(key.size())};
         this->invoke_callback(JSON::ParsePhase::Post, JSON::Type::Null,
                               key_line, null_post_column,
-                              JSON::ParseContext::Root, 0, empty_property_);
+                              JSON::ParseContext::Root, 0, EMPTY_PROPERTY);
         result.assign(key, JSON{nullptr});
       }
     } else if (next->type == TokenType::MappingStart ||
@@ -2005,13 +2010,13 @@ private:
 
     this->invoke_callback(JSON::ParsePhase::Post, JSON::Type::Object,
                           this->lexer_->line(), this->lexer_->column(),
-                          JSON::ParseContext::Root, 0, empty_property_);
+                          JSON::ParseContext::Root, 0, EMPTY_PROPERTY);
 
     return result;
   }
 
   auto record_preceding_comments_for_key(const std::string &key) -> void {
-    if (!this->roundtrip_) {
+    if (this->roundtrip_ == nullptr) {
       return;
     }
     auto comments{this->lexer_->take_preceding_comments()};
@@ -2026,7 +2031,7 @@ private:
 
   auto record_inline_comment_for_key(const std::string &key,
                                      const bool on_indicator = false) -> void {
-    if (!this->roundtrip_) {
+    if (this->roundtrip_ == nullptr) {
       return;
     }
     auto comment{this->lexer_->take_inline_comment()};
@@ -2045,7 +2050,7 @@ private:
   }
 
   auto record_preceding_comments_for_index(const std::size_t index) -> void {
-    if (!this->roundtrip_) {
+    if (this->roundtrip_ == nullptr) {
       return;
     }
     auto comments{this->lexer_->take_preceding_comments()};
@@ -2059,7 +2064,7 @@ private:
   }
 
   auto record_inline_comment_for_index(const std::size_t index) -> void {
-    if (!this->roundtrip_) {
+    if (this->roundtrip_ == nullptr) {
       return;
     }
     auto comment{this->lexer_->take_inline_comment()};
@@ -2073,7 +2078,7 @@ private:
   }
 
   auto record_indicator_comment_for_index(const std::size_t index) -> void {
-    if (!this->roundtrip_) {
+    if (this->roundtrip_ == nullptr) {
       return;
     }
     this->pointer_stack_.push_back(index);
@@ -2095,14 +2100,14 @@ private:
                           token.column, context, index, property);
     this->invoke_callback(JSON::ParsePhase::Post, JSON::Type::Null, token.line,
                           token.column, JSON::ParseContext::Root, 0,
-                          empty_property_);
+                          EMPTY_PROPERTY);
     this->recording_anchor_ = false;
     this->anchors_.insert_or_assign(
         std::string{anchor_name},
         AnchoredValue{.value = null_value,
                       .callbacks = std::move(this->current_anchor_callbacks_)});
     this->current_anchor_callbacks_.clear();
-    if (this->roundtrip_) {
+    if (this->roundtrip_ != nullptr) {
       auto &style{this->roundtrip_->styles[this->pointer_stack_]};
       style.anchor = std::string{anchor_name};
       if (inline_comment.has_value()) {
@@ -2113,7 +2118,7 @@ private:
 
   auto record_collection_style(const YAMLRoundTrip::CollectionStyle style)
       -> void {
-    if (!this->roundtrip_) {
+    if (this->roundtrip_ == nullptr) {
       return;
     }
 
@@ -2121,7 +2126,7 @@ private:
   }
 
   auto record_scalar_style(const Token &token, const JSON &value) -> void {
-    if (!this->roundtrip_) {
+    if (this->roundtrip_ == nullptr) {
       return;
     }
 
@@ -2191,7 +2196,7 @@ private:
   auto record_key_scalar_style(const std::string &key, const ScalarStyle style,
                                const std::string_view quoted_original = {})
       -> void {
-    if (!this->roundtrip_) {
+    if (this->roundtrip_ == nullptr) {
       return;
     }
     this->pointer_stack_.push_back(key);
@@ -2220,7 +2225,7 @@ private:
 
   auto detect_indent_width(const std::uint64_t parent_column,
                            const std::uint64_t child_column) -> void {
-    if (!this->roundtrip_ || this->indent_width_detected_) {
+    if ((this->roundtrip_ == nullptr) || this->indent_width_detected_) {
       return;
     }
     if (parent_column > 0 && child_column > parent_column) {
@@ -2230,7 +2235,7 @@ private:
     }
   }
 
-  inline static const std::string empty_property_{};
+  inline static const std::string EMPTY_PROPERTY{};
   Lexer *lexer_;
   const JSON::ParseCallback *callback_;
   YAMLRoundTrip *roundtrip_{nullptr};

--- a/src/core/yaml/stringify.h
+++ b/src/core/yaml/stringify.h
@@ -180,8 +180,8 @@ inline auto write_double_quoted(OutputStream &stream, const std::string &value)
         if (character >= '\x01' && character < '\x20') {
           const auto byte{static_cast<unsigned char>(character)};
           stream.write("\\x", 2);
-          stream.put(HEX_DIGITS[byte >> 4u]);
-          stream.put(HEX_DIGITS[byte & 0x0Fu]);
+          stream.put(HEX_DIGITS[byte >> 4U]);
+          stream.put(HEX_DIGITS[byte & 0x0FU]);
         } else {
           stream.put(character);
         }
@@ -294,7 +294,7 @@ inline auto find_anchor(const AnchorValues &anchors,
 inline auto matching_alias(const JSON &value, const YAMLRoundTrip *roundtrip,
                            const AnchorValues &anchors, const Pointer &pointer)
     -> const std::string * {
-  if (!roundtrip) {
+  if (roundtrip == nullptr) {
     return nullptr;
   }
 
@@ -304,7 +304,8 @@ inline auto matching_alias(const JSON &value, const YAMLRoundTrip *roundtrip,
   }
 
   const auto *anchored{find_anchor(anchors, match->second)};
-  return anchored && same_value(*anchored, value) ? &match->second : nullptr;
+  return (anchored != nullptr) && same_value(*anchored, value) ? &match->second
+                                                               : nullptr;
 }
 
 inline auto write_alias(OutputStream &stream, const std::string &name) -> void {
@@ -323,7 +324,7 @@ inline auto write_string_with_style(OutputStream &stream, const JSON &value,
                                     const YAMLRoundTrip *roundtrip,
                                     const Pointer &pointer) -> void {
   const auto &text{value.to_string()};
-  if (roundtrip) {
+  if (roundtrip != nullptr) {
     const auto match{roundtrip->styles.find(pointer)};
     if (match != roundtrip->styles.end() && match->second.scalar.has_value()) {
       if (match->second.quoted_content.has_value() &&
@@ -360,7 +361,7 @@ inline auto write_string_with_style(OutputStream &stream, const JSON &value,
 inline auto write_key_string(OutputStream &stream, const std::string &key,
                              const YAMLRoundTrip *roundtrip,
                              const Pointer &pointer) -> void {
-  if (roundtrip) {
+  if (roundtrip != nullptr) {
     const auto quoted_match{roundtrip->key_quoted_contents.find(pointer)};
     if (quoted_match != roundtrip->key_quoted_contents.end()) {
       const auto style_match{roundtrip->key_styles.find(pointer)};
@@ -412,12 +413,12 @@ inline auto write_inline_value(OutputStream &stream, const JSON &value,
                                AnchorValues &anchors, Pointer &pointer)
     -> void {
   const auto *alias{matching_alias(value, roundtrip, anchors, pointer)};
-  if (alias) {
+  if (alias != nullptr) {
     write_alias(stream, *alias);
     return;
   }
 
-  if (roundtrip) {
+  if (roundtrip != nullptr) {
     const auto style_match{roundtrip->styles.find(pointer)};
     if (style_match != roundtrip->styles.end() &&
         style_match->second.scalar.has_value() &&
@@ -494,7 +495,7 @@ inline auto write_inline_value(OutputStream &stream, const JSON &value,
 
 inline auto is_implicit_null(const JSON &value, const YAMLRoundTrip *roundtrip,
                              const Pointer &pointer) -> bool {
-  if (!roundtrip || !value.is_null()) {
+  if ((roundtrip == nullptr) || !value.is_null()) {
     return false;
   }
   if (roundtrip->aliases.contains(pointer)) {
@@ -511,7 +512,7 @@ inline auto write_flow_anchor(OutputStream &stream, const JSON &value,
                               const YAMLRoundTrip *roundtrip,
                               AnchorValues &anchors, const Pointer &pointer)
     -> void {
-  if (!roundtrip) {
+  if (roundtrip == nullptr) {
     return;
   }
   const auto match{roundtrip->styles.find(pointer)};
@@ -526,7 +527,7 @@ inline auto write_flow_mapping(OutputStream &stream, const JSON &value,
                                AnchorValues &anchors, Pointer &pointer)
     -> void {
   bool compact{false};
-  if (roundtrip) {
+  if (roundtrip != nullptr) {
     const auto match{roundtrip->styles.find(pointer)};
     if (match != roundtrip->styles.end()) {
       compact = match->second.compact_flow;
@@ -560,7 +561,7 @@ inline auto write_flow_sequence(OutputStream &stream, const JSON &value,
                                 AnchorValues &anchors, Pointer &pointer)
     -> void {
   bool compact{false};
-  if (roundtrip) {
+  if (roundtrip != nullptr) {
     const auto match{roundtrip->styles.find(pointer)};
     if (match != roundtrip->styles.end()) {
       compact = match->second.compact_flow;
@@ -600,7 +601,7 @@ inline auto write_block_sequence(OutputStream &stream, const JSON &value,
 
 inline auto emit_inline_comment(OutputStream &stream,
                                 const YAMLRoundTrip::NodeStyle *style) -> void {
-  if (style && style->comment_inline.has_value()) {
+  if ((style != nullptr) && style->comment_inline.has_value()) {
     stream.put(' ');
     const auto &comment{style->comment_inline.value()};
     stream.write(comment.data(), static_cast<std::streamsize>(comment.size()));
@@ -612,7 +613,7 @@ inline auto write_node(OutputStream &stream, const JSON &value,
                        const YAMLRoundTrip *roundtrip, AnchorValues &anchors,
                        Pointer &pointer) -> void {
   const YAMLRoundTrip::NodeStyle *node_style{nullptr};
-  if (roundtrip) {
+  if (roundtrip != nullptr) {
     const auto style_match{roundtrip->styles.find(pointer)};
     if (style_match != roundtrip->styles.end()) {
       node_style = &style_match->second;
@@ -620,7 +621,7 @@ inline auto write_node(OutputStream &stream, const JSON &value,
   }
 
   const auto *alias{matching_alias(value, roundtrip, anchors, pointer)};
-  if (alias) {
+  if (alias != nullptr) {
     write_alias(stream, *alias);
     emit_inline_comment(stream, node_style);
     stream.put('\n');
@@ -628,14 +629,14 @@ inline auto write_node(OutputStream &stream, const JSON &value,
   }
 
   bool has_anchor{false};
-  if (node_style && node_style->anchor.has_value()) {
+  if ((node_style != nullptr) && node_style->anchor.has_value()) {
     write_anchor(stream, node_style->anchor.value(), value, anchors);
     has_anchor = true;
   }
 
-  const bool flow{node_style && node_style->collection.has_value() &&
-                  node_style->collection.value() ==
-                      YAMLRoundTrip::CollectionStyle::Flow};
+  const bool flow{
+      (node_style != nullptr) && node_style->collection.has_value() &&
+      node_style->collection.value() == YAMLRoundTrip::CollectionStyle::Flow};
 
   if (value.is_object() && !value.empty()) {
     if (flow) {
@@ -671,7 +672,7 @@ inline auto write_node(OutputStream &stream, const JSON &value,
                            has_anchor ? false : skip_first_indent, roundtrip,
                            anchors, pointer);
     }
-  } else if (node_style && value.is_string() &&
+  } else if ((node_style != nullptr) && value.is_string() &&
              node_style->scalar.has_value() &&
              (node_style->scalar.value() ==
                   YAMLRoundTrip::ScalarStyle::Literal ||
@@ -707,13 +708,14 @@ inline auto write_block_mapping(OutputStream &stream, const JSON &value,
                                 AnchorValues &anchors, Pointer &pointer)
     -> void {
   assert(value.is_object() && !value.empty());
-  const auto width{roundtrip ? roundtrip->indent_width : INDENT_WIDTH};
+  const auto width{(roundtrip != nullptr) ? roundtrip->indent_width
+                                          : INDENT_WIDTH};
   bool first{true};
   for (const auto &entry : value.as_object()) {
     pointer.push_back(entry.first);
 
     const YAMLRoundTrip::NodeStyle *entry_style{nullptr};
-    if (roundtrip) {
+    if (roundtrip != nullptr) {
       const auto style_match{roundtrip->styles.find(pointer)};
       if (style_match != roundtrip->styles.end()) {
         entry_style = &style_match->second;
@@ -724,7 +726,7 @@ inline auto write_block_mapping(OutputStream &stream, const JSON &value,
         matching_alias(entry.second, roundtrip, anchors, pointer) != nullptr};
 
     if (!first || !skip_first_indent) {
-      if (entry_style && !entry_style->comments_before.empty()) {
+      if ((entry_style != nullptr) && !entry_style->comments_before.empty()) {
         for (const auto &comment : entry_style->comments_before) {
           if (comment.empty()) {
             stream.put('\n');
@@ -744,10 +746,10 @@ inline auto write_block_mapping(OutputStream &stream, const JSON &value,
     stream.put(':');
 
     const bool implicit_null{
-        roundtrip && entry.second.is_null() && !entry_is_alias &&
-        (!entry_style || !entry_style->scalar.has_value())};
+        (roundtrip != nullptr) && entry.second.is_null() && !entry_is_alias &&
+        ((entry_style == nullptr) || !entry_style->scalar.has_value())};
     if (implicit_null) {
-      if (entry_style && entry_style->anchor.has_value()) {
+      if ((entry_style != nullptr) && entry_style->anchor.has_value()) {
         stream.put(' ');
         write_anchor(stream, entry_style->anchor.value(), entry.second,
                      anchors);
@@ -756,7 +758,8 @@ inline auto write_block_mapping(OutputStream &stream, const JSON &value,
       stream.put('\n');
     } else {
       bool has_indicator_comment{false};
-      if (entry_style && entry_style->comment_on_indicator.has_value()) {
+      if ((entry_style != nullptr) &&
+          entry_style->comment_on_indicator.has_value()) {
         has_indicator_comment = true;
         stream.put(' ');
         const auto &comment{entry_style->comment_on_indicator.value()};
@@ -766,9 +769,10 @@ inline auto write_block_mapping(OutputStream &stream, const JSON &value,
         write_indent(stream, indent + 1, width);
       }
       if (!has_indicator_comment) {
-        const bool has_prefix{entry_is_alias ||
-                              (entry_style && entry_style->anchor.has_value())};
-        const bool entry_flow{entry_style &&
+        const bool has_prefix{
+            entry_is_alias ||
+            ((entry_style != nullptr) && entry_style->anchor.has_value())};
+        const bool entry_flow{(entry_style != nullptr) &&
                               entry_style->collection.has_value() &&
                               entry_style->collection.value() ==
                                   YAMLRoundTrip::CollectionStyle::Flow};
@@ -798,14 +802,15 @@ inline auto write_block_sequence(OutputStream &stream, const JSON &value,
                                  AnchorValues &anchors, Pointer &pointer)
     -> void {
   assert(value.is_array() && !value.empty());
-  const auto width{roundtrip ? roundtrip->indent_width : INDENT_WIDTH};
+  const auto width{(roundtrip != nullptr) ? roundtrip->indent_width
+                                          : INDENT_WIDTH};
   bool first{true};
   std::size_t item_index{0};
   for (const auto &item : value.as_array()) {
     pointer.push_back(item_index);
 
     const YAMLRoundTrip::NodeStyle *item_style{nullptr};
-    if (roundtrip) {
+    if (roundtrip != nullptr) {
       const auto style_match{roundtrip->styles.find(pointer)};
       if (style_match != roundtrip->styles.end()) {
         item_style = &style_match->second;
@@ -816,7 +821,7 @@ inline auto write_block_sequence(OutputStream &stream, const JSON &value,
         matching_alias(item, roundtrip, anchors, pointer) != nullptr};
 
     if (!first || !skip_first_indent) {
-      if (item_style && !item_style->comments_before.empty()) {
+      if ((item_style != nullptr) && !item_style->comments_before.empty()) {
         for (const auto &comment : item_style->comments_before) {
           if (comment.empty()) {
             stream.put('\n');
@@ -832,11 +837,12 @@ inline auto write_block_sequence(OutputStream &stream, const JSON &value,
     }
     first = false;
 
-    const bool implicit_null{roundtrip && item.is_null() && !item_is_alias &&
-                             (!item_style || !item_style->scalar.has_value())};
+    const bool implicit_null{
+        (roundtrip != nullptr) && item.is_null() && !item_is_alias &&
+        ((item_style == nullptr) || !item_style->scalar.has_value())};
     if (implicit_null) {
       stream.put('-');
-      if (item_style) {
+      if (item_style != nullptr) {
         if (item_style->anchor.has_value()) {
           stream.put(' ');
           write_anchor(stream, item_style->anchor.value(), item, anchors);
@@ -853,7 +859,8 @@ inline auto write_block_sequence(OutputStream &stream, const JSON &value,
       stream.put('\n');
     } else {
       bool has_indicator{false};
-      if (item_style && item_style->comment_on_indicator.has_value()) {
+      if ((item_style != nullptr) &&
+          item_style->comment_on_indicator.has_value()) {
         has_indicator = true;
         const auto &comment{item_style->comment_on_indicator.value()};
         if (comment.empty()) {

--- a/src/core/yaml/yaml.cc
+++ b/src/core/yaml/yaml.cc
@@ -94,7 +94,8 @@ auto read_yaml_or_json(const std::filesystem::path &path) -> JSON {
   const auto extension{path.extension()};
   if (extension == ".yaml" || extension == ".yml") {
     return read_yaml(path);
-  } else if (extension == ".json") {
+  }
+  if (extension == ".json") {
     return read_json(path);
   }
 
@@ -111,7 +112,8 @@ auto read_yaml_or_json(const std::filesystem::path &path, JSON &output,
   if (extension == ".yaml" || extension == ".yml") {
     read_yaml(path, output, callback);
     return;
-  } else if (extension == ".json") {
+  }
+  if (extension == ".json") {
     read_json(path, output, callback);
     return;
   }

--- a/src/lang/io/io.cc
+++ b/src/lang/io/io.cc
@@ -270,8 +270,8 @@ auto flush(const std::filesystem::path &path) -> void {
   CloseHandle(hFile);
 
 #else
-  auto fd = ::open(path.c_str(), O_RDWR);
-  if (fd == -1) {
+  auto descriptor = ::open(path.c_str(), O_RDWR);
+  if (descriptor == -1) {
     const auto error_code = std::error_code{errno, std::generic_category()};
     if (error_code == std::errc::no_such_file_or_directory) {
       throw IOFileNotFoundError{path};
@@ -284,14 +284,14 @@ auto flush(const std::filesystem::path &path) -> void {
                                             path, error_code};
   }
 
-  if (::fsync(fd) == -1) {
+  if (::fsync(descriptor) == -1) {
     const auto error_code = std::error_code{errno, std::generic_category()};
-    ::close(fd);
+    ::close(descriptor);
     throw std::filesystem::filesystem_error{"failed to flush the file to disk",
                                             path, error_code};
   }
 
-  ::close(fd);
+  ::close(descriptor);
 
   // After syncing a file, we should also sync the directory to ensure
   // durability

--- a/src/lang/io/io_atomic.cc
+++ b/src/lang/io/io_atomic.cc
@@ -32,10 +32,10 @@ auto unique_staging_path(const std::filesystem::path &destination)
   std::uniform_int_distribution<std::uint64_t> distribution;
   std::string suffix{".tmp."};
   suffix.reserve(suffix.size() + 16);
-  static constexpr std::string_view digits{"0123456789abcdef"};
+  static constexpr std::string_view DIGITS{"0123456789abcdef"};
   auto value{distribution(generator)};
   for (std::size_t index{0}; index < 16; index++) {
-    suffix.push_back(digits[value & 0xF]);
+    suffix.push_back(DIGITS[value & 0xF]);
     value >>= 4;
   }
 

--- a/src/lang/io/io_binary.cc
+++ b/src/lang/io/io_binary.cc
@@ -82,7 +82,7 @@ auto BinaryReader::get_qword() -> std::uint64_t {
 }
 
 auto BinaryReader::position() const -> std::size_t {
-  if (this->view_) {
+  if (this->view_ != nullptr) {
     return this->offset_;
   }
 
@@ -96,7 +96,7 @@ auto BinaryReader::position() const -> std::size_t {
 }
 
 auto BinaryReader::seek(const std::size_t position) -> void {
-  if (this->view_) {
+  if (this->view_ != nullptr) {
     if (position > this->view_->size()) {
       throw IOReadOutOfBoundsError{};
     }
@@ -114,7 +114,7 @@ auto BinaryReader::seek(const std::size_t position) -> void {
 
 auto BinaryReader::get_bytes(std::byte *destination, const std::size_t size)
     -> void {
-  if (this->view_) {
+  if (this->view_ != nullptr) {
     if (size > this->view_->size() - this->offset_) {
       throw IOReadOutOfBoundsError{};
     }
@@ -137,7 +137,7 @@ auto BinaryReader::get_bytes(std::byte *destination, const std::size_t size)
 }
 
 auto BinaryReader::has_more_data() const -> bool {
-  if (this->view_) {
+  if (this->view_ != nullptr) {
     return this->offset_ < this->view_->size();
   }
 

--- a/src/lang/numeric/big_coefficient.h
+++ b/src/lang/numeric/big_coefficient.h
@@ -54,7 +54,7 @@ constexpr std::int64_t COMPACT_MAX =
 
 class BigCoefficient {
   static constexpr std::uint32_t INLINE_CAPACITY = 4;
-  std::array<std::uint64_t, INLINE_CAPACITY> inline_words;
+  std::array<std::uint64_t, INLINE_CAPACITY> inline_words_;
 
   [[nodiscard]] auto is_inline() const -> bool {
     return this->capacity <= INLINE_CAPACITY;
@@ -67,9 +67,9 @@ public:
 
   explicit BigCoefficient(std::uint32_t requested_capacity) {
     if (requested_capacity <= INLINE_CAPACITY) {
-      this->words = this->inline_words.data();
+      this->words = this->inline_words_.data();
       this->capacity = INLINE_CAPACITY;
-      this->inline_words.fill(0);
+      this->inline_words_.fill(0);
     } else {
       this->words = new std::uint64_t[requested_capacity]();
       this->capacity = requested_capacity;
@@ -85,13 +85,13 @@ public:
   BigCoefficient(BigCoefficient &&other) noexcept
       : length{other.length}, capacity{other.capacity} {
     if (other.is_inline()) {
-      std::copy(other.inline_words.data(),
-                other.inline_words.data() + other.length,
-                this->inline_words.data());
-      this->words = this->inline_words.data();
+      std::copy(other.inline_words_.data(),
+                other.inline_words_.data() + other.length,
+                this->inline_words_.data());
+      this->words = this->inline_words_.data();
     } else {
       this->words = other.words;
-      other.words = other.inline_words.data();
+      other.words = other.inline_words_.data();
     }
 
     other.length = 0;
@@ -107,13 +107,13 @@ public:
       this->length = other.length;
       this->capacity = other.capacity;
       if (other.is_inline()) {
-        std::copy(other.inline_words.data(),
-                  other.inline_words.data() + other.length,
-                  this->inline_words.data());
-        this->words = this->inline_words.data();
+        std::copy(other.inline_words_.data(),
+                  other.inline_words_.data() + other.length,
+                  this->inline_words_.data());
+        this->words = this->inline_words_.data();
       } else {
         this->words = other.words;
-        other.words = other.inline_words.data();
+        other.words = other.inline_words_.data();
       }
 
       other.length = 0;
@@ -155,7 +155,7 @@ public:
       top_digits++;
     }
     return top_digits +
-           static_cast<std::uint64_t>(this->length - 1) * BASE_DIGITS;
+           (static_cast<std::uint64_t>(this->length - 1) * BASE_DIGITS);
   }
 
   [[nodiscard]] auto to_string() const -> std::string {
@@ -203,7 +203,7 @@ public:
         std::uint64_t borrow = 0;
         for (auto index = this->length; index > 0; index--) {
           const auto word = this->words[index - 1];
-          this->words[index - 1] = word / 10 + borrow * (BASE / 10);
+          this->words[index - 1] = (word / 10) + (borrow * (BASE / 10));
           borrow = word % 10;
         }
 
@@ -301,8 +301,8 @@ public:
            index_right++) {
         auto position = index_left + index_right;
         auto product =
-            static_cast<sourcemeta::core::uint128_t>(this->words[index_left]) *
-                other.words[index_right] +
+            (static_cast<sourcemeta::core::uint128_t>(this->words[index_left]) *
+             other.words[index_right]) +
             result.words[position] + carry;
         result.words[position] = static_cast<std::uint64_t>(product % BASE);
         carry = product / BASE;
@@ -334,12 +334,12 @@ public:
     result.length = this->length + full_words;
 
     if (residual > 0) {
-      auto multiplier = POWERS_OF_10[static_cast<std::uint32_t>(residual)];
+      auto multiplier = POWERS_OF_10[residual];
       sourcemeta::core::uint128_t carry = 0;
       for (std::uint32_t index = full_words; index < result.length; index++) {
         auto product =
-            static_cast<sourcemeta::core::uint128_t>(result.words[index]) *
-                multiplier +
+            (static_cast<sourcemeta::core::uint128_t>(result.words[index]) *
+             multiplier) +
             carry;
         result.words[index] = static_cast<std::uint64_t>(product % BASE);
         carry = product / BASE;
@@ -380,7 +380,7 @@ public:
       quotient.length = this->length;
       sourcemeta::core::uint128_t remainder = 0;
       for (auto index = this->length; index > 0; index--) {
-        auto current = remainder * BASE + this->words[index - 1];
+        auto current = (remainder * BASE) + this->words[index - 1];
         quotient.words[index - 1] =
             static_cast<std::uint64_t>(current / divisor.words[0]);
         remainder = current % divisor.words[0];
@@ -406,8 +406,8 @@ public:
     sourcemeta::core::uint128_t normalize_carry = 0;
     for (std::uint32_t index = 0; index < divisor.length; index++) {
       auto product =
-          static_cast<sourcemeta::core::uint128_t>(divisor.words[index]) *
-              normalizer +
+          (static_cast<sourcemeta::core::uint128_t>(divisor.words[index]) *
+           normalizer) +
           normalize_carry;
       normalized_divisor.words[index] =
           static_cast<std::uint64_t>(product % BASE);
@@ -419,8 +419,8 @@ public:
     normalize_carry = 0;
     for (std::uint32_t index = 0; index < this->length; index++) {
       auto product =
-          static_cast<sourcemeta::core::uint128_t>(this->words[index]) *
-              normalizer +
+          (static_cast<sourcemeta::core::uint128_t>(this->words[index]) *
+           normalizer) +
           normalize_carry;
       normalized_dividend.words[index] =
           static_cast<std::uint64_t>(product % BASE);
@@ -440,15 +440,15 @@ public:
     for (auto position = quotient_length; position > 0;) {
       position--;
       auto numerator =
-          static_cast<sourcemeta::core::uint128_t>(
-              normalized_dividend.words[position + divisor.length]) *
-              BASE +
+          (static_cast<sourcemeta::core::uint128_t>(
+               normalized_dividend.words[position + divisor.length]) *
+           BASE) +
           normalized_dividend.words[position + divisor.length - 1];
       auto trial_word = numerator / top_divisor_word;
       auto trial_remainder = numerator % top_divisor_word;
       while (trial_word >= BASE ||
              trial_word * next_divisor_word >
-                 trial_remainder * BASE +
+                 (trial_remainder * BASE) +
                      normalized_dividend.words[position + divisor.length - 2]) {
         trial_word -= 1;
         trial_remainder += top_divisor_word;
@@ -459,7 +459,8 @@ public:
 
       std::uint64_t borrow = 0;
       for (std::uint32_t index = 0; index < divisor.length; index++) {
-        auto subtrahend = trial_word * normalized_divisor.words[index] + borrow;
+        auto subtrahend =
+            (trial_word * normalized_divisor.words[index]) + borrow;
         auto subtrahend_low = static_cast<std::uint64_t>(subtrahend % BASE);
         borrow = static_cast<std::uint64_t>(subtrahend / BASE);
         auto &word = normalized_dividend.words[position + index];
@@ -502,7 +503,7 @@ public:
     sourcemeta::core::uint128_t denormalize_carry = 0;
     for (auto index = divisor.length; index > 0; index--) {
       auto current =
-          denormalize_carry * BASE + normalized_dividend.words[index - 1];
+          (denormalize_carry * BASE) + normalized_dividend.words[index - 1];
       remainder.words[index - 1] =
           static_cast<std::uint64_t>(current / normalizer);
       denormalize_carry = current % normalizer;
@@ -535,7 +536,7 @@ public:
 
     auto remaining = power;
     while (remaining > 0) {
-      if (remaining & 1) {
+      if ((remaining & 1) != 0u) {
         result = result.multiply_modulo(base, modulus);
       }
 
@@ -598,14 +599,14 @@ public:
 
     for (std::uint32_t word_index = 0; word_index < word_count; word_index++) {
       std::uint64_t word = 0;
-      auto end_position = count - word_index * BASE_DIGITS;
+      auto end_position = count - (word_index * BASE_DIGITS);
       auto start_position =
           end_position > static_cast<std::uint32_t>(BASE_DIGITS)
               ? end_position - static_cast<std::uint32_t>(BASE_DIGITS)
               : 0U;
       for (auto position = start_position; position < end_position;
            position++) {
-        word = word * 10 + static_cast<std::uint64_t>(digits[position] - '0');
+        word = (word * 10) + static_cast<std::uint64_t>(digits[position] - '0');
       }
       result.words[word_index] = word;
     }
@@ -618,7 +619,7 @@ public:
       -> sourcemeta::core::uint128_t {
     sourcemeta::core::uint128_t value = 0;
     for (auto index = this->length; index > 0; index--) {
-      value = value * BASE + this->words[index - 1];
+      value = (value * BASE) + this->words[index - 1];
     }
 
     // Zero admits arbitrarily extreme exponents, which would otherwise make
@@ -729,11 +730,11 @@ auto load_big_pointer(std::int64_t coefficient) -> BigCoefficient * {
 auto coefficient_to_digit_string(std::int64_t coefficient,
                                  std::uint64_t coefficient_high,
                                  std::uint8_t flags) -> std::string {
-  if (flags & FLAG_HEAP) {
+  if ((flags & FLAG_HEAP) != 0) {
     return load_big_pointer(coefficient)->to_string();
   }
 
-  if (flags & FLAG_BIG) {
+  if ((flags & FLAG_BIG) != 0) {
     auto high_string = std::to_string(coefficient_high);
     auto low_string = std::to_string(static_cast<std::uint64_t>(coefficient));
     std::string result = high_string;
@@ -764,7 +765,7 @@ auto modular_pow10(std::uint32_t exponent, std::uint64_t modulus)
   std::uint64_t base = 10 % modulus;
   auto remaining = exponent;
   while (remaining > 0) {
-    if (remaining & 1) {
+    if ((remaining & 1) != 0u) {
       result = static_cast<std::uint64_t>(
           static_cast<sourcemeta::core::uint128_t>(result) * base % modulus);
     }
@@ -783,11 +784,11 @@ constexpr std::int32_t WORKING_PRECISION = 16;
 auto round_to_precision(std::int64_t &coefficient,
                         std::uint64_t &coefficient_high, std::int32_t &exponent,
                         std::uint8_t &flags) -> void {
-  if (flags & (FLAG_NAN | FLAG_SNAN | FLAG_INFINITE)) {
+  if ((flags & (FLAG_NAN | FLAG_SNAN | FLAG_INFINITE)) != 0) {
     return;
   }
 
-  if (flags & FLAG_BIG) {
+  if ((flags & FLAG_BIG) != 0) {
     auto digit_string =
         coefficient_to_digit_string(coefficient, coefficient_high, flags);
     auto total_digits = static_cast<std::int32_t>(digit_string.size());
@@ -823,13 +824,13 @@ auto round_to_precision(std::int64_t &coefficient,
       }
     }
 
-    if (flags & FLAG_HEAP) {
+    if ((flags & FLAG_HEAP) != 0) {
       delete load_big_pointer(coefficient);
     }
 
     std::int64_t new_coefficient = 0;
     for (auto character : kept) {
-      new_coefficient = new_coefficient * 10 + (character - '0');
+      new_coefficient = (new_coefficient * 10) + (character - '0');
     }
     if (round_up) {
       new_coefficient++;
@@ -867,7 +868,7 @@ auto round_to_precision(std::int64_t &coefficient,
 }
 
 void free_big_coefficient(std::int64_t coefficient, std::uint8_t flags) {
-  if (flags & FLAG_HEAP) {
+  if ((flags & FLAG_HEAP) != 0) {
     delete load_big_pointer(coefficient);
   }
 }
@@ -875,11 +876,11 @@ void free_big_coefficient(std::int64_t coefficient, std::uint8_t flags) {
 auto coefficient_as_big(std::int64_t coefficient,
                         std::uint64_t coefficient_high, std::uint8_t flags)
     -> BigCoefficient {
-  if (flags & FLAG_HEAP) {
+  if ((flags & FLAG_HEAP) != 0) {
     return load_big_pointer(coefficient)->clone();
   }
 
-  if (flags & FLAG_BIG) {
+  if ((flags & FLAG_BIG) != 0) {
     BigCoefficient result{2};
     result.words[0] = static_cast<std::uint64_t>(coefficient);
     result.words[1] = coefficient_high;

--- a/src/lang/numeric/decimal.cc
+++ b/src/lang/numeric/decimal.cc
@@ -30,29 +30,29 @@ auto strip_trailing_zeros(std::int64_t &coefficient, std::int32_t &exponent)
   // so a strip is only performed when the exponent can absorb the matching
   // increment. Otherwise the increment would overflow, and dividing the
   // coefficient without it would change the represented value
-  constexpr std::int32_t maximum{std::numeric_limits<std::int32_t>::max()};
+  constexpr std::int32_t MAXIMUM{std::numeric_limits<std::int32_t>::max()};
   constexpr std::int64_t POWER_OF_10_16 = 10000000000000000LL;
-  if (exponent <= maximum - 16 && coefficient % POWER_OF_10_16 == 0) {
+  if (exponent <= MAXIMUM - 16 && coefficient % POWER_OF_10_16 == 0) {
     coefficient /= POWER_OF_10_16;
     exponent += 16;
   }
 
-  if (exponent <= maximum - 8 && coefficient % 100000000 == 0) {
+  if (exponent <= MAXIMUM - 8 && coefficient % 100000000 == 0) {
     coefficient /= 100000000;
     exponent += 8;
   }
 
-  if (exponent <= maximum - 4 && coefficient % 10000 == 0) {
+  if (exponent <= MAXIMUM - 4 && coefficient % 10000 == 0) {
     coefficient /= 10000;
     exponent += 4;
   }
 
-  if (exponent <= maximum - 2 && coefficient % 100 == 0) {
+  if (exponent <= MAXIMUM - 2 && coefficient % 100 == 0) {
     coefficient /= 100;
     exponent += 2;
   }
 
-  if (exponent <= maximum - 1 && coefficient % 10 == 0) {
+  if (exponent <= MAXIMUM - 1 && coefficient % 10 == 0) {
     coefficient /= 10;
     exponent += 1;
   }
@@ -64,7 +64,7 @@ auto multiply_decimal_digits(std::vector<std::uint8_t> &digits,
                              const unsigned factor) -> void {
   unsigned carry{0};
   for (auto &digit : digits) {
-    const unsigned product{digit * factor + carry};
+    const unsigned product{(digit * factor) + carry};
     digit = static_cast<std::uint8_t>(product % 10);
     carry = product / 10;
   }
@@ -153,7 +153,7 @@ auto parse_digit_payload(const char *cursor, std::size_t count)
   // byte makes the whole token invalid rather than being silently accepted. A
   // payload longer than the storage saturates rather than overflowing, which
   // would otherwise be signed integer overflow (undefined behaviour)
-  constexpr auto maximum{
+  constexpr auto MAXIMUM{
       static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())};
   std::uint64_t payload = 0;
   for (std::size_t index = 0; index < count; index++) {
@@ -162,11 +162,11 @@ auto parse_digit_payload(const char *cursor, std::size_t count)
     }
 
     const auto digit = static_cast<std::uint64_t>(cursor[index] - '0');
-    if (payload > (maximum - digit) / 10) {
+    if (payload > (MAXIMUM - digit) / 10) {
       return std::numeric_limits<std::int64_t>::max();
     }
 
-    payload = payload * 10 + digit;
+    payload = (payload * 10) + digit;
   }
 
   return static_cast<std::int64_t>(payload);
@@ -322,7 +322,7 @@ auto parse_decimal_string(const char *input, std::size_t length)
 
     bool has_exponent_digit = false;
     while (cursor < end && *cursor >= '0' && *cursor <= '9') {
-      exponent_suffix_64 = exponent_suffix_64 * 10 + (*cursor - '0');
+      exponent_suffix_64 = (exponent_suffix_64 * 10) + (*cursor - '0');
       has_exponent_digit = true;
       cursor++;
       if (exponent_suffix_64 > 4000000000LL) {
@@ -376,7 +376,7 @@ auto parse_decimal_string(const char *input, std::size_t length)
     std::int64_t coefficient = 0;
     for (std::uint32_t index = leading_zeros; index < digit_count_total;
          index++) {
-      coefficient = coefficient * 10 + (digit_buffer[index] - '0');
+      coefficient = (coefficient * 10) + (digit_buffer[index] - '0');
     }
 
     result.coefficient = coefficient;
@@ -386,13 +386,13 @@ auto parse_decimal_string(const char *input, std::size_t length)
     std::uint64_t low_word = 0;
     for (std::uint32_t index = low_start;
          index < leading_zeros + significant_digits; index++) {
-      low_word =
-          low_word * 10 + static_cast<std::uint64_t>(digit_buffer[index] - '0');
+      low_word = (low_word * 10) +
+                 static_cast<std::uint64_t>(digit_buffer[index] - '0');
     }
 
     std::uint64_t high_word = 0;
     for (std::uint32_t index = leading_zeros; index < low_start; index++) {
-      high_word = high_word * 10 +
+      high_word = (high_word * 10) +
                   static_cast<std::uint64_t>(digit_buffer[index] - '0');
     }
 
@@ -458,12 +458,12 @@ void check_exponent_overflow(std::int32_t left_exponent,
 
 auto format_special_value(std::string &result, std::uint8_t flags,
                           std::int64_t coefficient) -> bool {
-  if (flags & FLAG_NAN) {
-    if (flags & FLAG_SIGN) {
+  if ((flags & FLAG_NAN) != 0) {
+    if ((flags & FLAG_SIGN) != 0) {
       result += '-';
     }
 
-    if (flags & FLAG_SNAN) {
+    if ((flags & FLAG_SNAN) != 0) {
       result += "sNaN";
     } else {
       result += "NaN";
@@ -476,8 +476,8 @@ auto format_special_value(std::string &result, std::uint8_t flags,
     return true;
   }
 
-  if (flags & FLAG_INFINITE) {
-    if (flags & FLAG_SIGN) {
+  if ((flags & FLAG_INFINITE) != 0) {
+    if ((flags & FLAG_SIGN) != 0) {
       result += '-';
     }
 
@@ -500,7 +500,7 @@ Decimal::Decimal(const Decimal &other)
     : coefficient_{other.coefficient_},
       coefficient_high_{other.coefficient_high_}, exponent_{other.exponent_},
       flags_{other.flags_} {
-  if (other.flags_ & FLAG_HEAP) {
+  if ((other.flags_ & FLAG_HEAP) != 0) {
     store_big_pointer(this->coefficient_,
                       load_big_pointer(other.coefficient_)->clone());
   }
@@ -518,7 +518,7 @@ Decimal::Decimal(Decimal &&other) noexcept
 
 auto Decimal::operator=(const Decimal &other) -> Decimal & {
   if (this != &other) {
-    if (other.flags_ & FLAG_HEAP) {
+    if ((other.flags_ & FLAG_HEAP) != 0) {
       // Copy the heap coefficient before releasing the current one, so that a
       // failed allocation leaves this value intact rather than owning storage
       // shared with the source, which would then be released twice
@@ -706,7 +706,7 @@ auto Decimal::to_scientific_string() const -> std::string {
   auto number_of_digits = static_cast<std::int32_t>(digit_string.size());
   auto adjusted_exponent = this->exponent_ + number_of_digits - 1;
 
-  if (this->flags_ & FLAG_SIGN) {
+  if ((this->flags_ & FLAG_SIGN) != 0) {
     result += '-';
   }
 
@@ -744,18 +744,18 @@ auto Decimal::to_string() const -> std::string {
   std::int32_t decimal_place;
   if (this->exponent_ <= 0 && integer_digit_count > -6) {
     decimal_place = integer_digit_count;
-  } else if (this->coefficient_ == 0 && !(this->flags_ & FLAG_BIG)) {
-    decimal_place = -1 + ((this->exponent_ + 2) % 3 + 3) % 3;
+  } else if (this->coefficient_ == 0 && ((this->flags_ & FLAG_BIG) == 0)) {
+    decimal_place = -1 + ((((this->exponent_ + 2) % 3) + 3) % 3);
   } else {
     decimal_place = integer_digit_count +
-                    ((integer_digit_count - 1) % 3 + 3) % 3 -
-                    ((integer_digit_count - 1) % 3 + 3) % 3;
+                    ((((integer_digit_count - 1) % 3) + 3) % 3) -
+                    ((((integer_digit_count - 1) % 3) + 3) % 3);
     auto adjusted = integer_digit_count - 1;
     auto remainder = ((adjusted % 3) + 3) % 3;
     decimal_place = 1 + remainder;
   }
 
-  if (this->flags_ & FLAG_SIGN) {
+  if ((this->flags_ & FLAG_SIGN) != 0) {
     result += '-';
   }
 
@@ -795,11 +795,11 @@ auto Decimal::to_string() const -> std::string {
 auto Decimal::to_int64() const -> std::int64_t {
   assert(this->is_int64());
 
-  if (this->flags_ & FLAG_BIG) {
+  if ((this->flags_ & FLAG_BIG) != 0) {
     auto big = coefficient_as_big(this->coefficient_, this->coefficient_high_,
                                   this->flags_);
     auto value = big.to_uint128(this->exponent_);
-    if (this->flags_ & FLAG_SIGN) {
+    if ((this->flags_ & FLAG_SIGN) != 0) {
       // Negate in unsigned arithmetic so that the most negative value does not
       // overflow, since applying unary minus to its positive magnitude in a
       // signed type would be undefined behaviour
@@ -829,7 +829,7 @@ auto Decimal::to_int64() const -> std::int64_t {
     exponent++;
   }
 
-  return (this->flags_ & FLAG_SIGN) ? -coefficient : coefficient;
+  return ((this->flags_ & FLAG_SIGN) != 0) ? -coefficient : coefficient;
 }
 
 auto Decimal::to_int32() const -> std::int32_t {
@@ -840,7 +840,7 @@ auto Decimal::to_int32() const -> std::int32_t {
 auto Decimal::to_uint64() const -> std::uint64_t {
   assert(this->is_uint64());
 
-  if (this->flags_ & FLAG_BIG) {
+  if ((this->flags_ & FLAG_BIG) != 0) {
     auto big = coefficient_as_big(this->coefficient_, this->coefficient_high_,
                                   this->flags_);
     auto value = static_cast<std::uint64_t>(big.to_uint128(this->exponent_));
@@ -907,12 +907,12 @@ auto Decimal::to_double() const -> double {
 }
 
 auto Decimal::is_zero() const -> bool {
-  if (this->flags_ & SPECIAL_MASK) {
-    if (this->flags_ & FLAG_HEAP) {
+  if ((this->flags_ & SPECIAL_MASK) != 0) {
+    if ((this->flags_ & FLAG_HEAP) != 0) {
       return load_big_pointer(this->coefficient_)->is_zero();
     }
 
-    if (this->flags_ & FLAG_BIG) {
+    if ((this->flags_ & FLAG_BIG) != 0) {
       return this->coefficient_ == 0 && this->coefficient_high_ == 0;
     }
 
@@ -923,7 +923,7 @@ auto Decimal::is_zero() const -> bool {
 }
 
 auto Decimal::is_integral() const -> bool {
-  if (this->flags_ & (FLAG_NAN | FLAG_SNAN | FLAG_INFINITE)) {
+  if ((this->flags_ & (FLAG_NAN | FLAG_SNAN | FLAG_INFINITE)) != 0) {
     return false;
   }
 
@@ -935,7 +935,7 @@ auto Decimal::is_integral() const -> bool {
     return true;
   }
 
-  if (this->flags_ & FLAG_BIG) {
+  if ((this->flags_ & FLAG_BIG) != 0) {
     auto big = coefficient_as_big(this->coefficient_, this->coefficient_high_,
                                   this->flags_);
     auto stripped = big.strip_trailing_zeros();
@@ -993,7 +993,7 @@ auto Decimal::to_integral() const -> Decimal {
     return *this;
   }
 
-  if (this->flags_ & FLAG_BIG) {
+  if ((this->flags_ & FLAG_BIG) != 0) {
     auto digit_string = coefficient_to_digit_string(
         this->coefficient_, this->coefficient_high_, this->flags_);
     auto number_of_digits = static_cast<std::int32_t>(digit_string.size());
@@ -1007,7 +1007,7 @@ auto Decimal::to_integral() const -> Decimal {
     auto integer_string = digit_string.substr(
         0, static_cast<std::size_t>(number_of_digits - digits_to_remove));
     Decimal result{integer_string};
-    if (this->flags_ & FLAG_SIGN) {
+    if ((this->flags_ & FLAG_SIGN) != 0) {
       result.flags_ |= FLAG_SIGN;
     }
 
@@ -1038,7 +1038,7 @@ auto Decimal::to_integral() const -> Decimal {
   Decimal result;
   result.coefficient_ = quotient;
   result.exponent_ = 0;
-  if (this->flags_ & FLAG_SIGN) {
+  if ((this->flags_ & FLAG_SIGN) != 0) {
     result.flags_ = FLAG_SIGN;
   }
 
@@ -1058,17 +1058,17 @@ auto Decimal::divisible_by(const Decimal &divisor) const -> bool {
     return false;
   }
 
-  if (!(divisor.flags_ & FLAG_BIG) && !(this->flags_ & FLAG_HEAP)) {
+  if (((divisor.flags_ & FLAG_BIG) == 0) && ((this->flags_ & FLAG_HEAP) == 0)) {
     auto divisor_value = static_cast<std::uint64_t>(divisor.coefficient_);
 
     std::uint64_t dividend_mod;
-    if (this->flags_ & FLAG_BIG) {
+    if ((this->flags_ & FLAG_BIG) != 0) {
       auto hi_mod = this->coefficient_high_ % divisor_value;
       auto base_mod = BASE % divisor_value;
       auto lo_mod =
           static_cast<std::uint64_t>(this->coefficient_) % divisor_value;
       dividend_mod = static_cast<std::uint64_t>(
-          (static_cast<sourcemeta::core::uint128_t>(hi_mod) * base_mod +
+          ((static_cast<sourcemeta::core::uint128_t>(hi_mod) * base_mod) +
            lo_mod) %
           divisor_value);
     } else {
@@ -1092,10 +1092,10 @@ auto Decimal::divisible_by(const Decimal &divisor) const -> bool {
     }
 
     sourcemeta::core::uint128_t remaining;
-    if (this->flags_ & FLAG_BIG) {
+    if ((this->flags_ & FLAG_BIG) != 0) {
       remaining =
-          static_cast<sourcemeta::core::uint128_t>(this->coefficient_high_) *
-              BASE +
+          (static_cast<sourcemeta::core::uint128_t>(this->coefficient_high_) *
+           BASE) +
           static_cast<std::uint64_t>(this->coefficient_);
     } else {
       remaining = static_cast<sourcemeta::core::uint128_t>(
@@ -1161,14 +1161,14 @@ auto Decimal::reduce() const -> Decimal {
 
   if (this->is_zero()) {
     Decimal result;
-    if (this->flags_ & FLAG_SIGN) {
+    if ((this->flags_ & FLAG_SIGN) != 0) {
       result.flags_ = FLAG_SIGN;
     }
 
     return result;
   }
 
-  if (this->flags_ & FLAG_BIG) {
+  if ((this->flags_ & FLAG_BIG) != 0) {
     auto big = coefficient_as_big(this->coefficient_, this->coefficient_high_,
                                   this->flags_);
     auto stripped_count = big.strip_trailing_zeros();
@@ -1194,7 +1194,7 @@ auto Decimal::reduce() const -> Decimal {
   Decimal result;
   result.coefficient_ = coefficient;
   result.exponent_ = exponent;
-  if (this->flags_ & FLAG_SIGN) {
+  if ((this->flags_ & FLAG_SIGN) != 0) {
     result.flags_ = FLAG_SIGN;
   }
 
@@ -1215,7 +1215,7 @@ auto Decimal::logb() const -> Decimal {
   }
 
   std::int64_t digits;
-  if (this->flags_ & FLAG_BIG) {
+  if ((this->flags_ & FLAG_BIG) != 0) {
     auto big = coefficient_as_big(this->coefficient_, this->coefficient_high_,
                                   this->flags_);
     digits = static_cast<std::int64_t>(big.digit_count());
@@ -1336,7 +1336,7 @@ auto Decimal::compare_total(const Decimal &other) const -> Decimal {
   }
 
   int magnitude_compare;
-  if ((this->flags_ & FLAG_BIG) || (other.flags_ & FLAG_BIG)) {
+  if (((this->flags_ & FLAG_BIG) != 0) || ((other.flags_ & FLAG_BIG) != 0)) {
     auto left_big = coefficient_as_big(this->coefficient_,
                                        this->coefficient_high_, this->flags_);
     auto right_big = coefficient_as_big(other.coefficient_,
@@ -1537,7 +1537,7 @@ auto Decimal::operator==(const Decimal &other) const -> bool {
   auto right_coefficient = other.coefficient_;
   auto right_exponent = other.exponent_;
 
-  if ((this->flags_ & FLAG_BIG) || (other.flags_ & FLAG_BIG)) {
+  if (((this->flags_ & FLAG_BIG) != 0) || ((other.flags_ & FLAG_BIG) != 0)) {
     auto left_big = coefficient_as_big(this->coefficient_,
                                        this->coefficient_high_, this->flags_);
     auto right_big = coefficient_as_big(other.coefficient_,
@@ -1563,15 +1563,15 @@ auto Decimal::operator<(const Decimal &other) const -> bool {
   }
 
   if (this->is_infinite()) {
-    if (this->flags_ & FLAG_SIGN) {
-      return !other.is_infinite() || !(other.flags_ & FLAG_SIGN);
+    if ((this->flags_ & FLAG_SIGN) != 0) {
+      return !other.is_infinite() || ((other.flags_ & FLAG_SIGN) == 0);
     }
 
     return false;
   }
 
   if (other.is_infinite()) {
-    if (other.flags_ & FLAG_SIGN) {
+    if ((other.flags_ & FLAG_SIGN) != 0) {
       return false;
     }
 
@@ -1605,7 +1605,7 @@ auto Decimal::operator<(const Decimal &other) const -> bool {
 
   int magnitude_compare;
 
-  if ((this->flags_ & FLAG_BIG) || (other.flags_ & FLAG_BIG)) {
+  if (((this->flags_ & FLAG_BIG) != 0) || ((other.flags_ & FLAG_BIG) != 0)) {
     auto left_big = coefficient_as_big(this->coefficient_,
                                        this->coefficient_high_, this->flags_);
     auto right_big = coefficient_as_big(other.coefficient_,
@@ -1753,7 +1753,8 @@ auto Decimal::operator+=(const Decimal &other) -> Decimal & {
   bool left_negative = (this->flags_ & FLAG_SIGN) != 0;
   bool right_negative = (other.flags_ & FLAG_SIGN) != 0;
 
-  bool needs_big = (this->flags_ & FLAG_BIG) || (other.flags_ & FLAG_BIG);
+  bool needs_big =
+      ((this->flags_ & FLAG_BIG) != 0) || ((other.flags_ & FLAG_BIG) != 0);
   auto left_coefficient = this->coefficient_;
   auto right_coefficient = other.coefficient_;
   auto result_exponent = std::min(this->exponent_, other.exponent_);
@@ -1892,7 +1893,7 @@ auto Decimal::operator*=(const Decimal &other) -> Decimal & {
 
   auto result_exponent = static_cast<std::int32_t>(result_exponent_64);
 
-  if ((this->flags_ & FLAG_BIG) || (other.flags_ & FLAG_BIG)) {
+  if (((this->flags_ & FLAG_BIG) != 0) || ((other.flags_ & FLAG_BIG) != 0)) {
     auto left_big = coefficient_as_big(this->coefficient_,
                                        this->coefficient_high_, this->flags_);
     auto right_big = coefficient_as_big(other.coefficient_,
@@ -1982,7 +1983,7 @@ auto Decimal::operator/=(const Decimal &other) -> Decimal & {
   free_big_coefficient(this->coefficient_, this->flags_);
   store_big_result(this->coefficient_, this->coefficient_high_, this->flags_,
                    std::move(quotient), result_negative);
-  if (this->coefficient_ == 0 && !(this->flags_ & FLAG_BIG)) {
+  if (this->coefficient_ == 0 && ((this->flags_ & FLAG_BIG) == 0)) {
     this->flags_ = 0;
   }
 

--- a/src/lang/numeric/include/sourcemeta/core/numeric_decimal.h
+++ b/src/lang/numeric/include/sourcemeta/core/numeric_decimal.h
@@ -131,17 +131,17 @@ public:
   /// `false` for values constructed from floating-point primitives, from
   /// strings with a fractional or exponent part, or as the result of
   /// arithmetic operations.
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_integer() const -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_integer() const -> bool {
     return (this->flags_ & FLAG_INTEGER_LITERAL) != 0;
   }
 
   /// Check if the decimal number is finite
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_finite() const -> bool {
-    return !(this->flags_ & (FLAG_NAN | FLAG_SNAN | FLAG_INFINITE));
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_finite() const -> bool {
+    return (this->flags_ & (FLAG_NAN | FLAG_SNAN | FLAG_INFINITE)) == 0;
   }
 
   /// Check if the decimal number is a real number (finite and not NaN)
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_real() const -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_real() const -> bool {
     return this->is_finite() && !this->is_integral();
   }
 
@@ -167,34 +167,34 @@ public:
 
   /// Check if the decimal number is NaN (Not a Number), either quiet or
   /// signaling
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_nan() const -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_nan() const -> bool {
     return (this->flags_ & FLAG_NAN) != 0;
   }
 
   /// Check if the decimal number is a signaling NaN
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_snan() const -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_snan() const -> bool {
     return (this->flags_ & FLAG_SNAN) != 0;
   }
 
   /// Check if the decimal number is a quiet NaN
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_qnan() const -> bool {
-    return (this->flags_ & FLAG_NAN) != 0 && !(this->flags_ & FLAG_SNAN);
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_qnan() const -> bool {
+    return (this->flags_ & FLAG_NAN) != 0 && ((this->flags_ & FLAG_SNAN) == 0);
   }
 
   /// Get the payload of a NaN value (0 if no payload)
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto nan_payload() const
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto nan_payload() const
       -> std::uint64_t {
     assert(this->is_nan());
     return static_cast<std::uint64_t>(this->coefficient_);
   }
 
   /// Check if the decimal number is infinite
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_infinite() const -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_infinite() const -> bool {
     return (this->flags_ & FLAG_INFINITE) != 0;
   }
 
   /// Check if the decimal number is signed (negative, including -0)
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto is_signed() const -> bool {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE auto is_signed() const -> bool {
     return (this->flags_ & FLAG_SIGN) != 0;
   }
 

--- a/src/lang/numeric/include/sourcemeta/core/numeric_util.h
+++ b/src/lang/numeric/include/sourcemeta/core/numeric_util.h
@@ -48,7 +48,7 @@ concept any_decimal = (std::same_as<Ts, Decimal> || ...);
 /// assert(!sourcemeta::core::is_digit('a'));
 /// assert(!sourcemeta::core::is_digit(' '));
 /// ```
-inline constexpr auto is_digit(const char character) -> bool {
+constexpr auto is_digit(const char character) -> bool {
   return character >= '0' && character <= '9';
 }
 
@@ -66,7 +66,7 @@ inline constexpr auto is_digit(const char character) -> bool {
 /// assert(!sourcemeta::core::is_positive_digit('0'));
 /// assert(!sourcemeta::core::is_positive_digit('a'));
 /// ```
-inline constexpr auto is_positive_digit(const char character) -> bool {
+constexpr auto is_positive_digit(const char character) -> bool {
   return character >= '1' && character <= '9';
 }
 
@@ -95,35 +95,34 @@ auto divide_floor(const Dividend &dividend, const Divisor &divisor) {
     assert(decimal_divisor > Decimal{0});
     if (decimal_divisor == Decimal{1}) {
       return decimal_dividend;
-    } else if (decimal_dividend >= Decimal{0}) {
-      return decimal_dividend.divide_integer(decimal_divisor);
-    } else {
-      const Decimal absolute_dividend{
-          decimal_dividend.is_signed() ? -decimal_dividend : decimal_dividend};
-      const Decimal quotient{absolute_dividend.divide_integer(decimal_divisor)};
-      if (absolute_dividend % decimal_divisor == Decimal{0}) {
-        return -quotient;
-      } else {
-        return -(quotient + Decimal{1});
-      }
     }
+    if (decimal_dividend >= Decimal{0}) {
+      return decimal_dividend.divide_integer(decimal_divisor);
+    }
+    const Decimal absolute_dividend{
+        decimal_dividend.is_signed() ? -decimal_dividend : decimal_dividend};
+    const Decimal quotient{absolute_dividend.divide_integer(decimal_divisor)};
+    if (absolute_dividend % decimal_divisor == Decimal{0}) {
+      return -quotient;
+    }
+    return -(quotient + Decimal{1});
+
   } else {
     const auto signed_dividend{static_cast<std::int64_t>(dividend)};
     const auto unsigned_divisor{static_cast<std::uint64_t>(divisor)};
     assert(unsigned_divisor > 0);
     if (unsigned_divisor == 1) {
       return signed_dividend;
-    } else if (signed_dividend >= 0) {
+    }
+    if (signed_dividend >= 0) {
       return static_cast<std::int64_t>(
           static_cast<std::uint64_t>(signed_dividend) / unsigned_divisor);
-    } else {
-      // Negate in unsigned to avoid UB for INT64_MIN
-      const std::uint64_t absolute_dividend{
-          static_cast<std::uint64_t>(0) -
-          static_cast<std::uint64_t>(signed_dividend)};
-      return -(static_cast<std::int64_t>(
-          1 + ((absolute_dividend - 1) / unsigned_divisor)));
-    }
+    } // Negate in unsigned to avoid UB for INT64_MIN
+    const std::uint64_t absolute_dividend{
+        static_cast<std::uint64_t>(0) -
+        static_cast<std::uint64_t>(signed_dividend)};
+    return -(static_cast<std::int64_t>(
+        1 + ((absolute_dividend - 1) / unsigned_divisor)));
   }
 }
 
@@ -141,43 +140,41 @@ auto divide_ceil(const Dividend &dividend, const Divisor &divisor) {
     assert(decimal_divisor > Decimal{0});
     if (decimal_divisor == Decimal{1}) {
       return decimal_dividend;
-    } else if (decimal_dividend >= Decimal{0}) {
+    }
+    if (decimal_dividend >= Decimal{0}) {
       const Decimal quotient{decimal_dividend.divide_integer(decimal_divisor)};
       if (decimal_dividend % decimal_divisor == Decimal{0}) {
         return quotient;
-      } else {
-        return quotient + Decimal{1};
       }
-    } else {
-      const Decimal absolute_dividend{
-          decimal_dividend.is_signed() ? -decimal_dividend : decimal_dividend};
-      return -(absolute_dividend.divide_integer(decimal_divisor));
+      return quotient + Decimal{1};
     }
+    const Decimal absolute_dividend{
+        decimal_dividend.is_signed() ? -decimal_dividend : decimal_dividend};
+    return -(absolute_dividend.divide_integer(decimal_divisor));
+
   } else {
     const auto signed_dividend{static_cast<std::int64_t>(dividend)};
     const auto unsigned_divisor{static_cast<std::uint64_t>(divisor)};
     assert(unsigned_divisor > 0);
     if (unsigned_divisor == 1) {
       return signed_dividend;
-    } else if (signed_dividend >= 0) {
+    }
+    if (signed_dividend >= 0) {
       if (static_cast<std::uint64_t>(signed_dividend) + unsigned_divisor <
           unsigned_divisor) {
         return static_cast<std::int64_t>(
             (static_cast<std::uint64_t>(signed_dividend) / unsigned_divisor) +
             1 - (1 / unsigned_divisor));
-      } else {
-        return static_cast<std::int64_t>(
-            (static_cast<std::uint64_t>(signed_dividend) + unsigned_divisor -
-             1) /
-            unsigned_divisor);
       }
-    } else {
-      // Negate in unsigned to avoid UB for INT64_MIN
-      return -(static_cast<std::int64_t>(
-          (static_cast<std::uint64_t>(0) -
-           static_cast<std::uint64_t>(signed_dividend)) /
-          unsigned_divisor));
-    }
+      return static_cast<std::int64_t>(
+          (static_cast<std::uint64_t>(signed_dividend) + unsigned_divisor - 1) /
+          unsigned_divisor);
+
+    } // Negate in unsigned to avoid UB for INT64_MIN
+    return -(static_cast<std::int64_t>(
+        (static_cast<std::uint64_t>(0) -
+         static_cast<std::uint64_t>(signed_dividend)) /
+        unsigned_divisor));
   }
 }
 
@@ -228,7 +225,10 @@ auto count_multiples(const Minimum &minimum, const Maximum &maximum,
 
 /// @ingroup numeric
 /// The maximum value representable by an unsigned integer of T bits
+// The upper-case spelling this constant would otherwise take collides with the
+// UINT_MAX macro from the C standard library
 template <unsigned int T>
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr auto uint_max = []() -> std::uint64_t {
   static_assert(T > 0 && T < 64, "uint_max<T> requires 0 < T < 64");
   return (std::uint64_t{1} << T) - 1;
@@ -255,9 +255,8 @@ constexpr auto is_within(const T &value, const std::uint64_t lower,
   if (value >= 0) {
     return static_cast<std::uint64_t>(value) >= lower &&
            static_cast<std::uint64_t>(value) <= higher;
-  } else {
-    return false;
   }
+  return false;
 }
 
 /// @ingroup numeric
@@ -277,9 +276,8 @@ template <typename T> auto abs(const T &value) {
     if (value < 0) {
       // Negate in unsigned to avoid UB for INT64_MIN
       return static_cast<std::uint64_t>(0) - static_cast<std::uint64_t>(value);
-    } else {
-      return static_cast<std::uint64_t>(value);
     }
+    return static_cast<std::uint64_t>(value);
   }
 }
 
@@ -324,11 +322,11 @@ constexpr auto correct_ieee754(const Real value) -> Real {
   const Real next{base + 1};
   if (next - value <= threshold) {
     return next;
-  } else if (value - base <= threshold) {
-    return base;
-  } else {
-    return value;
   }
+  if (value - base <= threshold) {
+    return base;
+  }
+  return value;
 }
 
 /// @ingroup numeric
@@ -385,19 +383,19 @@ auto real_equal(const Real left, const Real right) -> bool {
   // Map the sign-and-magnitude bit pattern to a biased ordering in which
   // adjacent representable values differ by one, so their distance counts the
   // units in the last place between them
-  constexpr Bits sign_bit{Bits{1} << (8 * sizeof(Bits) - 1)};
+  constexpr Bits SIGN_BIT{Bits{1} << ((8 * sizeof(Bits)) - 1)};
   const Bits left_bits{std::bit_cast<Bits>(left)};
   const Bits right_bits{std::bit_cast<Bits>(right)};
-  const Bits left_biased{(sign_bit & left_bits) != 0
+  const Bits left_biased{(SIGN_BIT & left_bits) != 0
                              ? static_cast<Bits>(~left_bits + Bits{1})
-                             : static_cast<Bits>(sign_bit | left_bits)};
-  const Bits right_biased{(sign_bit & right_bits) != 0
+                             : static_cast<Bits>(SIGN_BIT | left_bits)};
+  const Bits right_biased{(SIGN_BIT & right_bits) != 0
                               ? static_cast<Bits>(~right_bits + Bits{1})
-                              : static_cast<Bits>(sign_bit | right_bits)};
-  constexpr Bits maximum_units_in_last_place{4};
+                              : static_cast<Bits>(SIGN_BIT | right_bits)};
+  constexpr Bits MAXIMUM_UNITS_IN_LAST_PLACE{4};
   return (left_biased >= right_biased
               ? left_biased - right_biased
-              : right_biased - left_biased) <= maximum_units_in_last_place;
+              : right_biased - left_biased) <= MAXIMUM_UNITS_IN_LAST_PLACE;
 }
 
 } // namespace sourcemeta::core

--- a/src/lang/numeric/include/sourcemeta/core/numeric_zigzag.h
+++ b/src/lang/numeric/include/sourcemeta/core/numeric_zigzag.h
@@ -26,9 +26,9 @@ template <typename T> auto zigzag_encode(const T &value) {
       return static_cast<std::uint64_t>(signed_value) * 2;
     }
     // Negate in unsigned to avoid UB for INT64_MIN
-    return (static_cast<std::uint64_t>(0) -
-            static_cast<std::uint64_t>(signed_value)) *
-               2 -
+    return ((static_cast<std::uint64_t>(0) -
+             static_cast<std::uint64_t>(signed_value)) *
+            2) -
            1;
   }
 }

--- a/src/lang/numeric/parse.cc
+++ b/src/lang/numeric/parse.cc
@@ -37,7 +37,7 @@ auto to_double(const std::string_view input) noexcept -> std::optional<double> {
   // is not guaranteed to be null-terminated, so it must be bounded first.
   // Darwin documents that a null locale argument selects the C locale, so a
   // failed locale construction still yields the intended behavior
-  static const locale_t c_locale{newlocale(LC_ALL_MASK, "C", nullptr)};
+  static const locale_t C_LOCALE{newlocale(LC_ALL_MASK, "C", nullptr)};
   std::array<char, 64> buffer;
   std::string overflow;
   const char *start{nullptr};
@@ -57,7 +57,7 @@ auto to_double(const std::string_view input) noexcept -> std::optional<double> {
 
   errno = 0;
   char *end{nullptr};
-  const auto value{strtod_l(start, &end, c_locale)};
+  const auto value{strtod_l(start, &end, C_LOCALE)};
   if (end != start + input.size()) {
     return std::nullopt;
   }

--- a/src/lang/options/include/sourcemeta/core/options.h
+++ b/src/lang/options/include/sourcemeta/core/options.h
@@ -113,10 +113,10 @@ private:
   static constexpr std::string_view POSITIONAL_ARGUMENT_NAME{""};
   static const std::vector<std::string_view> EMPTY;
 
-  std::vector<std::unique_ptr<std::string>> storage;
+  std::vector<std::unique_ptr<std::string>> storage_;
   std::unordered_map<std::string_view, std::string_view> aliases_;
   std::unordered_map<std::string_view, std::vector<std::string_view>> options_;
-  std::unordered_set<std::string_view> flags;
+  std::unordered_set<std::string_view> flags_;
 #if defined(_MSC_VER)
 #pragma warning(default : 4251 4275)
 #endif

--- a/src/lang/options/options.cc
+++ b/src/lang/options/options.cc
@@ -15,13 +15,12 @@ auto emplace_back_unique(T &container, V &&element) -> const auto & {
 
 template <typename T>
 auto find_canonical_name(const T &aliases, const typename T::key_type &alias)
-    -> const typename T::mapped_type & {
+    -> const T::mapped_type & {
   const auto iterator{aliases.find(alias)};
   if (iterator == aliases.cend()) {
     throw sourcemeta::core::OptionsUnknownOptionError(alias);
-  } else {
-    return iterator->second;
   }
+  return iterator->second;
 }
 
 } // namespace
@@ -33,12 +32,12 @@ const std::vector<std::string_view> Options::EMPTY = {};
 auto Options::option(std::string &&name,
                      std::initializer_list<std::string> aliases) -> void {
   assert(!name.empty());
-  const std::string_view view{emplace_back_unique(this->storage, name)};
+  const std::string_view view{emplace_back_unique(this->storage_, name)};
   this->aliases_.try_emplace(view, view);
   for (const auto &alias : aliases) {
     assert(!alias.empty());
     const std::string_view alias_view{
-        emplace_back_unique(this->storage, alias)};
+        emplace_back_unique(this->storage_, alias)};
     this->aliases_.try_emplace(alias_view, view);
   }
 }
@@ -46,16 +45,16 @@ auto Options::option(std::string &&name,
 auto Options::flag(std::string &&name,
                    std::initializer_list<std::string> aliases) -> void {
   assert(!name.empty());
-  const std::string_view view{emplace_back_unique(this->storage, name)};
+  const std::string_view view{emplace_back_unique(this->storage_, name)};
   this->aliases_.try_emplace(view, view);
   for (const auto &alias : aliases) {
     assert(!alias.empty());
     const std::string_view alias_view{
-        emplace_back_unique(this->storage, alias)};
+        emplace_back_unique(this->storage_, alias)};
     this->aliases_.try_emplace(alias_view, view);
   }
 
-  this->flags.emplace(view);
+  this->flags_.emplace(view);
 }
 
 auto Options::at(const std::string_view name) const
@@ -87,7 +86,8 @@ auto Options::parse(const int argc,
     if (end_of_options) {
       this->options_[POSITIONAL_ARGUMENT_NAME].emplace_back(token);
       continue;
-    } else if (token == "--") {
+    }
+    if (token == "--") {
       end_of_options = true;
       continue;
     }
@@ -97,21 +97,22 @@ auto Options::parse(const int argc,
 
     // Parse long options
     if (token.size() >= 3 && token[0] == '-' && token[1] == '-') {
-      const auto eq{token.find('=')};
-      const auto name{(eq == std::string_view::npos) ? token.substr(2)
-                                                     : token.substr(2, eq - 2)};
+      const auto separator{token.find('=')};
+      const auto name{(separator == std::string_view::npos)
+                          ? token.substr(2)
+                          : token.substr(2, separator - 2)};
       const auto &canonical{find_canonical_name(this->aliases_, name)};
-      const auto is_flag{this->flags.contains(canonical)};
+      const auto is_flag{this->flags_.contains(canonical)};
 
       if (is_flag) {
-        if (eq == std::string_view::npos) {
+        if (separator == std::string_view::npos) {
           this->options_[canonical].push_back(token.substr(2));
         } else {
           throw OptionsUnexpectedValueFlagError(name);
         }
-      } else if (eq != std::string_view::npos) {
-        this->options_[canonical].push_back(token.substr(eq + 1));
-      } else if (next) {
+      } else if (separator != std::string_view::npos) {
+        this->options_[canonical].push_back(token.substr(separator + 1));
+      } else if (next != nullptr) {
         this->options_[canonical].emplace_back(next);
         index += 1;
       } else {
@@ -123,14 +124,14 @@ auto Options::parse(const int argc,
       for (std::size_t flag = 1; flag < token.size(); flag++) {
         const auto name{token.substr(flag, 1)};
         const auto &canonical{find_canonical_name(this->aliases_, name)};
-        const auto is_flag{this->flags.contains(canonical)};
+        const auto is_flag{this->flags_.contains(canonical)};
 
         if (is_flag) {
           this->options_[canonical].emplace_back();
         } else if (flag + 1 < token.size()) {
           this->options_[canonical].push_back(token.substr(flag + 1));
           break;
-        } else if (next) {
+        } else if (next != nullptr) {
           this->options_[canonical].emplace_back(next);
           index += 1;
           break;

--- a/src/lang/process/spawn.cc
+++ b/src/lang/process/spawn.cc
@@ -372,7 +372,8 @@ auto drain_stream(Descriptor &descriptor, std::string &destination) -> bool {
   if (count > 0) {
     destination.append(buffer.data(), static_cast<std::size_t>(count));
     return true;
-  } else if (count == -1 && is_retryable_error()) {
+  }
+  if (count == -1 && is_retryable_error()) {
     return true;
   }
 
@@ -391,7 +392,8 @@ auto write_stream(Descriptor &descriptor, const std::string_view input,
     }
 
     return;
-  } else if (count == -1 && is_retryable_error()) {
+  }
+  if (count == -1 && is_retryable_error()) {
     return;
   }
 

--- a/src/lang/stacktrace/stacktrace_posix.h
+++ b/src/lang/stacktrace/stacktrace_posix.h
@@ -18,9 +18,9 @@
 
 namespace {
 
-constexpr int maximum_frames{128};
-constexpr std::size_t hex_buffer_size{2 + (sizeof(std::uintptr_t) * 2)};
-constexpr std::size_t decimal_buffer_size{24};
+constexpr int MAXIMUM_FRAMES{128};
+constexpr std::size_t HEX_BUFFER_SIZE{2 + (sizeof(std::uintptr_t) * 2)};
+constexpr std::size_t DECIMAL_BUFFER_SIZE{24};
 
 auto raw_write(int file_descriptor, const char *data, std::size_t size)
     -> void {
@@ -32,8 +32,8 @@ auto write_text(int file_descriptor, const char *text) -> void {
 }
 
 auto write_hex(int file_descriptor, std::uintptr_t value) -> void {
-  constexpr const char *digits{"0123456789abcdef"};
-  std::array<char, hex_buffer_size> buffer{{'0', 'x'}};
+  constexpr const char *DIGITS{"0123456789abcdef"};
+  std::array<char, HEX_BUFFER_SIZE> buffer{{'0', 'x'}};
   std::size_t index{2};
   if (value == 0) {
     buffer[index++] = '0';
@@ -41,7 +41,7 @@ auto write_hex(int file_descriptor, std::uintptr_t value) -> void {
     std::array<char, sizeof(std::uintptr_t) * 2> temporary{};
     std::size_t length{0};
     while (value != 0) {
-      temporary[length++] = digits[value & 0xF];
+      temporary[length++] = DIGITS[value & 0xF];
       value >>= 4;
     }
     while (length > 0) {
@@ -52,12 +52,12 @@ auto write_hex(int file_descriptor, std::uintptr_t value) -> void {
 }
 
 auto write_decimal(int file_descriptor, unsigned long value) -> void {
-  std::array<char, decimal_buffer_size> buffer{};
+  std::array<char, DECIMAL_BUFFER_SIZE> buffer{};
   std::size_t length{0};
   if (value == 0) {
     buffer[length++] = '0';
   } else {
-    std::array<char, decimal_buffer_size> temporary{};
+    std::array<char, DECIMAL_BUFFER_SIZE> temporary{};
     std::size_t temporary_length{0};
     while (value != 0) {
       temporary[temporary_length++] = static_cast<char>('0' + (value % 10));
@@ -101,14 +101,14 @@ auto write_frame(int file_descriptor, int frame_index, void *address) -> void {
   write_text(file_descriptor, "\n");
 }
 
-struct frame_buffer {
-  std::array<void *, maximum_frames> frames{};
+struct FrameBuffer {
+  std::array<void *, MAXIMUM_FRAMES> frames{};
   int count{0};
 };
 
 auto collect_frame(_Unwind_Context *context, void *argument)
     -> _Unwind_Reason_Code {
-  auto *buffer{static_cast<frame_buffer *>(argument)};
+  auto *buffer{static_cast<FrameBuffer *>(argument)};
   const auto program_counter{_Unwind_GetIP(context)};
   if (program_counter == 0) {
     return _URC_END_OF_STACK;
@@ -118,7 +118,7 @@ auto collect_frame(_Unwind_Context *context, void *argument)
   // NOLINTNEXTLINE(performance-no-int-to-ptr)
   buffer->frames[index] = reinterpret_cast<void *>(program_counter);
   buffer->count = buffer->count + 1;
-  return buffer->count == maximum_frames ? _URC_NORMAL_STOP : _URC_NO_REASON;
+  return buffer->count == MAXIMUM_FRAMES ? _URC_NORMAL_STOP : _URC_NO_REASON;
 }
 
 // We walk the stack through the unwinder that the C++ exception machinery
@@ -129,7 +129,7 @@ __attribute__((noinline)) auto write_backtrace(int file_descriptor,
                                                int frames_to_skip,
                                                void *crash_pc = nullptr)
     -> void {
-  frame_buffer buffer{};
+  FrameBuffer buffer{};
   _Unwind_Backtrace(&collect_frame, &buffer);
 
   int frame_index{0};
@@ -180,7 +180,7 @@ auto extract_crash_pc(void *context) -> void * {
   return reinterpret_cast<void *>(program_counter);
 }
 
-constexpr const char *separator{"========================================"
+constexpr const char *SEPARATOR{"========================================"
                                 "========================================\n"};
 
 std::atomic<bool> crash_handler_installed{false};
@@ -188,8 +188,8 @@ std::atomic<bool> crash_handler_installed{false};
 // A stack-overflow fault arrives on an already-exhausted stack, so the handler
 // must run on a separate region to be able to produce a trace. This is sized
 // generously to leave room for the backtrace machinery
-constexpr std::size_t alternate_stack_size{1 << 16};
-alignas(16) std::array<unsigned char, alternate_stack_size> alternate_stack{};
+constexpr std::size_t ALTERNATE_STACK_SIZE{1 << 16};
+alignas(16) std::array<unsigned char, ALTERNATE_STACK_SIZE> alternate_stack{};
 
 } // namespace
 
@@ -205,11 +205,11 @@ alignas(16) std::array<unsigned char, alternate_stack_size> alternate_stack{};
 // NOLINTNEXTLINE(misc-definitions-in-headers)
 extern "C" __attribute__((visibility("default"))) auto
 sourcemeta_core_stacktrace_crash_handler(int signal_number,
-                                         siginfo_t * /*info*/, void *context)
-    -> void {
+                                         [[maybe_unused]] siginfo_t *info,
+                                         void *context) -> void {
   const int file_descriptor{STDERR_FILENO};
   write_text(file_descriptor, "\n");
-  write_text(file_descriptor, separator);
+  write_text(file_descriptor, SEPARATOR);
   write_text(file_descriptor, "signal:  ");
   write_decimal(file_descriptor, static_cast<unsigned long>(signal_number));
   write_text(file_descriptor, " (");
@@ -240,7 +240,7 @@ sourcemeta_core_stacktrace_crash_handler(int signal_number,
   write_text(file_descriptor, "\n\n");
   write_backtrace(file_descriptor, /*frames_to_skip=*/1,
                   extract_crash_pc(context));
-  write_text(file_descriptor, separator);
+  write_text(file_descriptor, SEPARATOR);
 
   struct sigaction default_action{};
   default_action.sa_handler = SIG_DFL;
@@ -281,12 +281,12 @@ __attribute__((visibility("default"))) auto stacktrace_on_crash() -> void {
 // NOLINTNEXTLINE(misc-definitions-in-headers)
 __attribute__((noinline, visibility("default"))) auto stacktrace() -> void {
   const int file_descriptor{STDERR_FILENO};
-  write_text(file_descriptor, separator);
+  write_text(file_descriptor, SEPARATOR);
   write_text(file_descriptor, "pid:     ");
   write_decimal(file_descriptor, static_cast<unsigned long>(::getpid()));
   write_text(file_descriptor, "\n\n");
   write_backtrace(file_descriptor, /*frames_to_skip=*/1);
-  write_text(file_descriptor, separator);
+  write_text(file_descriptor, SEPARATOR);
 }
 
 } // namespace sourcemeta::core

--- a/src/lang/test/clitest/clitest.h
+++ b/src/lang/test/clitest/clitest.h
@@ -164,7 +164,10 @@ inline auto clitest_variable_at(const std::string_view token,
   }
 
   if (token[after] == '$') {
-    return CLITestVariable{CLITestVariable::Type::Escape, index, 2, {}};
+    return CLITestVariable{.type = CLITestVariable::Type::Escape,
+                           .start = index,
+                           .length = 2,
+                           .name = {}};
   }
 
   if (!clitest_is_name_start(token[after])) {
@@ -176,8 +179,10 @@ inline auto clitest_variable_at(const std::string_view token,
     cursor += 1;
   }
 
-  return CLITestVariable{CLITestVariable::Type::Reference, index,
-                         cursor - index, token.substr(after, cursor - after)};
+  return CLITestVariable{.type = CLITestVariable::Type::Reference,
+                         .start = index,
+                         .length = cursor - index,
+                         .name = token.substr(after, cursor - after)};
 }
 
 // The first variable form at or after the given index, if any
@@ -277,7 +282,7 @@ inline auto clitest_substitute(const std::string_view token,
     } else {
       const auto binding{bindings.find(variable->name)};
       if (binding == bindings.cend()) {
-        return {std::move(value), variable->name};
+        return {.value = std::move(value), .missing = variable->name};
       }
 
       value.append(binding->second);
@@ -286,7 +291,7 @@ inline auto clitest_substitute(const std::string_view token,
     index = variable->start + variable->length;
   }
 
-  return {std::move(value), {}};
+  return {.value = std::move(value), .missing = {}};
 }
 
 // The index just past the character class opening at the given index. A closing
@@ -557,7 +562,8 @@ inline auto clitest_target_of(const std::string_view token,
   std::string_view rest{token};
   if (rest == "$CWD") {
     return ".";
-  } else if (rest.starts_with("$CWD/")) {
+  }
+  if (rest.starts_with("$CWD/")) {
     rest.remove_prefix(5);
   }
 
@@ -589,8 +595,9 @@ inline auto clitest_is_pattern_operand(const CLITestStatement &statement,
   if (statement.keyword == "REPLACE" && statement.operands.size() == 6 &&
       statement.operands.front() == "MATCHING") {
     return index == 1;
-  } else if (statement.keyword == "DROP" && statement.operands.size() == 5 &&
-             statement.operands[1] == "MATCHING") {
+  }
+  if (statement.keyword == "DROP" && statement.operands.size() == 5 &&
+      statement.operands[1] == "MATCHING") {
     return index == 2;
   }
 
@@ -611,7 +618,8 @@ inline auto clitest_asserted(
 
     if (compared.contains(current)) {
       return true;
-    } else if (seen.contains(current)) {
+    }
+    if (seen.contains(current)) {
       continue;
     }
 
@@ -655,9 +663,10 @@ inline auto clitest_check(const std::vector<CLITestStatement> &statements,
         const auto reference{clitest_pattern_variable(operands[index])};
         if (reference.has_value()) {
           problems.push_back(
-              {statement.line,
-               "a pattern cannot expand this name, so use the literal form",
-               std::string{reference->name}});
+              {.line = statement.line,
+               .message =
+                   "a pattern cannot expand this name, so use the literal form",
+               .context = std::string{reference->name}});
         }
 
         continue;
@@ -686,9 +695,11 @@ inline auto clitest_check(const std::vector<CLITestStatement> &statements,
           clitest_target_of(operands[operands.size() - 3], bindings)};
       if (destination.has_value()) {
         observations.push_back(
-            {destination.value(), statement.line,
-             "nothing compares this file, so the run asserts only its "
-             "exit code"});
+            {.target = destination.value(),
+             .line = statement.line,
+             .message =
+                 "nothing compares this file, so the run asserts only its "
+                 "exit code"});
       }
 
       for (std::size_t index{0}; index + 8 < operands.size(); index += 1) {
@@ -714,49 +725,59 @@ inline auto clitest_check(const std::vector<CLITestStatement> &statements,
       }
 
       if (destination.has_value()) {
-        artifacts.push_back({destination.value(), statement.line,
-                             "nothing reads the file this copy produced"});
+        artifacts.push_back(
+            {.target = destination.value(),
+             .line = statement.line,
+             .message = "nothing reads the file this copy produced"});
       }
 
       clitest_collect(consumed, operands[0], bindings);
     } else if (statement.keyword == "TREE" && operands.size() == 3) {
       const auto destination{clitest_target_of(operands[2], bindings)};
       if (destination.has_value()) {
-        artifacts.push_back({destination.value(), statement.line,
-                             "nothing reads the listing this produced"});
+        artifacts.push_back(
+            {.target = destination.value(),
+             .line = statement.line,
+             .message = "nothing reads the listing this produced"});
       }
 
       clitest_collect(consumed, operands[0], bindings);
     } else if (statement.keyword == "COMPRESS" && operands.size() == 4) {
       const auto destination{clitest_target_of(operands[3], bindings)};
       if (destination.has_value()) {
-        artifacts.push_back({destination.value(), statement.line,
-                             "nothing reads the archive this produced"});
+        artifacts.push_back(
+            {.target = destination.value(),
+             .line = statement.line,
+             .message = "nothing reads the archive this produced"});
       }
 
       clitest_collect(consumed, operands[1], bindings);
     } else if (statement.keyword == "CHECKSUM" && operands.size() == 4) {
-      definitions.push_back({operands[3], position, statement.line});
+      definitions.push_back(
+          {.name = operands[3], .position = position, .line = statement.line});
       clitest_collect(consumed, operands[1], bindings);
     } else if (statement.keyword == "EXTRACT" && operands.size() == 5) {
       const auto destination{clitest_target_of(operands[4], bindings)};
       if (destination.has_value()) {
-        artifacts.push_back({destination.value(), statement.line,
-                             "nothing reads what this extracted"});
+        artifacts.push_back({.target = destination.value(),
+                             .line = statement.line,
+                             .message = "nothing reads what this extracted"});
       }
 
       clitest_collect(consumed, operands[2], bindings);
     } else if (statement.keyword == "STAT" && operands.size() == 4) {
       const auto destination{clitest_target_of(operands[3], bindings)};
       if (destination.has_value()) {
-        artifacts.push_back({destination.value(), statement.line,
-                             "nothing reads the timestamp this produced"});
+        artifacts.push_back(
+            {.target = destination.value(),
+             .line = statement.line,
+             .message = "nothing reads the timestamp this produced"});
       }
 
       clitest_collect(consumed, operands[1], bindings);
     } else if (statement.keyword == "ENV" && operands.size() == 2) {
       // Tracked so that a path spelled through a variable still resolves
-      if (operands[1].find('$') == std::string::npos) {
+      if (!operands[1].contains('$')) {
         bindings.insert_or_assign(operands[0], operands[1]);
       }
     }
@@ -769,15 +790,18 @@ inline auto clitest_check(const std::vector<CLITestStatement> &statements,
     // assertion
     if (!clitest_asserted(observation.target, compared, copies) &&
         !consumed.contains(observation.target)) {
-      problems.push_back(
-          {observation.line, observation.message, observation.target});
+      problems.push_back({.line = observation.line,
+                          .message = observation.message,
+                          .context = observation.target});
     }
   }
 
   for (const auto &artifact : artifacts) {
     if (!consumed.contains(artifact.target) &&
         !compared.contains(artifact.target)) {
-      problems.push_back({artifact.line, artifact.message, artifact.target});
+      problems.push_back({.line = artifact.line,
+                          .message = artifact.message,
+                          .context = artifact.target});
     }
   }
 
@@ -804,9 +828,9 @@ inline auto clitest_check(const std::vector<CLITestStatement> &statements,
     }
 
     if (!justified) {
-      problems.push_back({definitions[index].line,
-                          "nothing expands this variable",
-                          definitions[index].name});
+      problems.push_back({.line = definitions[index].line,
+                          .message = "nothing expands this variable",
+                          .context = definitions[index].name});
     }
   }
 
@@ -840,7 +864,7 @@ inline auto clitest_environment(const std::filesystem::path &sandbox,
       "CORES", std::to_string(std::max(static_cast<std::size_t>(
                                            std::thread::hardware_concurrency()),
                                        static_cast<std::size_t>(1))));
-  return {sandbox, std::move(bindings)};
+  return {.sandbox = sandbox, .bindings = std::move(bindings)};
 }
 
 inline auto clitest_expand(const CLITestEnvironment &environment,
@@ -889,7 +913,7 @@ inline auto clitest_lines(const std::string_view content) -> CLITestLines {
     values.pop_back();
   }
 
-  return {std::move(values), terminated};
+  return {.values = std::move(values), .terminated = terminated};
 }
 
 inline auto clitest_join(const std::vector<std::string_view> &lines,
@@ -1210,9 +1234,10 @@ inline auto clitest_command_drop(const CLITestCommand &command) -> void {
 
   if (command.at(1) == "CONTAINING") {
     const auto text{command.expand(2)};
-    std::erase_if(lines.values, [&text](const std::string_view candidate) {
-      return candidate.find(text) != std::string_view::npos;
-    });
+    std::erase_if(lines.values,
+                  [&text](const std::string_view candidate) -> bool {
+                    return candidate.contains(text);
+                  });
   } else {
     const auto regex{sourcemeta::core::to_regex(command.at(2))};
     if (!regex.has_value()) {
@@ -1221,9 +1246,10 @@ inline auto clitest_command_drop(const CLITestCommand &command) -> void {
 
     // The terminator is kept out of the subject, so that an anchor in a pattern
     // means the end of the line an author was looking at
-    std::erase_if(lines.values, [&regex](const std::string_view candidate) {
-      return sourcemeta::core::matches(regex.value(), candidate);
-    });
+    std::erase_if(lines.values,
+                  [&regex](const std::string_view candidate) -> bool {
+                    return sourcemeta::core::matches(regex.value(), candidate);
+                  });
   }
 
   command.write(4, clitest_join(lines.values, lines.terminated));
@@ -1255,7 +1281,7 @@ inline auto clitest_command_sort(const CLITestCommand &command) -> void {
 
   const auto content{command.read(0)};
   auto lines{clitest_lines(content)};
-  std::sort(lines.values.begin(), lines.values.end());
+  std::ranges::sort(lines.values);
   // A filter that rewrites a file in place changes its order, not its shape, so
   // a file that ended without a terminator still does
   command.write(0, clitest_join(lines.values, lines.terminated));
@@ -1302,7 +1328,7 @@ inline auto clitest_command_tree(const CLITestCommand &command) -> void {
   }
 
   // Ordered by code point, which for this encoding is the order of the bytes
-  std::sort(entries.begin(), entries.end());
+  std::ranges::sort(entries);
 
   std::string result;
   for (const auto &entry : entries) {
@@ -1383,7 +1409,8 @@ inline auto clitest_interpret(const std::vector<CLITestStatement> &statements,
                               const std::string &binary,
                               CLITestEnvironment &environment) -> void {
   for (const auto &statement : statements) {
-    const CLITestCommand command{statement, environment, binary};
+    const CLITestCommand command{
+        .statement = statement, .environment = environment, .binary = binary};
     const auto &keyword{statement.keyword};
 
     if (keyword == "WRITE") {

--- a/src/lang/test/clitest/main.cc
+++ b/src/lang/test/clitest/main.cc
@@ -23,7 +23,7 @@ static auto describe(const std::string_view script, const std::size_t line,
   if (!context.empty()) {
     // A difference or a listing spans lines of its own, and reads better under
     // the message than trailing off the end of it
-    stream << (context.find('\n') == std::string_view::npos ? ": " : ":\n")
+    stream << (!context.contains('\n') ? ": " : ":\n")
            << (context.ends_with('\n') ? context.substr(0, context.size() - 1)
                                        : context);
   }
@@ -178,7 +178,8 @@ auto main(int argc, char *argv[]) -> int {
       std::cout << "TAP version 14\n"
                    "Bail out! a binding needs a name before its value\n";
       return EXIT_FAILURE;
-    } else if (separator == std::string_view::npos) {
+    }
+    if (separator == std::string_view::npos) {
       bindings.insert_or_assign(std::string{entry}, "");
     } else {
       bindings.insert_or_assign(std::string{entry.substr(0, separator)},

--- a/src/lang/test/include/sourcemeta/core/test.h
+++ b/src/lang/test/include/sourcemeta/core/test.h
@@ -217,7 +217,7 @@ inline auto test_c_string_label(const char *const value) -> std::string_view {
 // lives for the duration of a single comparison call, so the usual hazards of
 // reference members do not apply here.
 /// A pair of operands captured by reference for one comparison.
-template <typename Left, typename Right> struct test_operands {
+template <typename Left, typename Right> struct TestOperands {
   // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
   /// The left-hand operand.
   const Left &left;
@@ -233,7 +233,7 @@ template <typename Left, typename Right> struct test_operands {
 template <typename Left, typename Right, typename Comparator>
 auto test_expect_comparison(std::string_view file, int line,
                             std::string_view expression,
-                            const test_operands<Left, Right> &operands,
+                            const TestOperands<Left, Right> &operands,
                             Comparator comparator) -> void {
   if (!comparator(operands.left, operands.right)) {
     test_report_failure(
@@ -281,7 +281,7 @@ auto test_expect_comparison(std::string_view file, int line,
 #define SOURCEMETA_CORE_TEST_COMPARE(actual, expected, comparator, operation)  \
   ::sourcemeta::core::test_expect_comparison(                                  \
       __FILE__, __LINE__, #actual " " operation " " #expected,                 \
-      ::sourcemeta::core::test_operands{(actual), (expected)},                 \
+      ::sourcemeta::core::TestOperands{(actual), (expected)},                  \
       [](const auto &sourcemeta_test_left,                                     \
          const auto &sourcemeta_test_right) {                                  \
         return ::sourcemeta::core::comparator(sourcemeta_test_left,            \

--- a/src/lang/test/test.cc
+++ b/src/lang/test/test.cc
@@ -48,7 +48,7 @@ auto print_usage(std::string_view program) -> void {
 }
 
 auto has_line_terminator(const std::string_view value) -> bool {
-  return value.find('\n') != std::string_view::npos;
+  return value.contains('\n');
 }
 
 auto print_diagnostic(std::string_view message) -> void {
@@ -88,9 +88,9 @@ auto test_register(std::string_view name, std::function<void()> body,
 
 auto test_suite_from_path(std::string_view path) -> std::string {
   std::string stem{std::filesystem::path{path}.stem().string()};
-  static constexpr std::string_view suffix{"_test"};
-  if (stem.size() > suffix.size() && stem.ends_with(suffix)) {
-    stem.erase(stem.size() - suffix.size());
+  static constexpr std::string_view SUFFIX{"_test"};
+  if (stem.size() > SUFFIX.size() && stem.ends_with(SUFFIX)) {
+    stem.erase(stem.size() - SUFFIX.size());
   }
 
   return stem;

--- a/src/lang/text/include/sourcemeta/core/text.h
+++ b/src/lang/text/include/sourcemeta/core/text.h
@@ -67,8 +67,7 @@ template <typename Character>
            std::same_as<Character, signed char> ||
            std::same_as<Character, unsigned char> ||
            std::same_as<Character, wchar_t>
-inline constexpr auto to_lowercase(const Character character) noexcept
-    -> Character {
+constexpr auto to_lowercase(const Character character) noexcept -> Character {
   return (character >= 'A' && character <= 'Z')
              ? static_cast<Character>(character + ('a' - 'A'))
              : character;
@@ -131,7 +130,7 @@ template <typename Character>
            std::same_as<Character, signed char> ||
            std::same_as<Character, unsigned char> ||
            std::same_as<Character, wchar_t>
-inline constexpr auto is_lowercase(const Character character) noexcept -> bool {
+constexpr auto is_lowercase(const Character character) noexcept -> bool {
   return character < 'A' || character > 'Z';
 }
 
@@ -194,7 +193,7 @@ template <typename Character>
            std::same_as<Character, signed char> ||
            std::same_as<Character, unsigned char> ||
            std::same_as<Character, wchar_t>
-inline constexpr auto is_alpha(const Character character) noexcept -> bool {
+constexpr auto is_alpha(const Character character) noexcept -> bool {
   return (character >= 'a' && character <= 'z') ||
          (character >= 'A' && character <= 'Z');
 }
@@ -212,7 +211,7 @@ inline constexpr auto is_alpha(const Character character) noexcept -> bool {
 /// assert(!sourcemeta::core::is_alpha("ab1"));
 /// assert(!sourcemeta::core::is_alpha(""));
 /// ```
-inline constexpr auto is_alpha(const std::string_view value) noexcept -> bool {
+constexpr auto is_alpha(const std::string_view value) noexcept -> bool {
   if (value.empty()) {
     return false;
   }
@@ -240,7 +239,7 @@ template <typename Character>
            std::same_as<Character, signed char> ||
            std::same_as<Character, unsigned char> ||
            std::same_as<Character, wchar_t>
-inline constexpr auto is_digit(const Character character) noexcept -> bool {
+constexpr auto is_digit(const Character character) noexcept -> bool {
   return character >= '0' && character <= '9';
 }
 
@@ -257,7 +256,7 @@ inline constexpr auto is_digit(const Character character) noexcept -> bool {
 /// assert(!sourcemeta::core::is_digit("12a"));
 /// assert(!sourcemeta::core::is_digit(""));
 /// ```
-inline constexpr auto is_digit(const std::string_view value) noexcept -> bool {
+constexpr auto is_digit(const std::string_view value) noexcept -> bool {
   if (value.empty()) {
     return false;
   }
@@ -286,7 +285,7 @@ template <typename Character>
            std::same_as<Character, signed char> ||
            std::same_as<Character, unsigned char> ||
            std::same_as<Character, wchar_t>
-inline constexpr auto is_alphanum(const Character character) noexcept -> bool {
+constexpr auto is_alphanum(const Character character) noexcept -> bool {
   return is_alpha(character) || is_digit(character);
 }
 
@@ -303,8 +302,7 @@ inline constexpr auto is_alphanum(const Character character) noexcept -> bool {
 /// assert(!sourcemeta::core::is_alphanum("abc-123"));
 /// assert(!sourcemeta::core::is_alphanum(""));
 /// ```
-inline constexpr auto is_alphanum(const std::string_view value) noexcept
-    -> bool {
+constexpr auto is_alphanum(const std::string_view value) noexcept -> bool {
   if (value.empty()) {
     return false;
   }
@@ -412,8 +410,8 @@ auto strip_right(const std::string_view input, const char character) noexcept
 /// assert(sourcemeta::core::unquote("abc", '"') == "abc");
 /// assert(sourcemeta::core::unquote("\"", '"') == "\"");
 /// ```
-inline constexpr auto unquote(const std::string_view input,
-                              const char quote) noexcept -> std::string_view {
+constexpr auto unquote(const std::string_view input, const char quote) noexcept
+    -> std::string_view {
   if (input.size() < 2 || input.front() != quote || input.back() != quote) {
     return input;
   }
@@ -644,7 +642,7 @@ concept text_spellable_integer =
 /// represents without loss, and a signed type needs one more again for a sign.
 template <typename Integer>
   requires text_spellable_integer<Integer>
-inline constexpr std::size_t digits_capacity{
+inline constexpr std::size_t DIGITS_CAPACITY{
     static_cast<std::size_t>(std::numeric_limits<Integer>::digits10) + 1 +
     (std::numeric_limits<Integer>::is_signed ? 1U : 0U)};
 
@@ -653,8 +651,8 @@ inline constexpr std::size_t digits_capacity{
 /// A buffer wide enough for the decimal spelling of any integer of up to 64
 /// bits, including a leading sign. That bound is twenty characters, reached by
 /// both the largest unsigned value and the smallest signed one.
-using DigitsBuffer = std::array<char, std::max(digits_capacity<std::uint64_t>,
-                                               digits_capacity<std::int64_t>)>;
+using DigitsBuffer = std::array<char, std::max(DIGITS_CAPACITY<std::uint64_t>,
+                                               DIGITS_CAPACITY<std::int64_t>)>;
 
 /// @ingroup text
 ///
@@ -680,7 +678,7 @@ using DigitsBuffer = std::array<char, std::max(digits_capacity<std::uint64_t>,
 /// to fail, which is why it reports no error.
 template <typename Integer, std::size_t Capacity>
   requires text_spellable_integer<Integer> &&
-           (Capacity >= digits_capacity<Integer>)
+           (Capacity >= DIGITS_CAPACITY<Integer>)
 inline auto digits_view(const Integer value,
                         std::array<char, Capacity> &buffer) noexcept
     -> std::string_view {
@@ -706,7 +704,7 @@ inline auto digits_view(const Integer value,
 template <typename Output, typename Integer>
   requires text_spellable_integer<Integer>
 inline auto digits_append(Output &output, const Integer value) -> void {
-  std::array<char, digits_capacity<Integer>> buffer;
+  std::array<char, DIGITS_CAPACITY<Integer>> buffer;
   const auto digits{digits_view(value, buffer)};
   output.append(digits.data(), digits.size());
 }
@@ -731,7 +729,7 @@ template <typename CharT, typename Traits, typename Integer>
   requires text_spellable_integer<Integer>
 inline auto digits_write(std::basic_ostream<CharT, Traits> &stream,
                          const Integer value) -> void {
-  std::array<char, digits_capacity<Integer>> buffer;
+  std::array<char, DIGITS_CAPACITY<Integer>> buffer;
   const auto digits{digits_view(value, buffer)};
   stream.write(digits.data(), static_cast<std::streamsize>(digits.size()));
 }
@@ -752,7 +750,7 @@ inline auto digits_write(std::basic_ostream<CharT, Traits> &stream,
 inline auto hex_digit_value(const char character) noexcept -> std::int8_t {
   // Indexed by byte value: ASCII '0'-'9', 'A'-'F', and 'a'-'f' map to their
   // hexadecimal value, everything else to -1
-  static constexpr std::array<std::int8_t, 256> table{
+  static constexpr std::array<std::int8_t, 256> TABLE{
       {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0,  1,  2,  3,  4,  5,
@@ -768,7 +766,7 @@ inline auto hex_digit_value(const char character) noexcept -> std::int8_t {
        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
        -1, -1, -1, -1}};
-  return table[static_cast<unsigned char>(character)];
+  return TABLE[static_cast<unsigned char>(character)];
 }
 
 /// @ingroup text

--- a/src/lang/text/text.cc
+++ b/src/lang/text/text.cc
@@ -232,7 +232,7 @@ auto hex_to_bytes(const std::string_view input, const bool allow_odd_length)
   }
 
   std::string result;
-  result.reserve(input.size() / 2 + 1);
+  result.reserve((input.size() / 2) + 1);
 
   std::size_t index{0};
   if (odd_length) {
@@ -259,13 +259,13 @@ auto hex_to_bytes(const std::string_view input, const bool allow_odd_length)
 }
 
 auto bytes_to_hex(const std::string_view input) -> std::string {
-  static constexpr std::string_view digits{"0123456789abcdef"};
+  static constexpr std::string_view DIGITS{"0123456789abcdef"};
   std::string result;
   result.reserve(input.size() * 2);
   for (const auto character : input) {
     const auto byte{static_cast<unsigned char>(character)};
-    result.push_back(digits[byte >> 4u]);
-    result.push_back(digits[byte & 0x0fu]);
+    result.push_back(DIGITS[byte >> 4U]);
+    result.push_back(DIGITS[byte & 0x0fU]);
   }
 
   return result;

--- a/test/crypto/pyca_cryptography_test.cc
+++ b/test/crypto/pyca_cryptography_test.cc
@@ -35,13 +35,14 @@ auto to_signature_hash_function(const std::string_view name)
     -> std::optional<sourcemeta::core::SignatureHashFunction> {
   if (name == "SHA256" || name == "SHA-256") {
     return sourcemeta::core::SignatureHashFunction::SHA256;
-  } else if (name == "SHA384" || name == "SHA-384") {
-    return sourcemeta::core::SignatureHashFunction::SHA384;
-  } else if (name == "SHA512" || name == "SHA-512") {
-    return sourcemeta::core::SignatureHashFunction::SHA512;
-  } else {
-    return std::nullopt;
   }
+  if (name == "SHA384" || name == "SHA-384") {
+    return sourcemeta::core::SignatureHashFunction::SHA384;
+  }
+  if (name == "SHA512" || name == "SHA-512") {
+    return sourcemeta::core::SignatureHashFunction::SHA512;
+  }
+  return std::nullopt;
 }
 
 struct CurveParameters {
@@ -52,13 +53,14 @@ struct CurveParameters {
 auto to_curve(const std::string_view name) -> std::optional<CurveParameters> {
   if (name == "P-256") {
     return CurveParameters{sourcemeta::core::EllipticCurve::P256, 32};
-  } else if (name == "P-384") {
-    return CurveParameters{sourcemeta::core::EllipticCurve::P384, 48};
-  } else if (name == "P-521") {
-    return CurveParameters{sourcemeta::core::EllipticCurve::P521, 66};
-  } else {
-    return std::nullopt;
   }
+  if (name == "P-384") {
+    return CurveParameters{sourcemeta::core::EllipticCurve::P384, 48};
+  }
+  if (name == "P-521") {
+    return CurveParameters{sourcemeta::core::EllipticCurve::P521, 66};
+  }
+  return std::nullopt;
 }
 
 // The hash functions are overloaded, so the registrars name the digest variant

--- a/test/crypto/wycheproof_test.cc
+++ b/test/crypto/wycheproof_test.cc
@@ -20,13 +20,14 @@ auto to_signature_hash_function(const std::string_view name)
     -> std::optional<sourcemeta::core::SignatureHashFunction> {
   if (name == "SHA-256") {
     return sourcemeta::core::SignatureHashFunction::SHA256;
-  } else if (name == "SHA-384") {
-    return sourcemeta::core::SignatureHashFunction::SHA384;
-  } else if (name == "SHA-512") {
-    return sourcemeta::core::SignatureHashFunction::SHA512;
-  } else {
-    return std::nullopt;
   }
+  if (name == "SHA-384") {
+    return sourcemeta::core::SignatureHashFunction::SHA384;
+  }
+  if (name == "SHA-512") {
+    return sourcemeta::core::SignatureHashFunction::SHA512;
+  }
+  return std::nullopt;
 }
 
 struct CurveParameters {
@@ -37,13 +38,14 @@ struct CurveParameters {
 auto to_curve(const std::string_view name) -> std::optional<CurveParameters> {
   if (name == "secp256r1") {
     return CurveParameters{sourcemeta::core::EllipticCurve::P256, 32};
-  } else if (name == "secp384r1") {
-    return CurveParameters{sourcemeta::core::EllipticCurve::P384, 48};
-  } else if (name == "secp521r1") {
-    return CurveParameters{sourcemeta::core::EllipticCurve::P521, 66};
-  } else {
-    return std::nullopt;
   }
+  if (name == "secp384r1") {
+    return CurveParameters{sourcemeta::core::EllipticCurve::P384, 48};
+  }
+  if (name == "secp521r1") {
+    return CurveParameters{sourcemeta::core::EllipticCurve::P521, 66};
+  }
+  return std::nullopt;
 }
 
 // Each vector reduces to a closure that asserts on data captured at
@@ -644,11 +646,11 @@ auto to_oaep_hash(const std::string_view name)
     -> std::optional<sourcemeta::core::RSAOAEPHash> {
   if (name == "SHA-1") {
     return sourcemeta::core::RSAOAEPHash::SHA1;
-  } else if (name == "SHA-256") {
-    return sourcemeta::core::RSAOAEPHash::SHA256;
-  } else {
-    return std::nullopt;
   }
+  if (name == "SHA-256") {
+    return sourcemeta::core::RSAOAEPHash::SHA256;
+  }
+  return std::nullopt;
 }
 
 // A valid vector must decrypt to exactly the plaintext. An invalid vector must
@@ -738,7 +740,8 @@ auto to_ecdh_curve(const std::string_view name) -> std::optional<EcdhCurve> {
         "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
         "0468ae7706221e5990f7484d34fbec5a99050179a6c11817bbed4aed962998ff",
         "b5228d89a1b448f12332376c8c7f080763532a055e07f14a5de0dc30104579e1"};
-  } else if (name == "secp384r1") {
+  }
+  if (name == "secp384r1") {
     return EcdhCurve{sourcemeta::core::EllipticCurve::P384, 48,
                      "00c1781d86cac2c052b7e4f48cef415c5c133052f4e504397e75e4d7"
                      "cd0ca149da0b4988b8a6ded5ceae4b580691376187",
@@ -746,7 +749,8 @@ auto to_ecdh_curve(const std::string_view name) -> std::optional<EcdhCurve> {
                      "71e6f03e2926cd60e9a9ccd42e1aa8799d2ef3a7",
                      "9d045f3a3df974743268be650fbaf68c7045a483093ce2e289903097"
                      "396f040058faacb723eb493b5b631bc365c5fc49"};
-  } else if (name == "secp521r1") {
+  }
+  if (name == "secp521r1") {
     return EcdhCurve{
         sourcemeta::core::EllipticCurve::P521, 66,
         "01781d86cac2c052b7e4f48cef415c5c1319e07db70db92a497c2ac764e9509ac0b073"
@@ -755,9 +759,8 @@ auto to_ecdh_curve(const std::string_view name) -> std::optional<EcdhCurve> {
         "376f7d5151db140b3cdae698bca9683f3d041164fe0e3dba0d2f02d6643adb",
         "010a3f1fcb6dbccc773d143d454347145a9bec498e7a5e2d412095b9350c58d8e9411e"
         "a85afe4c56053ad35d8be4230f5e2718365f43dbd2ed44b096a90bfc6227b6"};
-  } else {
-    return std::nullopt;
   }
+  return std::nullopt;
 }
 
 // A valid vector must derive exactly the given shared secret. An invalid vector
@@ -872,40 +875,40 @@ auto main(int argc, char **argv) -> int {
   const std::filesystem::path base{WYCHEPROOF_PATH};
   const auto vectors{base / "testvectors_v1"};
 
-  constexpr std::array<std::string_view, 9> rsa_pkcs1{
+  constexpr std::array<std::string_view, 9> RSA_PKCS1{
       {"rsa_signature_2048_sha256_test", "rsa_signature_2048_sha384_test",
        "rsa_signature_2048_sha512_test", "rsa_signature_3072_sha256_test",
        "rsa_signature_3072_sha384_test", "rsa_signature_3072_sha512_test",
        "rsa_signature_4096_sha256_test", "rsa_signature_4096_sha384_test",
        "rsa_signature_4096_sha512_test"}};
-  for (const auto name : rsa_pkcs1) {
+  for (const auto name : RSA_PKCS1) {
     register_rsa_tests(vectors / (std::string{name} + ".json"),
                        "Wycheproof_RSA_PKCS1", verify_pkcs1);
   }
 
-  constexpr std::array<std::string_view, 6> rsa_pss{
+  constexpr std::array<std::string_view, 6> RSA_PSS{
       {"rsa_pss_2048_sha256_mgf1_32_test", "rsa_pss_2048_sha384_mgf1_48_test",
        "rsa_pss_3072_sha256_mgf1_32_test", "rsa_pss_4096_sha256_mgf1_32_test",
        "rsa_pss_4096_sha384_mgf1_48_test", "rsa_pss_4096_sha512_mgf1_64_test"}};
-  for (const auto name : rsa_pss) {
+  for (const auto name : RSA_PSS) {
     register_rsa_tests(vectors / (std::string{name} + ".json"),
                        "Wycheproof_RSA_PSS", verify_pss);
   }
 
-  constexpr std::array<std::string_view, 5> rsa_pkcs1_sign{
+  constexpr std::array<std::string_view, 5> RSA_PKCS1_SIGN{
       {"rsa_pkcs1_1024_sig_gen_test", "rsa_pkcs1_1536_sig_gen_test",
        "rsa_pkcs1_2048_sig_gen_test", "rsa_pkcs1_3072_sig_gen_test",
        "rsa_pkcs1_4096_sig_gen_test"}};
-  for (const auto name : rsa_pkcs1_sign) {
+  for (const auto name : RSA_PKCS1_SIGN) {
     register_rsa_sign_tests(vectors / (std::string{name} + ".json"),
                             "Wycheproof_RSA_PKCS1_Sign");
   }
 
-  constexpr std::array<std::string_view, 5> ecdsa{
+  constexpr std::array<std::string_view, 5> ECDSA{
       {"ecdsa_secp256r1_sha256_p1363_test", "ecdsa_secp256r1_sha512_p1363_test",
        "ecdsa_secp384r1_sha384_p1363_test", "ecdsa_secp384r1_sha512_p1363_test",
        "ecdsa_secp521r1_sha512_p1363_test"}};
-  for (const auto name : ecdsa) {
+  for (const auto name : ECDSA) {
     register_ecdsa_tests(vectors / (std::string{name} + ".json"),
                          "Wycheproof_ECDSA");
   }

--- a/test/gzip/gzip_streambuf_test.cc
+++ b/test/gzip/gzip_streambuf_test.cc
@@ -244,8 +244,8 @@ TEST(incompressible_random_bytes) {
   std::uniform_int_distribution<int> distribution{0, 255};
   std::string input;
   input.resize(65536);
-  for (std::size_t index = 0; index < input.size(); ++index) {
-    input[index] = static_cast<char>(distribution(generator));
+  for (char &index : input) {
+    index = static_cast<char>(distribution(generator));
   }
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};

--- a/test/http/http_status_test.cc
+++ b/test/http/http_status_test.cc
@@ -102,8 +102,8 @@ TEST(inequality_different_codes) {
 }
 
 TEST(equality_copy) {
-  constexpr auto copy{sourcemeta::core::HTTP_STATUS_OK};
-  EXPECT_EQ(copy, sourcemeta::core::HTTP_STATUS_OK);
+  constexpr auto COPY{sourcemeta::core::HTTP_STATUS_OK};
+  EXPECT_EQ(COPY, sourcemeta::core::HTTP_STATUS_OK);
 }
 
 TEST(webdav_multi_status) {

--- a/test/io/io_atomic_write_file_test.cc
+++ b/test/io/io_atomic_write_file_test.cc
@@ -15,45 +15,45 @@
 class IOAtomicWriteFileTest {
 protected:
   IOAtomicWriteFileTest() {
-    std::filesystem::create_directories(this->workspace);
+    std::filesystem::create_directories(this->workspace_);
   }
 
   ~IOAtomicWriteFileTest() {
     std::error_code error;
-    std::filesystem::remove_all(this->workspace, error);
+    std::filesystem::remove_all(this->workspace_, error);
   }
 
   // The tests are always sequential, so using the same path is safe
-  std::filesystem::path workspace{std::filesystem::path{BUILD_DIRECTORY} /
-                                  "sourcemeta_core_io_atomic_write_test"};
+  std::filesystem::path workspace_{std::filesystem::path{BUILD_DIRECTORY} /
+                                   "sourcemeta_core_io_atomic_write_test"};
 };
 
 TEST_F(IOAtomicWriteFileTest, string_view_creates_file) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   sourcemeta::core::atomic_write_file(path, "hello");
   EXPECT_TRUE(std::filesystem::exists(path));
   EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "hello");
 }
 
 TEST_F(IOAtomicWriteFileTest, empty_contents) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   sourcemeta::core::atomic_write_file(path, "");
   EXPECT_TRUE(std::filesystem::exists(path));
   EXPECT_EQ(std::filesystem::file_size(path), 0);
 }
 
 TEST_F(IOAtomicWriteFileTest, byte_span_creates_file) {
-  const auto path{this->workspace / "out.bin"};
-  constexpr std::array<std::byte, 5> bytes{{std::byte{0x48}, std::byte{0x65},
+  const auto path{this->workspace_ / "out.bin"};
+  constexpr std::array<std::byte, 5> BYTES{{std::byte{0x48}, std::byte{0x65},
                                             std::byte{0x6c}, std::byte{0x6c},
                                             std::byte{0x6f}}};
-  sourcemeta::core::atomic_write_file(path, std::span<const std::byte>{bytes});
+  sourcemeta::core::atomic_write_file(path, std::span<const std::byte>{BYTES});
   EXPECT_TRUE(std::filesystem::exists(path));
   EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "Hello");
 }
 
 TEST_F(IOAtomicWriteFileTest, callback_variant) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   sourcemeta::core::atomic_write_file(path, [](std::ostream &stream) -> void {
     stream << "first";
     stream << " ";
@@ -63,14 +63,14 @@ TEST_F(IOAtomicWriteFileTest, callback_variant) {
 }
 
 TEST_F(IOAtomicWriteFileTest, creates_parent_directories) {
-  const auto path{this->workspace / "a" / "b" / "c" / "deep.txt"};
+  const auto path{this->workspace_ / "a" / "b" / "c" / "deep.txt"};
   sourcemeta::core::atomic_write_file(path, "nested");
   EXPECT_TRUE(std::filesystem::exists(path));
   EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "nested");
 }
 
 TEST_F(IOAtomicWriteFileTest, overwrites_existing_file) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   sourcemeta::core::atomic_write_file(path, "original");
   sourcemeta::core::atomic_write_file(path, "replacement");
   EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "replacement");
@@ -78,7 +78,7 @@ TEST_F(IOAtomicWriteFileTest, overwrites_existing_file) {
 
 TEST_F(IOAtomicWriteFileTest,
        exception_in_callback_leaves_destination_untouched) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   sourcemeta::core::atomic_write_file(path, "original");
 
   try {
@@ -96,7 +96,7 @@ TEST_F(IOAtomicWriteFileTest,
 }
 
 TEST_F(IOAtomicWriteFileTest, exception_in_callback_removes_staging_file) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   auto staging{path};
   staging += ".tmp";
 
@@ -116,7 +116,7 @@ TEST_F(IOAtomicWriteFileTest, exception_in_callback_removes_staging_file) {
 }
 
 TEST_F(IOAtomicWriteFileTest, no_leftover_staging_on_success) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   auto staging{path};
   staging += ".tmp";
 
@@ -127,7 +127,7 @@ TEST_F(IOAtomicWriteFileTest, no_leftover_staging_on_success) {
 }
 
 TEST_F(IOAtomicWriteFileTest, binary_writes_preserve_exact_bytes) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   sourcemeta::core::atomic_write_file(path, "line one\nline two\n");
 
   std::ifstream stream{path, std::ios::binary};
@@ -141,7 +141,7 @@ TEST_F(IOAtomicWriteFileTest, binary_writes_preserve_exact_bytes) {
 // EACCES-via-errno detection inside `atomic_write_file` is POSIX-only.
 #if !defined(_WIN32)
 TEST_F(IOAtomicWriteFileTest, read_only_parent_throws_permission_error) {
-  const auto read_only_dir{this->workspace / "locked"};
+  const auto read_only_dir{this->workspace_ / "locked"};
   std::filesystem::create_directory(read_only_dir);
   std::filesystem::permissions(read_only_dir,
                                std::filesystem::perms::owner_read |

--- a/test/io/io_binary_test.cc
+++ b/test/io/io_binary_test.cc
@@ -26,16 +26,16 @@ struct ExampleHeader {
 
 class IOBinaryTest {
 protected:
-  IOBinaryTest() { std::filesystem::create_directories(this->workspace); }
+  IOBinaryTest() { std::filesystem::create_directories(this->workspace_); }
 
   ~IOBinaryTest() {
     std::error_code error;
-    std::filesystem::remove_all(this->workspace, error);
+    std::filesystem::remove_all(this->workspace_, error);
   }
 
   // The tests are always sequential, so using the same path is safe
-  std::filesystem::path workspace{std::filesystem::path{BUILD_DIRECTORY} /
-                                  "sourcemeta_core_io_binary_test"};
+  std::filesystem::path workspace_{std::filesystem::path{BUILD_DIRECTORY} /
+                                   "sourcemeta_core_io_binary_test"};
 };
 
 // -----------------------------------------------------------------------------
@@ -92,9 +92,9 @@ TEST(put_qword_emits_eight_bytes_little_endian) {
 TEST(put_bytes_emits_raw_buffer) {
   std::ostringstream stream;
   sourcemeta::core::BinaryWriter writer{stream};
-  constexpr std::array<std::byte, 3> payload{
+  constexpr std::array<std::byte, 3> PAYLOAD{
       {std::byte{0xDE}, std::byte{0xAD}, std::byte{0xBE}}};
-  writer.put_bytes(payload.data(), payload.size());
+  writer.put_bytes(PAYLOAD.data(), PAYLOAD.size());
   const auto bytes{stream.str()};
   EXPECT_EQ(bytes.size(), 3);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[0]), 0xDE);
@@ -261,7 +261,7 @@ TEST(has_more_data_treats_null_byte_as_data) {
 // -----------------------------------------------------------------------------
 
 TEST_F(IOBinaryTest, put_dword_to_file) {
-  const auto path{this->workspace / "value.bin"};
+  const auto path{this->workspace_ / "value.bin"};
   {
     std::ofstream raw{path, std::ios::binary};
     sourcemeta::core::BinaryWriter writer{raw};
@@ -271,15 +271,15 @@ TEST_F(IOBinaryTest, put_dword_to_file) {
 }
 
 TEST_F(IOBinaryTest, put_bytes_to_file) {
-  const auto path{this->workspace / "values.bin"};
-  constexpr std::array<std::byte, 4> payload{
+  const auto path{this->workspace_ / "values.bin"};
+  constexpr std::array<std::byte, 4> PAYLOAD{
       {std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04}}};
   {
     std::ofstream raw{path, std::ios::binary};
     sourcemeta::core::BinaryWriter writer{raw};
-    writer.put_bytes(payload.data(), payload.size());
+    writer.put_bytes(PAYLOAD.data(), PAYLOAD.size());
   }
-  EXPECT_EQ(std::filesystem::file_size(path), payload.size());
+  EXPECT_EQ(std::filesystem::file_size(path), PAYLOAD.size());
 }
 
 // -----------------------------------------------------------------------------
@@ -287,8 +287,8 @@ TEST_F(IOBinaryTest, put_bytes_to_file) {
 // -----------------------------------------------------------------------------
 
 TEST_F(IOBinaryTest, get_after_put_integer_roundtrip_via_file) {
-  const auto path{this->workspace / "value.bin"};
-  constexpr std::uint32_t expected{0x12345678};
+  const auto path{this->workspace_ / "value.bin"};
+  constexpr std::uint32_t EXPECTED{0x12345678};
   {
     std::ofstream raw{path, std::ios::binary};
     sourcemeta::core::BinaryWriter writer{raw};
@@ -297,12 +297,12 @@ TEST_F(IOBinaryTest, get_after_put_integer_roundtrip_via_file) {
 
   const sourcemeta::core::FileView view{path};
   sourcemeta::core::BinaryReader reader{view};
-  EXPECT_EQ(reader.get_dword(), expected);
+  EXPECT_EQ(reader.get_dword(), EXPECTED);
   EXPECT_EQ(reader.position(), sizeof(std::uint32_t));
 }
 
 TEST_F(IOBinaryTest, get_after_put_struct_roundtrip_via_file) {
-  const auto path{this->workspace / "header.bin"};
+  const auto path{this->workspace_ / "header.bin"};
   const ExampleHeader expected{0xDEADBEEF, 7, 0x42, 1024};
   {
     std::ofstream raw{path, std::ios::binary};
@@ -322,7 +322,7 @@ TEST_F(IOBinaryTest, get_after_put_struct_roundtrip_via_file) {
 }
 
 TEST_F(IOBinaryTest, sequential_gets_advance_cursor_via_file) {
-  const auto path{this->workspace / "sequence.bin"};
+  const auto path{this->workspace_ / "sequence.bin"};
   {
     std::ofstream raw{path, std::ios::binary};
     sourcemeta::core::BinaryWriter writer{raw};
@@ -342,7 +342,7 @@ TEST_F(IOBinaryTest, sequential_gets_advance_cursor_via_file) {
 }
 
 TEST_F(IOBinaryTest, seek_moves_cursor_via_file) {
-  const auto path{this->workspace / "seek.bin"};
+  const auto path{this->workspace_ / "seek.bin"};
   {
     std::ofstream raw{path, std::ios::binary};
     sourcemeta::core::BinaryWriter writer{raw};
@@ -359,7 +359,7 @@ TEST_F(IOBinaryTest, seek_moves_cursor_via_file) {
 }
 
 TEST_F(IOBinaryTest, seek_to_end_is_allowed_via_file) {
-  const auto path{this->workspace / "end.bin"};
+  const auto path{this->workspace_ / "end.bin"};
   {
     std::ofstream raw{path, std::ios::binary};
     sourcemeta::core::BinaryWriter writer{raw};
@@ -373,7 +373,7 @@ TEST_F(IOBinaryTest, seek_to_end_is_allowed_via_file) {
 }
 
 TEST_F(IOBinaryTest, seek_past_end_throws_via_file) {
-  const auto path{this->workspace / "tiny.bin"};
+  const auto path{this->workspace_ / "tiny.bin"};
   {
     std::ofstream raw{path, std::ios::binary};
     sourcemeta::core::BinaryWriter writer{raw};
@@ -391,7 +391,7 @@ TEST_F(IOBinaryTest, seek_past_end_throws_via_file) {
 }
 
 TEST_F(IOBinaryTest, get_past_end_throws_via_file) {
-  const auto path{this->workspace / "tiny.bin"};
+  const auto path{this->workspace_ / "tiny.bin"};
   {
     std::ofstream raw{path, std::ios::binary};
     sourcemeta::core::BinaryWriter writer{raw};
@@ -409,25 +409,25 @@ TEST_F(IOBinaryTest, get_past_end_throws_via_file) {
 }
 
 TEST_F(IOBinaryTest, get_byte_span_roundtrip_via_file) {
-  const auto path{this->workspace / "bytes.bin"};
-  constexpr std::array<std::byte, 4> payload{
+  const auto path{this->workspace_ / "bytes.bin"};
+  constexpr std::array<std::byte, 4> PAYLOAD{
       {std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04}}};
   {
     std::ofstream raw{path, std::ios::binary};
     sourcemeta::core::BinaryWriter writer{raw};
-    writer.put_bytes(payload.data(), payload.size());
+    writer.put_bytes(PAYLOAD.data(), PAYLOAD.size());
   }
 
   const sourcemeta::core::FileView view{path};
   sourcemeta::core::BinaryReader reader{view};
   std::array<std::byte, 4> destination{};
   reader.get_bytes(destination.data(), destination.size());
-  EXPECT_EQ(destination, payload);
-  EXPECT_EQ(reader.position(), payload.size());
+  EXPECT_EQ(destination, PAYLOAD);
+  EXPECT_EQ(reader.position(), PAYLOAD.size());
 }
 
 TEST_F(IOBinaryTest, has_more_data_on_file_view) {
-  const auto path{this->workspace / "value.bin"};
+  const auto path{this->workspace_ / "value.bin"};
   {
     std::ofstream raw{path, std::ios::binary};
     sourcemeta::core::BinaryWriter writer{raw};

--- a/test/io/io_read_to_string_test.cc
+++ b/test/io/io_read_to_string_test.cc
@@ -76,22 +76,22 @@ TEST(missing_file_throws) {
 class IOReadFileToStringTest {
 protected:
   IOReadFileToStringTest() {
-    std::filesystem::create_directories(this->workspace);
+    std::filesystem::create_directories(this->workspace_);
   }
 
   ~IOReadFileToStringTest() {
     std::error_code error;
-    std::filesystem::remove_all(this->workspace, error);
+    std::filesystem::remove_all(this->workspace_, error);
   }
 
   // The tests are always sequential, so using the same path is safe
-  std::filesystem::path workspace{
+  std::filesystem::path workspace_{
       std::filesystem::path{BUILD_DIRECTORY} /
       "sourcemeta_core_io_read_file_to_string_test"};
 };
 
 TEST_F(IOReadFileToStringTest, freshly_written_file) {
-  const auto path{this->workspace / "payload.txt"};
+  const auto path{this->workspace_ / "payload.txt"};
   {
     std::ofstream stream{path};
     stream << "first line\nsecond line\n";
@@ -103,7 +103,7 @@ TEST_F(IOReadFileToStringTest, freshly_written_file) {
 }
 
 TEST_F(IOReadFileToStringTest, empty_file) {
-  const auto path{this->workspace / "empty.txt"};
+  const auto path{this->workspace_ / "empty.txt"};
   std::ofstream{path};
   EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "");
 }
@@ -119,7 +119,7 @@ TEST_F(IOReadFileToStringTest, fifo) {
     }
   };
 
-  const auto path{this->workspace / "fifo"};
+  const auto path{this->workspace_ / "fifo"};
   std::filesystem::remove(path);
   EXPECT_EQ(::mkfifo(path.c_str(), S_IRUSR | S_IWUSR), 0);
   std::thread writer{[&path]() {

--- a/test/io/io_write_file_test.cc
+++ b/test/io/io_write_file_test.cc
@@ -14,44 +14,44 @@
 
 class IOWriteFileTest {
 protected:
-  IOWriteFileTest() { std::filesystem::create_directories(this->workspace); }
+  IOWriteFileTest() { std::filesystem::create_directories(this->workspace_); }
 
   ~IOWriteFileTest() {
     std::error_code error;
-    std::filesystem::remove_all(this->workspace, error);
+    std::filesystem::remove_all(this->workspace_, error);
   }
 
   // The tests are always sequential, so using the same path is safe
-  std::filesystem::path workspace{std::filesystem::path{BUILD_DIRECTORY} /
-                                  "sourcemeta_core_io_write_test"};
+  std::filesystem::path workspace_{std::filesystem::path{BUILD_DIRECTORY} /
+                                   "sourcemeta_core_io_write_test"};
 };
 
 TEST_F(IOWriteFileTest, string_view_creates_file) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   sourcemeta::core::write_file(path, "hello");
   EXPECT_TRUE(std::filesystem::exists(path));
   EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "hello");
 }
 
 TEST_F(IOWriteFileTest, empty_contents) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   sourcemeta::core::write_file(path, "");
   EXPECT_TRUE(std::filesystem::exists(path));
   EXPECT_EQ(std::filesystem::file_size(path), 0);
 }
 
 TEST_F(IOWriteFileTest, byte_span_creates_file) {
-  const auto path{this->workspace / "out.bin"};
-  constexpr std::array<std::byte, 5> bytes{{std::byte{0x48}, std::byte{0x65},
+  const auto path{this->workspace_ / "out.bin"};
+  constexpr std::array<std::byte, 5> BYTES{{std::byte{0x48}, std::byte{0x65},
                                             std::byte{0x6c}, std::byte{0x6c},
                                             std::byte{0x6f}}};
-  sourcemeta::core::write_file(path, std::span<const std::byte>{bytes});
+  sourcemeta::core::write_file(path, std::span<const std::byte>{BYTES});
   EXPECT_TRUE(std::filesystem::exists(path));
   EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "Hello");
 }
 
 TEST_F(IOWriteFileTest, callback_variant) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   sourcemeta::core::write_file(path, [](std::ostream &stream) -> void {
     stream << "first";
     stream << " ";
@@ -61,21 +61,21 @@ TEST_F(IOWriteFileTest, callback_variant) {
 }
 
 TEST_F(IOWriteFileTest, creates_parent_directories) {
-  const auto path{this->workspace / "a" / "b" / "c" / "deep.txt"};
+  const auto path{this->workspace_ / "a" / "b" / "c" / "deep.txt"};
   sourcemeta::core::write_file(path, "nested");
   EXPECT_TRUE(std::filesystem::exists(path));
   EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "nested");
 }
 
 TEST_F(IOWriteFileTest, overwrites_existing_file) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   sourcemeta::core::write_file(path, "original");
   sourcemeta::core::write_file(path, "replacement");
   EXPECT_EQ(sourcemeta::core::read_file_to_string(path), "replacement");
 }
 
 TEST_F(IOWriteFileTest, binary_writes_preserve_exact_bytes) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   sourcemeta::core::write_file(path, "line one\nline two\n");
 
   std::ifstream stream{path, std::ios::binary};
@@ -86,7 +86,7 @@ TEST_F(IOWriteFileTest, binary_writes_preserve_exact_bytes) {
 }
 
 TEST_F(IOWriteFileTest, no_staging_file_created) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   auto staging{path};
   staging += ".tmp";
 
@@ -97,7 +97,7 @@ TEST_F(IOWriteFileTest, no_staging_file_created) {
 }
 
 TEST_F(IOWriteFileTest, exception_in_callback_leaves_partial_file) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
 
   try {
     sourcemeta::core::write_file(path, [&path](std::ostream &stream) -> void {
@@ -116,7 +116,7 @@ TEST_F(IOWriteFileTest, exception_in_callback_leaves_partial_file) {
 }
 
 TEST_F(IOWriteFileTest, exception_in_callback_truncates_existing_file) {
-  const auto path{this->workspace / "out.txt"};
+  const auto path{this->workspace_ / "out.txt"};
   sourcemeta::core::write_file(path, "original");
 
   try {
@@ -137,7 +137,7 @@ TEST_F(IOWriteFileTest, exception_in_callback_truncates_existing_file) {
 // POSIX permission bits don't map cleanly to Windows ACLs
 #if !defined(_WIN32)
 TEST_F(IOWriteFileTest, read_only_parent_throws_permission_error) {
-  const auto read_only_dir{this->workspace / "locked"};
+  const auto read_only_dir{this->workspace_ / "locked"};
   std::filesystem::create_directory(read_only_dir);
   std::filesystem::permissions(read_only_dir,
                                std::filesystem::perms::owner_read |

--- a/test/jose/jose_cookbook_test.cc
+++ b/test/jose/jose_cookbook_test.cc
@@ -117,11 +117,11 @@ auto main(int argc, char **argv) -> int {
   // The single-signature compact examples, which our engine runs in full. The
   // detached, unprotected-header, and general serialization examples stay
   // masked out of the vendored tree
-  constexpr std::array<std::string_view, 4> examples{
+  constexpr std::array<std::string_view, 4> EXAMPLES{
       {"4_1.rsa_v15_signature.json", "4_2.rsa-pss_signature.json",
        "4_3.ecdsa_signature.json", "4_4.hmac-sha2_integrity_protection.json"}};
 
-  for (const auto example : examples) {
+  for (const auto example : EXAMPLES) {
     const auto name{std::filesystem::path{example}.stem().string()};
     sourcemeta::core::test_register(name + ".verify", [example]() {
       EXPECT_TRUE(verify_example(load("jws", example)));
@@ -134,17 +134,17 @@ auto main(int argc, char **argv) -> int {
   // The compact JWE examples whose key-management and content encryption
   // algorithms this module implements. The masked-out examples use RSA1_5,
   // PBES2, AES-GCM key wrapping, compression, or the JSON serialization
-  constexpr std::string_view ecdh_es_kw_example{
+  constexpr std::string_view ECDH_ES_KW_EXAMPLE{
       "5_4.key_agreement_with_key_wrapping_using_ecdh-es_and_aes-keywrap_with_"
       "aes-gcm.json"};
-  constexpr std::array<std::string_view, 5> encryption_examples{
+  constexpr std::array<std::string_view, 5> ENCRYPTION_EXAMPLES{
       {"5_2.key_encryption_using_rsa-oaep_with_aes-gcm.json",
-       ecdh_es_kw_example,
+       ECDH_ES_KW_EXAMPLE,
        "5_5.key_agreement_using_ecdh-es_with_aes-cbc-hmac-sha2.json",
        "5_6.direct_encryption_using_aes-gcm.json",
        "5_8.key_wrap_using_aes-keywrap_with_aes-gcm.json"}};
 
-  for (const auto example : encryption_examples) {
+  for (const auto example : ENCRYPTION_EXAMPLES) {
     const auto name{std::filesystem::path{example}.stem().string()};
     sourcemeta::core::test_register(name + ".decrypt", [example]() {
       EXPECT_TRUE(decrypt_example(load("jwe", example)));

--- a/test/json/json_array_test.cc
+++ b/test/json/json_array_test.cc
@@ -2,6 +2,7 @@
 #include <sourcemeta/core/test.h>
 
 #include <algorithm>
+#include <ranges>
 #include <set>
 #include <string>
 #include <type_traits>
@@ -167,9 +168,8 @@ TEST(reverse_boolean_iterator) {
        sourcemeta::core::JSON{false}})};
 
   std::vector<bool> result;
-  for (auto iterator = document.as_array().crbegin();
-       iterator != document.as_array().crend(); iterator++) {
-    result.push_back(iterator->to_boolean());
+  for (const auto &element : std::views::reverse(document.as_array())) {
+    result.push_back(element.to_boolean());
   }
 
   EXPECT_EQ(result.size(), 3);

--- a/test/json/json_auto_test.cc
+++ b/test/json/json_auto_test.cc
@@ -17,11 +17,11 @@
 #include <sourcemeta/core/json.h>
 
 struct ClassWithCustomMethod {
-  auto to_json() const -> sourcemeta::core::JSON {
+  [[nodiscard]] auto to_json() const -> sourcemeta::core::JSON {
     return sourcemeta::core::JSON{42};
   }
 
-  static auto from_json(const sourcemeta::core::JSON &)
+  static auto from_json([[maybe_unused]] const sourcemeta::core::JSON &value)
       -> std::optional<ClassWithCustomMethod> {
     return ClassWithCustomMethod{};
   }
@@ -30,7 +30,7 @@ struct ClassWithCustomMethod {
       -> bool = default;
 };
 
-enum class SampleEnum { Foo = 0, Bar = 1, Baz };
+enum class SampleEnum { Foo = 0, Bar = 1, Baz = 2 };
 
 TEST(class_with_custom_method) {
   const ClassWithCustomMethod value;

--- a/test/json/json_object_test.cc
+++ b/test/json/json_object_test.cc
@@ -1616,28 +1616,28 @@ TEST(assign_if_nonempty_array_computes_hash) {
 }
 
 TEST(hash_is_a_constant_expression_matching_runtime) {
-  static constexpr auto compile_time{
+  static constexpr auto COMPILE_TIME{
       sourcemeta::core::JSON::Object::hash(std::string_view{"foobar"})};
   const auto run_time{
       sourcemeta::core::JSON::Object::hash(std::string_view{"foobar"})};
-  EXPECT_TRUE(compile_time == run_time);
+  EXPECT_TRUE(COMPILE_TIME == run_time);
 }
 
 TEST(constexpr_hash_finds_an_object_member) {
-  static constexpr auto key_hash{
+  static constexpr auto KEY_HASH{
       sourcemeta::core::JSON::Object::hash(std::string_view{"foo"})};
   const auto document{sourcemeta::core::parse_json(R"JSON({ "foo": 1 })JSON")};
-  const auto *value{document.try_at(std::string_view{"foo"}, key_hash)};
+  const auto *value{document.try_at(std::string_view{"foo"}, KEY_HASH)};
   EXPECT_TRUE(value != nullptr);
   EXPECT_EQ(value->to_integer(), 1);
 }
 
 TEST(constexpr_hash_matches_runtime_for_a_long_key) {
-  static constexpr std::string_view key{
+  static constexpr std::string_view KEY{
       "a_property_name_that_is_definitely_longer_than_thirty_one_bytes"};
-  static constexpr auto compile_time{sourcemeta::core::JSON::Object::hash(key)};
-  const auto run_time{sourcemeta::core::JSON::Object::hash(key)};
-  EXPECT_TRUE(compile_time == run_time);
+  static constexpr auto COMPILE_TIME{sourcemeta::core::JSON::Object::hash(KEY)};
+  const auto run_time{sourcemeta::core::JSON::Object::hash(KEY)};
+  EXPECT_TRUE(COMPILE_TIME == run_time);
 }
 
 TEST(unique_keys_empty_object) {

--- a/test/json/json_parse_error_test.cc
+++ b/test/json/json_parse_error_test.cc
@@ -337,12 +337,12 @@ TEST(string_invalid_control_characters) {
   std::istringstream input07{"\"foo \u0007 bar\""};
   std::istringstream input08{"\"foo \u0008 bar\""};
   std::istringstream input09{"\"foo \u0009 bar\""};
-  std::istringstream input0A{"\"foo \u000A bar\""};
-  std::istringstream input0B{"\"foo \u000B bar\""};
-  std::istringstream input0C{"\"foo \u000C bar\""};
-  std::istringstream input0D{"\"foo \u000D bar\""};
-  std::istringstream input0E{"\"foo \u000E bar\""};
-  std::istringstream input0F{"\"foo \u000F bar\""};
+  std::istringstream input0_a{"\"foo \u000A bar\""};
+  std::istringstream input0_b{"\"foo \u000B bar\""};
+  std::istringstream input0_c{"\"foo \u000C bar\""};
+  std::istringstream input0_d{"\"foo \u000D bar\""};
+  std::istringstream input0_e{"\"foo \u000E bar\""};
+  std::istringstream input0_f{"\"foo \u000F bar\""};
   std::istringstream input10{"\"foo \u0010 bar\""};
   std::istringstream input11{"\"foo \u0011 bar\""};
   std::istringstream input12{"\"foo \u0012 bar\""};
@@ -353,12 +353,12 @@ TEST(string_invalid_control_characters) {
   std::istringstream input17{"\"foo \u0017 bar\""};
   std::istringstream input18{"\"foo \u0018 bar\""};
   std::istringstream input19{"\"foo \u0019 bar\""};
-  std::istringstream input1A{"\"foo \u001A bar\""};
-  std::istringstream input1B{"\"foo \u001B bar\""};
-  std::istringstream input1C{"\"foo \u001C bar\""};
-  std::istringstream input1D{"\"foo \u001D bar\""};
-  std::istringstream input1E{"\"foo \u001E bar\""};
-  std::istringstream input1F{"\"foo \u001F bar\""};
+  std::istringstream input1_a{"\"foo \u001A bar\""};
+  std::istringstream input1_b{"\"foo \u001B bar\""};
+  std::istringstream input1_c{"\"foo \u001C bar\""};
+  std::istringstream input1_d{"\"foo \u001D bar\""};
+  std::istringstream input1_e{"\"foo \u001E bar\""};
+  std::istringstream input1_f{"\"foo \u001F bar\""};
 
   EXPECT_PARSE_ERROR(input00, 1, 6);
   EXPECT_PARSE_ERROR(input01, 1, 6);
@@ -370,12 +370,12 @@ TEST(string_invalid_control_characters) {
   EXPECT_PARSE_ERROR(input07, 1, 6);
   EXPECT_PARSE_ERROR(input08, 1, 6);
   EXPECT_PARSE_ERROR(input09, 1, 6);
-  EXPECT_PARSE_ERROR(input0A, 1, 6);
-  EXPECT_PARSE_ERROR(input0B, 1, 6);
-  EXPECT_PARSE_ERROR(input0C, 1, 6);
-  EXPECT_PARSE_ERROR(input0D, 1, 6);
-  EXPECT_PARSE_ERROR(input0E, 1, 6);
-  EXPECT_PARSE_ERROR(input0F, 1, 6);
+  EXPECT_PARSE_ERROR(input0_a, 1, 6);
+  EXPECT_PARSE_ERROR(input0_b, 1, 6);
+  EXPECT_PARSE_ERROR(input0_c, 1, 6);
+  EXPECT_PARSE_ERROR(input0_d, 1, 6);
+  EXPECT_PARSE_ERROR(input0_e, 1, 6);
+  EXPECT_PARSE_ERROR(input0_f, 1, 6);
   EXPECT_PARSE_ERROR(input10, 1, 6);
   EXPECT_PARSE_ERROR(input11, 1, 6);
   EXPECT_PARSE_ERROR(input12, 1, 6);
@@ -386,12 +386,12 @@ TEST(string_invalid_control_characters) {
   EXPECT_PARSE_ERROR(input17, 1, 6);
   EXPECT_PARSE_ERROR(input18, 1, 6);
   EXPECT_PARSE_ERROR(input19, 1, 6);
-  EXPECT_PARSE_ERROR(input1A, 1, 6);
-  EXPECT_PARSE_ERROR(input1B, 1, 6);
-  EXPECT_PARSE_ERROR(input1C, 1, 6);
-  EXPECT_PARSE_ERROR(input1D, 1, 6);
-  EXPECT_PARSE_ERROR(input1E, 1, 6);
-  EXPECT_PARSE_ERROR(input1F, 1, 6);
+  EXPECT_PARSE_ERROR(input1_a, 1, 6);
+  EXPECT_PARSE_ERROR(input1_b, 1, 6);
+  EXPECT_PARSE_ERROR(input1_c, 1, 6);
+  EXPECT_PARSE_ERROR(input1_d, 1, 6);
+  EXPECT_PARSE_ERROR(input1_e, 1, 6);
+  EXPECT_PARSE_ERROR(input1_f, 1, 6);
 }
 
 TEST(string_invalid_code_point) {

--- a/test/json/json_value_test.cc
+++ b/test/json/json_value_test.cc
@@ -367,11 +367,13 @@ TEST(to_ostream) {
 class ClassMemberInitializerList {
 public:
   ClassMemberInitializerList(sourcemeta::core::JSON document)
-      : data{std::move(document)} {}
-  auto get() const -> const sourcemeta::core::JSON & { return this->data; }
+      : data_{std::move(document)} {}
+  [[nodiscard]] auto get() const -> const sourcemeta::core::JSON & {
+    return this->data_;
+  }
 
 private:
-  const sourcemeta::core::JSON data;
+  const sourcemeta::core::JSON data_;
 };
 
 TEST(class_member_initializer_list) {
@@ -667,62 +669,62 @@ TEST(unordered_map_with_reference_wrapper) {
 }
 
 TEST(destructs_deeply_nested_array_without_stack_overflow) {
-  constexpr std::size_t depth{100000};
+  constexpr std::size_t DEPTH{100000};
   std::string deep;
-  deep.reserve(depth * 2 + 1);
-  deep.append(depth, '[');
+  deep.reserve((DEPTH * 2) + 1);
+  deep.append(DEPTH, '[');
   deep.push_back('0');
-  deep.append(depth, ']');
+  deep.append(DEPTH, ']');
   auto document = sourcemeta::core::parse_json(deep);
   EXPECT_TRUE(document.is_array());
 }
 
 TEST(destructs_deeply_nested_object_without_stack_overflow) {
-  constexpr std::size_t depth{100000};
+  constexpr std::size_t DEPTH{100000};
   std::string deep;
-  deep.reserve(depth * 6 + 1 + depth);
-  for (std::size_t index = 0; index < depth; ++index) {
+  deep.reserve((DEPTH * 6) + 1 + DEPTH);
+  for (std::size_t index = 0; index < DEPTH; ++index) {
     deep.append("{\"x\":");
   }
   deep.push_back('0');
-  deep.append(depth, '}');
+  deep.append(DEPTH, '}');
   auto document = sourcemeta::core::parse_json(deep);
   EXPECT_TRUE(document.is_object());
 }
 
 TEST(copies_deeply_nested_array_without_stack_overflow) {
-  constexpr std::size_t depth{100000};
+  constexpr std::size_t DEPTH{100000};
   std::string deep;
-  deep.reserve(depth * 2 + 1);
-  deep.append(depth, '[');
+  deep.reserve((DEPTH * 2) + 1);
+  deep.append(DEPTH, '[');
   deep.push_back('0');
-  deep.append(depth, ']');
+  deep.append(DEPTH, ']');
   auto document = sourcemeta::core::parse_json(deep);
   auto copy = document;
   EXPECT_TRUE(copy.is_array());
 }
 
 TEST(copies_deeply_nested_object_without_stack_overflow) {
-  constexpr std::size_t depth{100000};
+  constexpr std::size_t DEPTH{100000};
   std::string deep;
-  deep.reserve(depth * 6 + 1 + depth);
-  for (std::size_t index = 0; index < depth; ++index) {
+  deep.reserve((DEPTH * 6) + 1 + DEPTH);
+  for (std::size_t index = 0; index < DEPTH; ++index) {
     deep.append("{\"x\":");
   }
   deep.push_back('0');
-  deep.append(depth, '}');
+  deep.append(DEPTH, '}');
   auto document = sourcemeta::core::parse_json(deep);
   auto copy = document;
   EXPECT_TRUE(copy.is_object());
 }
 
 TEST(copy_assigns_deeply_nested_array_without_stack_overflow) {
-  constexpr std::size_t depth{100000};
+  constexpr std::size_t DEPTH{100000};
   std::string deep;
-  deep.reserve(depth * 2 + 1);
-  deep.append(depth, '[');
+  deep.reserve((DEPTH * 2) + 1);
+  deep.append(DEPTH, '[');
   deep.push_back('0');
-  deep.append(depth, ']');
+  deep.append(DEPTH, ']');
   auto source = sourcemeta::core::parse_json(deep);
   auto target = sourcemeta::core::parse_json(deep);
   target = source;
@@ -730,14 +732,14 @@ TEST(copy_assigns_deeply_nested_array_without_stack_overflow) {
 }
 
 TEST(copy_assigns_deeply_nested_object_without_stack_overflow) {
-  constexpr std::size_t depth{100000};
+  constexpr std::size_t DEPTH{100000};
   std::string deep;
-  deep.reserve(depth * 6 + 1 + depth);
-  for (std::size_t index = 0; index < depth; ++index) {
+  deep.reserve((DEPTH * 6) + 1 + DEPTH);
+  for (std::size_t index = 0; index < DEPTH; ++index) {
     deep.append("{\"x\":");
   }
   deep.push_back('0');
-  deep.append(depth, '}');
+  deep.append(DEPTH, '}');
   auto source = sourcemeta::core::parse_json(deep);
   auto target = sourcemeta::core::parse_json(deep);
   target = source;
@@ -745,12 +747,12 @@ TEST(copy_assigns_deeply_nested_object_without_stack_overflow) {
 }
 
 TEST(move_assigns_deeply_nested_array_without_stack_overflow) {
-  constexpr std::size_t depth{100000};
+  constexpr std::size_t DEPTH{100000};
   std::string deep;
-  deep.reserve(depth * 2 + 1);
-  deep.append(depth, '[');
+  deep.reserve((DEPTH * 2) + 1);
+  deep.append(DEPTH, '[');
   deep.push_back('0');
-  deep.append(depth, ']');
+  deep.append(DEPTH, ']');
   auto source = sourcemeta::core::parse_json(deep);
   auto target = sourcemeta::core::parse_json(deep);
   target = std::move(source);
@@ -758,14 +760,14 @@ TEST(move_assigns_deeply_nested_array_without_stack_overflow) {
 }
 
 TEST(move_assigns_deeply_nested_object_without_stack_overflow) {
-  constexpr std::size_t depth{100000};
+  constexpr std::size_t DEPTH{100000};
   std::string deep;
-  deep.reserve(depth * 6 + 1 + depth);
-  for (std::size_t index = 0; index < depth; ++index) {
+  deep.reserve((DEPTH * 6) + 1 + DEPTH);
+  for (std::size_t index = 0; index < DEPTH; ++index) {
     deep.append("{\"x\":");
   }
   deep.push_back('0');
-  deep.append(depth, '}');
+  deep.append(DEPTH, '}');
   auto source = sourcemeta::core::parse_json(deep);
   auto target = sourcemeta::core::parse_json(deep);
   target = std::move(source);
@@ -775,12 +777,12 @@ TEST(move_assigns_deeply_nested_object_without_stack_overflow) {
 TEST(direct_list_inits_deeply_nested_array_without_stack_overflow) {
   // On GCC and MSVC, JSON x{other} selects JSON(initializer_list<JSON>) whose
   // single-element workaround invokes operator=(const JSON&)
-  constexpr std::size_t depth{100000};
+  constexpr std::size_t DEPTH{100000};
   std::string deep;
-  deep.reserve(depth * 2 + 1);
-  deep.append(depth, '[');
+  deep.reserve((DEPTH * 2) + 1);
+  deep.append(DEPTH, '[');
   deep.push_back('0');
-  deep.append(depth, ']');
+  deep.append(DEPTH, ']');
   auto source = sourcemeta::core::parse_json(deep);
   sourcemeta::core::JSON copy{source};
   EXPECT_TRUE(copy.is_array());

--- a/test/jsonld/jsonld_materialize_test.cc
+++ b/test/jsonld/jsonld_materialize_test.cc
@@ -5209,7 +5209,7 @@ TEST(promotion_with_constants) {
   const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
 
   sourcemeta::core::JSONLDPromotion promotion;
-  promotion.types.push_back("https://example.com/Quantity");
+  promotion.types.emplace_back("https://example.com/Quantity");
   promotion.value = "https://example.com/value";
   promotion.constants = sourcemeta::core::parse_json(R"({
     "https://example.com/unit": [ { "@id": "https://example.com/metre" } ]
@@ -5637,7 +5637,7 @@ TEST(promotion_output_flattens) {
   const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
 
   sourcemeta::core::JSONLDPromotion promotion;
-  promotion.types.push_back("https://example.com/Quantity");
+  promotion.types.emplace_back("https://example.com/Quantity");
   promotion.value = "https://example.com/value";
   promotion.constants = sourcemeta::core::parse_json(R"({
     "https://example.com/unit": [ { "@id": "https://example.com/metre" } ]
@@ -5660,7 +5660,7 @@ TEST(promotion_output_compacts_and_re_expands) {
   const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
 
   sourcemeta::core::JSONLDPromotion promotion;
-  promotion.types.push_back("https://example.com/Quantity");
+  promotion.types.emplace_back("https://example.com/Quantity");
   promotion.value = "https://example.com/value";
   promotion.constants = sourcemeta::core::parse_json(R"({
     "https://example.com/unit": [ { "@id": "https://example.com/metre" } ]

--- a/test/jsonpointer/jsonpointer_empty_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_empty_pointer_test.cc
@@ -2,6 +2,6 @@
 #include <sourcemeta/core/test.h>
 
 TEST(is_empty) {
-  EXPECT_TRUE(sourcemeta::core::empty_pointer.empty());
-  EXPECT_EQ(sourcemeta::core::empty_pointer, sourcemeta::core::Pointer{});
+  EXPECT_TRUE(sourcemeta::core::EMPTY_POINTER.empty());
+  EXPECT_EQ(sourcemeta::core::EMPTY_POINTER, sourcemeta::core::Pointer{});
 }

--- a/test/jsonpointer/jsonpointer_is_relative_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_is_relative_pointer_test.cc
@@ -421,29 +421,29 @@ TEST(valid_tab_inside_reference_token) {
 
 // embedded NUL - legal in a token; a truncating validator would differ
 TEST(valid_nul_inside_reference_token) {
-  static constexpr char value[]{"0/foo\x00"
+  static constexpr char VALUE[]{"0/foo\x00"
                                 "bar"};
-  static_assert(sizeof(value) - 1 == 9,
+  static_assert(sizeof(VALUE) - 1 == 9,
                 "string literal length changed - check \\xNN escaping");
   EXPECT_TRUE(
-      sourcemeta::core::is_relative_pointer(std::string_view{value, 9}));
+      sourcemeta::core::is_relative_pointer(std::string_view{VALUE, 9}));
 }
 
 TEST(invalid_nul_then_dangling_tilde) {
-  static constexpr char value[]{"0/foo\x00~"};
-  static_assert(sizeof(value) - 1 == 7,
+  static constexpr char VALUE[]{"0/foo\x00~"};
+  static_assert(sizeof(VALUE) - 1 == 7,
                 "string literal length changed - check \\xNN escaping");
   EXPECT_FALSE(
-      sourcemeta::core::is_relative_pointer(std::string_view{value, 7}));
+      sourcemeta::core::is_relative_pointer(std::string_view{VALUE, 7}));
 }
 
 TEST(invalid_nul_before_integer) {
-  static constexpr char value[]{"\x00"
+  static constexpr char VALUE[]{"\x00"
                                 "0"};
-  static_assert(sizeof(value) - 1 == 2,
+  static_assert(sizeof(VALUE) - 1 == 2,
                 "string literal length changed - check \\xNN escaping");
   EXPECT_FALSE(
-      sourcemeta::core::is_relative_pointer(std::string_view{value, 2}));
+      sourcemeta::core::is_relative_pointer(std::string_view{VALUE, 2}));
 }
 
 // escape sequences inherited from RFC 6901 section 3 through the wrapper

--- a/test/jsonpointer/jsonpointer_weakpointer_test.cc
+++ b/test/jsonpointer/jsonpointer_weakpointer_test.cc
@@ -10,10 +10,10 @@
 #include <unordered_map>
 #include <unordered_set>
 
-static const std::string foo = "foo";
-static const std::string bar = "bar";
-static const std::string baz = "baz";
-static const std::string qux = "qux";
+static const std::string FOO = "foo";
+static const std::string BAR = "bar";
+static const std::string BAZ = "baz";
+static const std::string QUX = "qux";
 
 TEST(general_traits) {
   EXPECT_TRUE(
@@ -50,48 +50,48 @@ TEST(empty) {
 }
 
 TEST(store_a_const_ref) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO)};
 
   EXPECT_EQ(pointer.size(), 1);
   EXPECT_FALSE(pointer.empty());
   EXPECT_TRUE(pointer.at(0).is_property());
-  EXPECT_EQ(pointer.at(0).to_property(), foo);
+  EXPECT_EQ(pointer.at(0).to_property(), FOO);
 }
 
 TEST(one_fragment_back) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO)};
 
   EXPECT_EQ(pointer.size(), 1);
   EXPECT_TRUE(pointer.back().is_property());
-  EXPECT_EQ(pointer.back().to_property(), foo);
+  EXPECT_EQ(pointer.back().to_property(), FOO);
 }
 
 TEST(multiple_fragments_mixed) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), 2,
-                                              std::cref(bar)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), 2,
+                                              std::cref(BAR)};
   EXPECT_EQ(pointer.size(), 3);
   EXPECT_FALSE(pointer.empty());
   EXPECT_TRUE(pointer.at(0).is_property());
   EXPECT_TRUE(pointer.at(1).is_index());
   EXPECT_TRUE(pointer.at(2).is_property());
-  EXPECT_EQ(pointer.at(0).to_property(), foo);
+  EXPECT_EQ(pointer.at(0).to_property(), FOO);
   EXPECT_EQ(pointer.at(1).to_index(), 2);
-  EXPECT_EQ(pointer.at(2).to_property(), bar);
+  EXPECT_EQ(pointer.at(2).to_property(), BAR);
 }
 
 TEST(multiple_fragments_back) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), 2,
-                                              std::cref(bar)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), 2,
+                                              std::cref(BAR)};
   EXPECT_TRUE(pointer.back().is_property());
-  EXPECT_EQ(pointer.back().to_property(), bar);
+  EXPECT_EQ(pointer.back().to_property(), BAR);
 }
 
 TEST(build_with_emplace_back) {
   sourcemeta::core::WeakPointer pointer;
   EXPECT_EQ(pointer.size(), 0);
-  auto &result_1{pointer.emplace_back(std::cref(foo))};
+  auto &result_1{pointer.emplace_back(std::cref(FOO))};
   EXPECT_TRUE(result_1.is_property());
-  EXPECT_EQ(result_1.to_property(), foo);
+  EXPECT_EQ(result_1.to_property(), FOO);
 
   auto &result_2{pointer.emplace_back(1)};
   EXPECT_TRUE(result_2.is_index());
@@ -100,7 +100,7 @@ TEST(build_with_emplace_back) {
   EXPECT_EQ(pointer.size(), 2);
   EXPECT_TRUE(pointer.at(0).is_property());
   EXPECT_TRUE(pointer.at(1).is_index());
-  EXPECT_EQ(pointer.at(0).to_property(), foo);
+  EXPECT_EQ(pointer.at(0).to_property(), FOO);
   EXPECT_EQ(pointer.at(1).to_index(), 1);
 }
 
@@ -111,23 +111,23 @@ TEST(equality_empty) {
 }
 
 TEST(equality_true) {
-  const sourcemeta::core::WeakPointer pointer_1{std::cref(foo), 1,
-                                                std::cref(bar)};
-  const sourcemeta::core::WeakPointer pointer_2{std::cref(foo), 1,
-                                                std::cref(bar)};
+  const sourcemeta::core::WeakPointer pointer_1{std::cref(FOO), 1,
+                                                std::cref(BAR)};
+  const sourcemeta::core::WeakPointer pointer_2{std::cref(FOO), 1,
+                                                std::cref(BAR)};
   EXPECT_EQ(pointer_1, pointer_2);
 }
 
 TEST(equality_false) {
-  const sourcemeta::core::WeakPointer pointer_1{std::cref(foo), 1,
-                                                std::cref(bar)};
-  const sourcemeta::core::WeakPointer pointer_2{std::cref(foo), 3,
-                                                std::cref(bar)};
+  const sourcemeta::core::WeakPointer pointer_1{std::cref(FOO), 1,
+                                                std::cref(BAR)};
+  const sourcemeta::core::WeakPointer pointer_2{std::cref(FOO), 3,
+                                                std::cref(BAR)};
   EXPECT_FALSE(pointer_1 == pointer_2);
 }
 
 TEST(pop_back_non_empty) {
-  sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
+  sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR)};
 
   pointer.pop_back();
   EXPECT_EQ(pointer.size(), 1);
@@ -136,9 +136,9 @@ TEST(pop_back_non_empty) {
 }
 
 TEST(ordering_less_than) {
-  const sourcemeta::core::WeakPointer pointer_1{std::cref(foo), std::cref(bar)};
-  const sourcemeta::core::WeakPointer pointer_2{std::cref(foo)};
-  const sourcemeta::core::WeakPointer pointer_3{std::cref(baz)};
+  const sourcemeta::core::WeakPointer pointer_1{std::cref(FOO), std::cref(BAR)};
+  const sourcemeta::core::WeakPointer pointer_2{std::cref(FOO)};
+  const sourcemeta::core::WeakPointer pointer_3{std::cref(BAZ)};
   EXPECT_TRUE(pointer_2 < pointer_1);
   EXPECT_TRUE(pointer_3 < pointer_1);
   EXPECT_TRUE(pointer_3 < pointer_2);
@@ -151,8 +151,8 @@ TEST(pop_back_zero_empty) {
 }
 
 TEST(pop_back_many_subset) {
-  sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
-                                        std::cref(baz)};
+  sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR),
+                                        std::cref(BAZ)};
   pointer.pop_back(2);
   EXPECT_EQ(pointer.size(), 1);
   EXPECT_TRUE(pointer.at(0).is_property());
@@ -160,15 +160,15 @@ TEST(pop_back_many_subset) {
 }
 
 TEST(pop_back_many_all) {
-  sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
-                                        std::cref(baz)};
+  sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR),
+                                        std::cref(BAZ)};
   pointer.pop_back(3);
   EXPECT_EQ(pointer.size(), 0);
 }
 
 TEST(push_back_pointer_copy) {
-  sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
-  const sourcemeta::core::WeakPointer other{std::cref(baz), std::cref(qux)};
+  sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR)};
+  const sourcemeta::core::WeakPointer other{std::cref(BAZ), std::cref(QUX)};
   pointer.push_back(other);
   EXPECT_EQ(pointer.size(), 4);
   EXPECT_TRUE(pointer.at(0).is_property());
@@ -182,8 +182,8 @@ TEST(push_back_pointer_copy) {
 }
 
 TEST(push_back_pointer_move) {
-  sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
-  sourcemeta::core::WeakPointer other{std::cref(baz), std::cref(qux)};
+  sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR)};
+  sourcemeta::core::WeakPointer other{std::cref(BAZ), std::cref(QUX)};
 
   pointer.push_back(std::move(other));
   EXPECT_EQ(pointer.size(), 4);
@@ -200,13 +200,13 @@ TEST(push_back_pointer_move) {
 }
 
 TEST(initial_with_one_token) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO)};
   const sourcemeta::core::WeakPointer result{pointer.initial()};
   EXPECT_EQ(result.size(), 0);
 }
 
 TEST(initial_with_two_tokens) {
-  sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
+  sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR)};
   const sourcemeta::core::WeakPointer result{pointer.initial()};
   EXPECT_EQ(result.size(), 1);
   EXPECT_TRUE(pointer.at(0).is_property());
@@ -214,8 +214,8 @@ TEST(initial_with_two_tokens) {
 }
 
 TEST(initial_with_three_tokens) {
-  sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
-                                        std::cref(baz)};
+  sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR),
+                                        std::cref(BAZ)};
   const sourcemeta::core::WeakPointer result{pointer.initial()};
   EXPECT_EQ(result.size(), 2);
   EXPECT_TRUE(pointer.at(0).is_property());
@@ -225,8 +225,8 @@ TEST(initial_with_three_tokens) {
 }
 
 TEST(push_back_property_copy) {
-  sourcemeta::core::WeakPointer pointer{std::cref(foo)};
-  const sourcemeta::core::WeakPointer other{std::cref(bar)};
+  sourcemeta::core::WeakPointer pointer{std::cref(FOO)};
+  const sourcemeta::core::WeakPointer other{std::cref(BAR)};
   pointer.push_back(other.back().to_property());
   EXPECT_EQ(pointer.size(), 2);
   EXPECT_TRUE(pointer.at(0).is_property());
@@ -236,8 +236,8 @@ TEST(push_back_property_copy) {
 }
 
 TEST(push_back_property_move) {
-  sourcemeta::core::WeakPointer pointer{std::cref(foo)};
-  pointer.push_back(std::cref(bar));
+  sourcemeta::core::WeakPointer pointer{std::cref(FOO)};
+  pointer.push_back(std::cref(BAR));
   EXPECT_EQ(pointer.size(), 2);
   EXPECT_TRUE(pointer.at(0).is_property());
   EXPECT_EQ(pointer.at(0).to_property(), "foo");
@@ -246,7 +246,7 @@ TEST(push_back_property_move) {
 }
 
 TEST(push_back_index_copy) {
-  sourcemeta::core::WeakPointer pointer{std::cref(foo)};
+  sourcemeta::core::WeakPointer pointer{std::cref(FOO)};
   const sourcemeta::core::WeakPointer other{0};
   pointer.push_back(other.back().to_index());
   EXPECT_EQ(pointer.size(), 2);
@@ -257,7 +257,7 @@ TEST(push_back_index_copy) {
 }
 
 TEST(push_back_index_move) {
-  sourcemeta::core::WeakPointer pointer{std::cref(foo)};
+  sourcemeta::core::WeakPointer pointer{std::cref(FOO)};
   pointer.push_back(0);
   EXPECT_EQ(pointer.size(), 2);
   EXPECT_TRUE(pointer.at(0).is_property());
@@ -267,8 +267,8 @@ TEST(push_back_index_move) {
 }
 
 TEST(push_back_pointer) {
-  const sourcemeta::core::Pointer pointer{bar, baz};
-  sourcemeta::core::WeakPointer destination{std::cref(foo)};
+  const sourcemeta::core::Pointer pointer{BAR, BAZ};
+  sourcemeta::core::WeakPointer destination{std::cref(FOO)};
   destination.push_back(pointer);
   EXPECT_EQ(destination.size(), 3);
   EXPECT_TRUE(destination.at(0).is_property());
@@ -286,8 +286,8 @@ TEST(try_get_complex_true) {
     }
   })JSON")};
 
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar), 2,
-                                              std::cref(baz)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR), 2,
+                                              std::cref(BAZ)};
 
   const auto result{sourcemeta::core::try_get(document, pointer)};
   EXPECT_TRUE(result);
@@ -301,8 +301,8 @@ TEST(try_get_complex_false) {
     }
   })JSON")};
 
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), 2,
-                                              std::cref(baz)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), 2,
+                                              std::cref(BAZ)};
 
   const auto result{sourcemeta::core::try_get(document, pointer)};
   EXPECT_FALSE(result);
@@ -326,8 +326,8 @@ TEST(get_mutable_nested) {
     }
   })JSON")};
 
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar), 2,
-                                              std::cref(baz)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR), 2,
+                                              std::cref(BAZ)};
   sourcemeta::core::JSON &result{sourcemeta::core::get(document, pointer)};
   EXPECT_TRUE(result.is_string());
   EXPECT_EQ(result.to_string(), "qux");
@@ -355,7 +355,7 @@ TEST(get_mutable_from_pointer_conversion) {
 }
 
 TEST(to_pointer) {
-  const sourcemeta::core::WeakPointer weak{std::cref(foo), 0};
+  const sourcemeta::core::WeakPointer weak{std::cref(FOO), 0};
   const sourcemeta::core::Pointer pointer{sourcemeta::core::to_pointer(weak)};
 
   EXPECT_EQ(weak.size(), 2);
@@ -394,16 +394,16 @@ TEST(hash_unordered_set) {
   // Test empty pointer
   const sourcemeta::core::WeakPointer empty{};
   // Test single token
-  const sourcemeta::core::WeakPointer single{std::cref(foo)};
+  const sourcemeta::core::WeakPointer single{std::cref(FOO)};
   // Test two tokens
-  const sourcemeta::core::WeakPointer two{std::cref(foo), std::cref(bar)};
+  const sourcemeta::core::WeakPointer two{std::cref(FOO), std::cref(BAR)};
   // Test three or more tokens
-  const sourcemeta::core::WeakPointer three{std::cref(foo), std::cref(bar),
-                                            std::cref(baz)};
-  const sourcemeta::core::WeakPointer four{std::cref(foo), std::cref(bar),
-                                           std::cref(baz), 1};
+  const sourcemeta::core::WeakPointer three{std::cref(FOO), std::cref(BAR),
+                                            std::cref(BAZ)};
+  const sourcemeta::core::WeakPointer four{std::cref(FOO), std::cref(BAR),
+                                           std::cref(BAZ), 1};
   // Duplicate to test deduplication
-  const sourcemeta::core::WeakPointer two_dup{std::cref(foo), std::cref(bar)};
+  const sourcemeta::core::WeakPointer two_dup{std::cref(FOO), std::cref(BAR)};
 
   set.insert(empty);
   set.insert(single);
@@ -429,12 +429,12 @@ TEST(hash_unordered_map) {
   // Test empty pointer
   const sourcemeta::core::WeakPointer empty{};
   // Test single token
-  const sourcemeta::core::WeakPointer single{std::cref(foo)};
+  const sourcemeta::core::WeakPointer single{std::cref(FOO)};
   // Test two tokens
-  const sourcemeta::core::WeakPointer two{std::cref(foo), 0};
+  const sourcemeta::core::WeakPointer two{std::cref(FOO), 0};
   // Test three or more tokens
-  const sourcemeta::core::WeakPointer four{std::cref(foo), std::cref(bar),
-                                           std::cref(baz), 1};
+  const sourcemeta::core::WeakPointer four{std::cref(FOO), std::cref(BAR),
+                                           std::cref(BAZ), 1};
 
   map[empty] = 0;
   map[single] = 1;
@@ -457,39 +457,39 @@ TEST(hash_empty_consistency) {
 
 TEST(hash_single_token_consistency) {
   const sourcemeta::core::WeakPointer::Hasher hasher;
-  const sourcemeta::core::WeakPointer single_1{std::cref(foo)};
-  const sourcemeta::core::WeakPointer single_2{std::cref(foo)};
-  const sourcemeta::core::WeakPointer single_3{std::cref(bar)};
+  const sourcemeta::core::WeakPointer single_1{std::cref(FOO)};
+  const sourcemeta::core::WeakPointer single_2{std::cref(FOO)};
+  const sourcemeta::core::WeakPointer single_3{std::cref(BAR)};
   EXPECT_EQ(hasher(single_1), hasher(single_2));
   EXPECT_NE(hasher(single_1), hasher(single_3));
 }
 
 TEST(hash_two_token_consistency) {
   const sourcemeta::core::WeakPointer::Hasher hasher;
-  const sourcemeta::core::WeakPointer two_1{std::cref(foo), std::cref(bar)};
-  const sourcemeta::core::WeakPointer two_2{std::cref(foo), std::cref(bar)};
-  const sourcemeta::core::WeakPointer two_3{std::cref(foo), std::cref(baz)};
+  const sourcemeta::core::WeakPointer two_1{std::cref(FOO), std::cref(BAR)};
+  const sourcemeta::core::WeakPointer two_2{std::cref(FOO), std::cref(BAR)};
+  const sourcemeta::core::WeakPointer two_3{std::cref(FOO), std::cref(BAZ)};
   EXPECT_EQ(hasher(two_1), hasher(two_2));
   EXPECT_NE(hasher(two_1), hasher(two_3));
 }
 
 TEST(hash_three_token_consistency) {
   const sourcemeta::core::WeakPointer::Hasher hasher;
-  const sourcemeta::core::WeakPointer multi_1{std::cref(foo), std::cref(bar),
+  const sourcemeta::core::WeakPointer multi_1{std::cref(FOO), std::cref(BAR),
                                               1};
-  const sourcemeta::core::WeakPointer multi_2{std::cref(foo), std::cref(bar),
+  const sourcemeta::core::WeakPointer multi_2{std::cref(FOO), std::cref(BAR),
                                               1};
-  const sourcemeta::core::WeakPointer multi_3{std::cref(foo), std::cref(baz),
+  const sourcemeta::core::WeakPointer multi_3{std::cref(FOO), std::cref(BAZ),
                                               1};
   EXPECT_EQ(hasher(multi_1), hasher(multi_2));
   EXPECT_NE(hasher(multi_1), hasher(multi_3));
 }
 
 TEST(hash_reference_wrapper_unordered_map) {
-  const sourcemeta::core::WeakPointer pointer_1{std::cref(foo), std::cref(bar)};
-  const sourcemeta::core::WeakPointer pointer_2{std::cref(baz)};
-  const sourcemeta::core::WeakPointer pointer_3{std::cref(foo), std::cref(bar),
-                                                std::cref(baz)};
+  const sourcemeta::core::WeakPointer pointer_1{std::cref(FOO), std::cref(BAR)};
+  const sourcemeta::core::WeakPointer pointer_2{std::cref(BAZ)};
+  const sourcemeta::core::WeakPointer pointer_3{std::cref(FOO), std::cref(BAR),
+                                                std::cref(BAZ)};
 
   std::unordered_map<
       std::reference_wrapper<const sourcemeta::core::WeakPointer>, int,
@@ -509,17 +509,17 @@ TEST(hash_reference_wrapper_unordered_map) {
   EXPECT_EQ(map.at(pointer_2), 2);
   EXPECT_EQ(map.at(pointer_3), 3);
 
-  const sourcemeta::core::WeakPointer lookup{std::cref(foo), std::cref(bar)};
+  const sourcemeta::core::WeakPointer lookup{std::cref(FOO), std::cref(BAR)};
   EXPECT_TRUE(map.contains(lookup));
   EXPECT_EQ(map.at(lookup), 1);
 
-  const sourcemeta::core::WeakPointer missing{std::cref(qux)};
+  const sourcemeta::core::WeakPointer missing{std::cref(QUX)};
   EXPECT_FALSE(map.contains(missing));
 }
 
 TEST(slice_from_zero) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
-                                              std::cref(baz)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR),
+                                              std::cref(BAZ)};
   const sourcemeta::core::WeakPointer result{pointer.slice(0)};
   EXPECT_EQ(result.size(), 3);
   EXPECT_TRUE(result.at(0).is_property());
@@ -531,8 +531,8 @@ TEST(slice_from_zero) {
 }
 
 TEST(slice_from_one) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
-                                              std::cref(baz)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR),
+                                              std::cref(BAZ)};
   const sourcemeta::core::WeakPointer result{pointer.slice(1)};
   EXPECT_EQ(result.size(), 2);
   EXPECT_TRUE(result.at(0).is_property());
@@ -542,8 +542,8 @@ TEST(slice_from_one) {
 }
 
 TEST(slice_from_two) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
-                                              std::cref(baz)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR),
+                                              std::cref(BAZ)};
   const sourcemeta::core::WeakPointer result{pointer.slice(2)};
   EXPECT_EQ(result.size(), 1);
   EXPECT_TRUE(result.at(0).is_property());
@@ -551,8 +551,8 @@ TEST(slice_from_two) {
 }
 
 TEST(slice_from_end) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
-                                              std::cref(baz)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR),
+                                              std::cref(BAZ)};
   const sourcemeta::core::WeakPointer result{pointer.slice(3)};
   EXPECT_EQ(result.size(), 0);
   EXPECT_TRUE(result.empty());
@@ -566,7 +566,7 @@ TEST(slice_empty_from_zero) {
 }
 
 TEST(slice_with_indices) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), 1, std::cref(bar),
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), 1, std::cref(BAR),
                                               2};
   const sourcemeta::core::WeakPointer result{pointer.slice(1)};
   EXPECT_EQ(result.size(), 3);
@@ -585,8 +585,8 @@ TEST(to_uri_empty) {
 }
 
 TEST(with_property_tokens) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
-                                              std::cref(baz)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR),
+                                              std::cref(BAZ)};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo/bar/baz");
 }
@@ -598,55 +598,55 @@ TEST(with_index_tokens) {
 }
 
 TEST(with_mixed_tokens) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), 1,
-                                              std::cref(bar)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), 1,
+                                              std::cref(BAR)};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo/1/bar");
 }
 
 TEST(with_absolute_base_uri) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR)};
   const sourcemeta::core::URI base{"https://www.example.com"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
   EXPECT_EQ(fragment.recompose(), "https://www.example.com#/foo/bar");
 }
 
 TEST(with_relative_base_uri) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR)};
   const sourcemeta::core::URI base{"../baz"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
   EXPECT_EQ(fragment.recompose(), "../baz#/foo/bar");
 }
 
 TEST(with_absolute_base_string_view) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR)};
   const std::string_view base{"https://www.example.com"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
   EXPECT_EQ(fragment.recompose(), "https://www.example.com#/foo/bar");
 }
 
 TEST(with_empty_base_string_view) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR)};
   const std::string_view base{""};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
   EXPECT_EQ(fragment.recompose(), "#/foo/bar");
 }
 
 TEST(with_relative_base_string_view) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO), std::cref(BAR)};
   const std::string_view base{"../baz"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
   EXPECT_EQ(fragment.recompose(), "../baz#/foo/bar");
 }
 
 TEST(single_property_token) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo)};
-  const sourcemeta::core::WeakPointer result{std::cref(foo), std::cref(bar)};
-  EXPECT_EQ(pointer.concat(std::cref(bar)), result);
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO)};
+  const sourcemeta::core::WeakPointer result{std::cref(FOO), std::cref(BAR)};
+  EXPECT_EQ(pointer.concat(std::cref(BAR)), result);
 }
 
 TEST(single_index_token) {
-  const sourcemeta::core::WeakPointer pointer{std::cref(foo)};
-  const sourcemeta::core::WeakPointer result{std::cref(foo), 1};
+  const sourcemeta::core::WeakPointer pointer{std::cref(FOO)};
+  const sourcemeta::core::WeakPointer result{std::cref(FOO), 1};
   EXPECT_EQ(pointer.concat(1), result);
 }

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -1832,11 +1832,11 @@ TEST(construct_from_float_high_precision) {
 }
 
 TEST(multithreaded_construction) {
-  constexpr int number_of_threads{4};
+  constexpr int NUMBER_OF_THREADS{4};
   std::vector<std::thread> threads;
-  threads.reserve(number_of_threads);
+  threads.reserve(NUMBER_OF_THREADS);
 
-  for (int index = 0; index < number_of_threads; index++) {
+  for (int index = 0; index < NUMBER_OF_THREADS; index++) {
     threads.emplace_back([]() {
       const sourcemeta::core::Decimal value{42};
       const sourcemeta::core::Decimal result{value +
@@ -3311,11 +3311,11 @@ TEST(compound_modulo_self_gives_zero) {
 }
 
 TEST(multithreaded_parsing) {
-  constexpr int number_of_threads{16};
+  constexpr int NUMBER_OF_THREADS{16};
   std::vector<std::thread> threads;
-  threads.reserve(number_of_threads);
+  threads.reserve(NUMBER_OF_THREADS);
 
-  for (int index = 0; index < number_of_threads; index++) {
+  for (int index = 0; index < NUMBER_OF_THREADS; index++) {
     threads.emplace_back([]() {
       const sourcemeta::core::Decimal value{"3.14159265358979"};
       EXPECT_FALSE(value.is_zero());
@@ -3329,11 +3329,11 @@ TEST(multithreaded_parsing) {
 }
 
 TEST(multithreaded_stringification) {
-  constexpr int number_of_threads{16};
+  constexpr int NUMBER_OF_THREADS{16};
   std::vector<std::thread> threads;
-  threads.reserve(number_of_threads);
+  threads.reserve(NUMBER_OF_THREADS);
 
-  for (int index = 0; index < number_of_threads; index++) {
+  for (int index = 0; index < NUMBER_OF_THREADS; index++) {
     threads.emplace_back([]() {
       const sourcemeta::core::Decimal value{12345};
       EXPECT_EQ(value.to_string(), "12345");
@@ -3346,11 +3346,11 @@ TEST(multithreaded_stringification) {
 }
 
 TEST(multithreaded_comparison) {
-  constexpr int number_of_threads{16};
+  constexpr int NUMBER_OF_THREADS{16};
   std::vector<std::thread> threads;
-  threads.reserve(number_of_threads);
+  threads.reserve(NUMBER_OF_THREADS);
 
-  for (int index = 0; index < number_of_threads; index++) {
+  for (int index = 0; index < NUMBER_OF_THREADS; index++) {
     threads.emplace_back([]() {
       const sourcemeta::core::Decimal left{100};
       const sourcemeta::core::Decimal right{200};
@@ -3366,11 +3366,11 @@ TEST(multithreaded_comparison) {
 }
 
 TEST(multithreaded_divisibility) {
-  constexpr int number_of_threads{16};
+  constexpr int NUMBER_OF_THREADS{16};
   std::vector<std::thread> threads;
-  threads.reserve(number_of_threads);
+  threads.reserve(NUMBER_OF_THREADS);
 
-  for (int index = 0; index < number_of_threads; index++) {
+  for (int index = 0; index < NUMBER_OF_THREADS; index++) {
     threads.emplace_back([]() {
       const sourcemeta::core::Decimal dividend{100};
       const sourcemeta::core::Decimal divisor{5};
@@ -3384,11 +3384,11 @@ TEST(multithreaded_divisibility) {
 }
 
 TEST(multithreaded_mixed_operations) {
-  constexpr int number_of_threads{16};
+  constexpr int NUMBER_OF_THREADS{16};
   std::vector<std::thread> threads;
-  threads.reserve(number_of_threads);
+  threads.reserve(NUMBER_OF_THREADS);
 
-  for (int index = 0; index < number_of_threads; index++) {
+  for (int index = 0; index < NUMBER_OF_THREADS; index++) {
     threads.emplace_back([index]() {
       if (index % 4 == 0) {
         EXPECT_EQ(sourcemeta::core::Decimal{10} + sourcemeta::core::Decimal{5},
@@ -3411,11 +3411,11 @@ TEST(multithreaded_mixed_operations) {
 }
 
 TEST(multithreaded_high_thread_count) {
-  constexpr int number_of_threads{32};
+  constexpr int NUMBER_OF_THREADS{32};
   std::vector<std::thread> threads;
-  threads.reserve(number_of_threads);
+  threads.reserve(NUMBER_OF_THREADS);
 
-  for (int index = 0; index < number_of_threads; index++) {
+  for (int index = 0; index < NUMBER_OF_THREADS; index++) {
     threads.emplace_back([]() {
       const sourcemeta::core::Decimal value{42};
       const sourcemeta::core::Decimal result{value +

--- a/test/oauth/oauth_bearer_test.cc
+++ b/test/oauth/oauth_bearer_test.cc
@@ -156,22 +156,22 @@ TEST(challenge_parameter_rejects_an_unterminated_quoted_string) {
 
 TEST(challenge_parameter_parses_the_rfc7235_example) {
   // RFC 7235 Section 4.1 example, adapted with the standard schemes
-  static constexpr std::string_view header{
+  static constexpr std::string_view HEADER{
       R"(Newauth realm="apps", type=1, title="Login", Basic realm="simple")"};
   EXPECT_EQ(
-      sourcemeta::core::oauth_challenge_parameter(header, "Newauth", "realm")
+      sourcemeta::core::oauth_challenge_parameter(HEADER, "Newauth", "realm")
           .value(),
       "apps");
   EXPECT_EQ(
-      sourcemeta::core::oauth_challenge_parameter(header, "Newauth", "type")
+      sourcemeta::core::oauth_challenge_parameter(HEADER, "Newauth", "type")
           .value(),
       "1");
   EXPECT_EQ(
-      sourcemeta::core::oauth_challenge_parameter(header, "Newauth", "title")
+      sourcemeta::core::oauth_challenge_parameter(HEADER, "Newauth", "title")
           .value(),
       "Login");
   EXPECT_EQ(
-      sourcemeta::core::oauth_challenge_parameter(header, "Basic", "realm")
+      sourcemeta::core::oauth_challenge_parameter(HEADER, "Basic", "realm")
           .value(),
       "simple");
 }

--- a/test/oauth/oauth_conformance_test.cc
+++ b/test/oauth/oauth_conformance_test.cc
@@ -155,9 +155,9 @@ TEST(conformance_pkce_mint_round_trips) {
 
 TEST(conformance_full_code_pkce_exchange) {
   // The client mints a PKCE pair and drives a code request through the server.
-  static constexpr std::string_view verifier{
+  static constexpr std::string_view VERIFIER{
       "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"};
-  const auto challenge{sourcemeta::core::oauth_pkce_challenge(verifier)};
+  const auto challenge{sourcemeta::core::oauth_pkce_challenge(VERIFIER)};
   const std::string_view challenge_view{challenge.data(), challenge.size()};
 
   sourcemeta::core::OAuthAuthorizationRequest authorization;
@@ -203,7 +203,7 @@ TEST(conformance_full_code_pkce_exchange) {
   const std::span<const sourcemeta::core::OAuthParameter> resources;
   sourcemeta::core::SecureString body;
   sourcemeta::core::oauth_build_token_request_code(
-      callback.code, "https://client.example/cb", verifier, resources, body);
+      callback.code, "https://client.example/cb", VERIFIER, resources, body);
   sourcemeta::core::SecureString header;
   sourcemeta::core::oauth_client_secret_basic("s6BhdRkqt3", "gX1fBat3bV",
                                               header);

--- a/test/oidc/oidc_hash_test.cc
+++ b/test/oidc/oidc_hash_test.cc
@@ -5,13 +5,13 @@
 
 // The reference access token and its hashes, from the coreos/go-oidc test
 // suite. The RS256 value is a Google-issued production value.
-static constexpr std::string_view reference_token{
+static constexpr std::string_view REFERENCE_TOKEN{
     "ya29.CjHSA1l5WUn8xZ6HanHFzzdHdbXm-"
     "14rxnC7JHch9eFIsZkQEGoWzaYG4o7k5f6BnPLj"};
 
 TEST(token_hash_rs256) {
   const auto hash{sourcemeta::core::oidc_token_hash(
-      reference_token, sourcemeta::core::JWSAlgorithm::RS256)};
+      REFERENCE_TOKEN, sourcemeta::core::JWSAlgorithm::RS256)};
   EXPECT_TRUE(hash.has_value());
   EXPECT_EQ(hash.value(), "piwt8oCH-K2D9pXlaS1Y-w");
 }
@@ -20,29 +20,29 @@ TEST(token_hash_rejects_eddsa) {
   // The correct digest for EdDSA depends on the signing curve, which the
   // algorithm alone does not convey, so it is rejected rather than guessed
   EXPECT_FALSE(sourcemeta::core::oidc_token_hash(
-                   reference_token, sourcemeta::core::JWSAlgorithm::EdDSA)
+                   REFERENCE_TOKEN, sourcemeta::core::JWSAlgorithm::EdDSA)
                    .has_value());
 }
 
 TEST(token_hash_es384) {
   const auto hash{sourcemeta::core::oidc_token_hash(
-      reference_token, sourcemeta::core::JWSAlgorithm::ES384)};
+      REFERENCE_TOKEN, sourcemeta::core::JWSAlgorithm::ES384)};
   EXPECT_TRUE(hash.has_value());
   EXPECT_EQ(hash.value(), "_ILKVQjbEzFKNJjUKC2kz9eReYi0A9Of");
 }
 
 TEST(token_hash_ps512) {
   const auto hash{sourcemeta::core::oidc_token_hash(
-      reference_token, sourcemeta::core::JWSAlgorithm::PS512)};
+      REFERENCE_TOKEN, sourcemeta::core::JWSAlgorithm::PS512)};
   EXPECT_TRUE(hash.has_value());
   EXPECT_EQ(hash.value(), "Spa_APgwBrarSeQbxI-rbragXho6dqFpH5x9PqaPfUI");
 }
 
 TEST(token_hash_es256_matches_rs256_by_digest) {
   const auto rs256{sourcemeta::core::oidc_token_hash(
-      reference_token, sourcemeta::core::JWSAlgorithm::RS256)};
+      REFERENCE_TOKEN, sourcemeta::core::JWSAlgorithm::RS256)};
   const auto es256{sourcemeta::core::oidc_token_hash(
-      reference_token, sourcemeta::core::JWSAlgorithm::ES256)};
+      REFERENCE_TOKEN, sourcemeta::core::JWSAlgorithm::ES256)};
   EXPECT_TRUE(rs256.has_value());
   EXPECT_TRUE(es256.has_value());
   EXPECT_EQ(rs256.value(), es256.value());
@@ -50,25 +50,25 @@ TEST(token_hash_es256_matches_rs256_by_digest) {
 
 TEST(verify_token_hash_accepts_a_matching_claim) {
   EXPECT_TRUE(sourcemeta::core::oidc_verify_token_hash(
-      reference_token, sourcemeta::core::JWSAlgorithm::RS256,
+      REFERENCE_TOKEN, sourcemeta::core::JWSAlgorithm::RS256,
       "piwt8oCH-K2D9pXlaS1Y-w"));
 }
 
 TEST(verify_token_hash_rejects_a_mismatched_claim) {
   EXPECT_FALSE(sourcemeta::core::oidc_verify_token_hash(
-      reference_token, sourcemeta::core::JWSAlgorithm::RS256,
+      REFERENCE_TOKEN, sourcemeta::core::JWSAlgorithm::RS256,
       "Spa_APgwBrarSeQbxI-rbragXho6dqFpH5x9PqaPfUI"));
 }
 
 TEST(verify_token_hash_rejects_a_wrong_algorithm) {
   EXPECT_FALSE(sourcemeta::core::oidc_verify_token_hash(
-      reference_token, sourcemeta::core::JWSAlgorithm::ES384,
+      REFERENCE_TOKEN, sourcemeta::core::JWSAlgorithm::ES384,
       "piwt8oCH-K2D9pXlaS1Y-w"));
 }
 
 TEST(verify_token_hash_rejects_an_empty_claim) {
   EXPECT_FALSE(sourcemeta::core::oidc_verify_token_hash(
-      reference_token, sourcemeta::core::JWSAlgorithm::RS256, ""));
+      REFERENCE_TOKEN, sourcemeta::core::JWSAlgorithm::RS256, ""));
 }
 
 TEST(token_hash_of_a_code_uses_the_same_function) {

--- a/test/oidc/oidc_id_token_test.cc
+++ b/test/oidc/oidc_id_token_test.cc
@@ -41,11 +41,11 @@ static auto sign_id_token(const std::string_view payload) -> std::string {
   return sign_id_token(sourcemeta::core::parse_json(payload));
 }
 
-static constexpr std::array<sourcemeta::core::JWSAlgorithm, 1> allowed_hs256{
+static constexpr std::array<sourcemeta::core::JWSAlgorithm, 1> ALLOWED_HS256{
     {sourcemeta::core::JWSAlgorithm::HS256}};
 
 // A fixed reference time, 2023-11-14T22:13:20Z
-static const auto reference_now{
+static const auto REFERENCE_NOW{
     std::chrono::system_clock::from_time_t(1700000000)};
 
 // The oldest whole second the clock can represent and a conversion still
@@ -87,8 +87,8 @@ TEST(mint_and_validate_round_trip) {
   claims.issuer = "https://issuer.example";
   claims.subject = "user-1";
   claims.audience = "client-id";
-  claims.issued_at = reference_now;
-  claims.expiration = reference_now + std::chrono::hours{1};
+  claims.issued_at = REFERENCE_NOW;
+  claims.expiration = REFERENCE_NOW + std::chrono::hours{1};
   claims.nonce = "n-abc";
   claims.access_token = "the-access-token";
   const auto compact{sourcemeta::core::oidc_mint_id_token(
@@ -102,8 +102,8 @@ TEST(mint_and_validate_round_trip) {
   sourcemeta::core::OIDCValidationOptions options;
   options.nonce = "n-abc";
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_TRUE(identity.has_value());
   EXPECT_EQ(identity.value().subject, "user-1");
   EXPECT_EQ(identity.value().issuer, "https://issuer.example");
@@ -114,8 +114,8 @@ TEST(mint_rejects_a_code_binding_under_eddsa) {
   claims.issuer = "https://issuer.example";
   claims.subject = "user-1";
   claims.audience = "client-id";
-  claims.issued_at = reference_now;
-  claims.expiration = reference_now + std::chrono::hours{1};
+  claims.issued_at = REFERENCE_NOW;
+  claims.expiration = REFERENCE_NOW + std::chrono::hours{1};
   claims.nonce = "n-abc";
   claims.code = "the-authorization-code";
   // EdDSA has no defined c_hash digest, so minting fails rather than emitting a
@@ -130,8 +130,8 @@ TEST(mint_rejects_an_access_token_binding_under_eddsa) {
   claims.issuer = "https://issuer.example";
   claims.subject = "user-1";
   claims.audience = "client-id";
-  claims.issued_at = reference_now;
-  claims.expiration = reference_now + std::chrono::hours{1};
+  claims.issued_at = REFERENCE_NOW;
+  claims.expiration = REFERENCE_NOW + std::chrono::hours{1};
   claims.nonce = "n-abc";
   claims.access_token = "the-access-token";
   const auto compact{sourcemeta::core::oidc_mint_id_token(
@@ -150,8 +150,8 @@ TEST(validate_rejects_an_expired_token) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now + std::chrono::hours{2})};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW + std::chrono::hours{2})};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -166,8 +166,8 @@ TEST(validate_rejects_a_wrong_issuer) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://attacker.example",
-      "client-id", reference_now)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://attacker.example",
+      "client-id", REFERENCE_NOW)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -182,8 +182,8 @@ TEST(validate_rejects_a_wrong_audience) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "other-client", reference_now)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "other-client", REFERENCE_NOW)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -197,8 +197,8 @@ TEST(validate_rejects_a_missing_subject) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -212,8 +212,8 @@ TEST(validate_rejects_a_missing_iat) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -229,8 +229,8 @@ TEST(validate_rejects_a_malformed_audience_array) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -248,8 +248,8 @@ TEST(validate_rejects_a_mismatched_nonce) {
   sourcemeta::core::OIDCValidationOptions options;
   options.nonce = "n-wrong";
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -266,8 +266,8 @@ TEST(validate_rejects_a_missing_nonce_when_one_was_sent) {
   sourcemeta::core::OIDCValidationOptions options;
   options.nonce = "n-abc";
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -285,8 +285,8 @@ TEST(validate_echoes_a_matching_nonce) {
   sourcemeta::core::OIDCValidationOptions options;
   options.nonce = "n-abc";
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_TRUE(identity.has_value());
   EXPECT_EQ(identity.value().subject, "user-1");
 }
@@ -305,8 +305,8 @@ TEST(validate_rejects_an_untrusted_additional_audience) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -325,8 +325,8 @@ TEST(validate_accepts_a_trusted_additional_audience_with_matching_azp) {
   sourcemeta::core::OIDCValidationOptions options;
   options.trusted_audiences = trusted;
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_TRUE(identity.has_value());
   EXPECT_EQ(identity.value().subject, "user-1");
 }
@@ -347,8 +347,8 @@ TEST(validate_rejects_a_trusted_additional_audience_without_azp) {
   sourcemeta::core::OIDCValidationOptions options;
   options.trusted_audiences = trusted;
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -365,8 +365,8 @@ TEST(validate_accepts_a_single_audience_under_an_empty_trusted_set) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW)};
   EXPECT_TRUE(identity.has_value());
   EXPECT_EQ(identity.value().subject, "user-1");
 }
@@ -382,8 +382,8 @@ TEST(validate_rejects_a_multi_audience_token_without_azp) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -399,8 +399,8 @@ TEST(validate_rejects_a_mismatched_azp) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -419,15 +419,15 @@ TEST(validate_enforces_an_acceptable_acr) {
   sourcemeta::core::OIDCValidationOptions options;
   options.acceptable_authentication_context_classes = acceptable;
   const auto rejected{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(rejected.has_value());
 
   const std::array<std::string_view, 2> allowed_classes{{"silver", "gold"}};
   options.acceptable_authentication_context_classes = allowed_classes;
   const auto accepted{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_TRUE(accepted.has_value());
   EXPECT_EQ(accepted.value().authentication_context_class.value(), "silver");
 }
@@ -446,14 +446,14 @@ TEST(validate_enforces_the_maximum_authentication_age) {
   sourcemeta::core::OIDCValidationOptions options;
   options.maximum_authentication_age = std::chrono::minutes{5};
   const auto rejected{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(rejected.has_value());
 
   options.maximum_authentication_age = std::chrono::hours{2};
   const auto accepted{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_TRUE(accepted.has_value());
 }
 
@@ -471,8 +471,8 @@ TEST(validate_accepts_a_fractional_auth_time) {
   sourcemeta::core::OIDCValidationOptions options;
   options.maximum_authentication_age = std::chrono::hours{2};
   const auto accepted{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_TRUE(accepted.has_value());
 }
 
@@ -490,8 +490,8 @@ TEST(validate_rejects_a_future_auth_time) {
   sourcemeta::core::OIDCValidationOptions options;
   options.maximum_authentication_age = std::chrono::hours{2};
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -502,14 +502,14 @@ TEST(validate_enforces_the_maximum_issued_at_age) {
   sourcemeta::core::OIDCValidationOptions options;
   options.maximum_issued_at_age = std::chrono::minutes{5};
   const auto rejected{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(rejected.has_value());
 
   options.maximum_issued_at_age = std::chrono::hours{2};
   const auto accepted{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_TRUE(accepted.has_value());
 }
 
@@ -520,14 +520,14 @@ TEST(validate_accepts_an_issued_at_exactly_at_the_age_boundary) {
   sourcemeta::core::OIDCValidationOptions options;
   options.maximum_issued_at_age = std::chrono::seconds{3600};
   const auto accepted{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_TRUE(accepted.has_value());
 
   options.maximum_issued_at_age = std::chrono::seconds{3599};
   const auto rejected{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(rejected.has_value());
 }
 
@@ -542,8 +542,8 @@ TEST(validate_rejects_an_issued_at_near_the_representable_bound) {
   sourcemeta::core::OIDCValidationOptions options;
   options.maximum_issued_at_age = std::chrono::minutes{5};
   const auto rejected{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(rejected.has_value());
 }
 
@@ -555,8 +555,8 @@ TEST(validate_rejects_an_auth_time_near_the_representable_bound) {
   sourcemeta::core::OIDCValidationOptions options;
   options.maximum_authentication_age = std::chrono::minutes{5};
   const auto rejected{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(rejected.has_value());
 }
 
@@ -569,8 +569,8 @@ TEST(validate_accepts_a_recent_issued_at_under_an_unbounded_age) {
   sourcemeta::core::OIDCValidationOptions options;
   options.maximum_issued_at_age = std::chrono::seconds::max();
   const auto accepted{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_TRUE(accepted.has_value());
 }
 
@@ -585,8 +585,8 @@ TEST(validate_rejects_an_ancient_issued_at_under_an_unbounded_age) {
   sourcemeta::core::OIDCValidationOptions options;
   options.maximum_issued_at_age = std::chrono::seconds::max();
   const auto rejected{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(rejected.has_value());
 }
 
@@ -599,8 +599,8 @@ TEST(validate_rejects_a_stale_issued_at_under_a_negative_age) {
   sourcemeta::core::OIDCValidationOptions options;
   options.maximum_issued_at_age = std::chrono::seconds::min();
   const auto rejected{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(rejected.has_value());
 }
 
@@ -618,7 +618,7 @@ TEST(validate_rejects_an_algorithm_outside_the_allow_list) {
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const auto identity{sourcemeta::core::oidc_validate_id_token(
       token.value(), oct_key_set(), only_rs256, "https://issuer.example",
-      "client-id", reference_now)};
+      "client-id", REFERENCE_NOW)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -627,8 +627,8 @@ TEST(validate_enforces_the_access_token_hash) {
   claims.issuer = "https://issuer.example";
   claims.subject = "user-1";
   claims.audience = "client-id";
-  claims.issued_at = reference_now;
-  claims.expiration = reference_now + std::chrono::hours{1};
+  claims.issued_at = REFERENCE_NOW;
+  claims.expiration = REFERENCE_NOW + std::chrono::hours{1};
   claims.access_token = "the-access-token";
   const auto compact{sourcemeta::core::oidc_mint_id_token(
       claims, oct_private_key(), sourcemeta::core::JWSAlgorithm::HS256)};
@@ -638,15 +638,15 @@ TEST(validate_enforces_the_access_token_hash) {
   sourcemeta::core::OIDCValidationOptions matching;
   matching.access_token = "the-access-token";
   const auto accepted{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, matching)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, matching)};
   EXPECT_TRUE(accepted.has_value());
 
   sourcemeta::core::OIDCValidationOptions mismatched;
   mismatched.access_token = "the-wrong-access-token";
   const auto rejected{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, mismatched)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, mismatched)};
   EXPECT_FALSE(rejected.has_value());
 }
 
@@ -664,8 +664,8 @@ TEST(validate_requires_the_access_token_hash_when_configured) {
   options.access_token = "the-access-token";
   options.require_access_token_hash = true;
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -674,8 +674,8 @@ TEST(validate_accepts_a_required_access_token_hash_when_present) {
   claims.issuer = "https://issuer.example";
   claims.subject = "user-1";
   claims.audience = "client-id";
-  claims.issued_at = reference_now;
-  claims.expiration = reference_now + std::chrono::hours{1};
+  claims.issued_at = REFERENCE_NOW;
+  claims.expiration = REFERENCE_NOW + std::chrono::hours{1};
   claims.access_token = "the-access-token";
   const auto compact{sourcemeta::core::oidc_mint_id_token(
       claims, oct_private_key(), sourcemeta::core::JWSAlgorithm::HS256)};
@@ -686,8 +686,8 @@ TEST(validate_accepts_a_required_access_token_hash_when_present) {
   options.access_token = "the-access-token";
   options.require_access_token_hash = true;
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_TRUE(identity.has_value());
 }
 
@@ -696,8 +696,8 @@ TEST(validate_rejects_a_required_access_token_hash_without_the_token) {
   claims.issuer = "https://issuer.example";
   claims.subject = "user-1";
   claims.audience = "client-id";
-  claims.issued_at = reference_now;
-  claims.expiration = reference_now + std::chrono::hours{1};
+  claims.issued_at = REFERENCE_NOW;
+  claims.expiration = REFERENCE_NOW + std::chrono::hours{1};
   claims.access_token = "the-access-token";
   const auto compact{sourcemeta::core::oidc_mint_id_token(
       claims, oct_private_key(), sourcemeta::core::JWSAlgorithm::HS256)};
@@ -710,8 +710,8 @@ TEST(validate_rejects_a_required_access_token_hash_without_the_token) {
   sourcemeta::core::OIDCValidationOptions options;
   options.require_access_token_hash = true;
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -720,8 +720,8 @@ TEST(validate_enforces_the_code_hash) {
   claims.issuer = "https://issuer.example";
   claims.subject = "user-1";
   claims.audience = "client-id";
-  claims.issued_at = reference_now;
-  claims.expiration = reference_now + std::chrono::hours{1};
+  claims.issued_at = REFERENCE_NOW;
+  claims.expiration = REFERENCE_NOW + std::chrono::hours{1};
   claims.code = "the-authorization-code";
   const auto compact{sourcemeta::core::oidc_mint_id_token(
       claims, oct_private_key(), sourcemeta::core::JWSAlgorithm::HS256)};
@@ -731,8 +731,8 @@ TEST(validate_enforces_the_code_hash) {
   sourcemeta::core::OIDCValidationOptions mismatched;
   mismatched.code = "the-wrong-code";
   const auto rejected{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, mismatched)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, mismatched)};
   EXPECT_FALSE(rejected.has_value());
 }
 
@@ -750,8 +750,8 @@ TEST(validate_requires_the_code_hash_when_configured) {
   options.code = "the-authorization-code";
   options.require_code_hash = true;
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -760,8 +760,8 @@ TEST(validate_rejects_a_required_code_hash_without_the_code) {
   claims.issuer = "https://issuer.example";
   claims.subject = "user-1";
   claims.audience = "client-id";
-  claims.issued_at = reference_now;
-  claims.expiration = reference_now + std::chrono::hours{1};
+  claims.issued_at = REFERENCE_NOW;
+  claims.expiration = REFERENCE_NOW + std::chrono::hours{1};
   claims.code = "the-authorization-code";
   const auto compact{sourcemeta::core::oidc_mint_id_token(
       claims, oct_private_key(), sourcemeta::core::JWSAlgorithm::HS256)};
@@ -774,8 +774,8 @@ TEST(validate_rejects_a_required_code_hash_without_the_code) {
   sourcemeta::core::OIDCValidationOptions options;
   options.require_code_hash = true;
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -810,8 +810,8 @@ TEST(mint_embeds_a_code_hash) {
   claims.issuer = "https://issuer.example";
   claims.subject = "user-1";
   claims.audience = "client-id";
-  claims.issued_at = reference_now;
-  claims.expiration = reference_now + std::chrono::hours{1};
+  claims.issued_at = REFERENCE_NOW;
+  claims.expiration = REFERENCE_NOW + std::chrono::hours{1};
   claims.code = "the-authorization-code";
   const auto compact{sourcemeta::core::oidc_mint_id_token(
       claims, oct_private_key(), sourcemeta::core::JWSAlgorithm::HS256)};
@@ -841,11 +841,11 @@ TEST(mint_emits_optional_claims) {
   claims.issuer = "https://issuer.example";
   claims.subject = "user-1";
   claims.audience = "client-id";
-  claims.issued_at = reference_now;
-  claims.expiration = reference_now + std::chrono::hours{1};
+  claims.issued_at = REFERENCE_NOW;
+  claims.expiration = REFERENCE_NOW + std::chrono::hours{1};
   claims.authorized_party = "client-id";
   claims.authentication_context_class = "urn:mace:incommon:iap:silver";
-  claims.authentication_time = reference_now - std::chrono::minutes{5};
+  claims.authentication_time = REFERENCE_NOW - std::chrono::minutes{5};
   const auto compact{sourcemeta::core::oidc_mint_id_token(
       claims, oct_private_key(), sourcemeta::core::JWSAlgorithm::HS256)};
   EXPECT_TRUE(compact.has_value());
@@ -872,8 +872,8 @@ TEST(validate_rejects_a_missing_acr_when_a_set_was_requested) {
   const std::array<std::string_view, 1> classes{{"urn:example:gold"}};
   options.acceptable_authentication_context_classes = classes;
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(identity.has_value());
 }
 
@@ -891,7 +891,7 @@ TEST(validate_treats_an_overflowing_auth_time_as_absent) {
   sourcemeta::core::OIDCValidationOptions options;
   options.maximum_authentication_age = std::chrono::seconds{60};
   const auto identity{sourcemeta::core::oidc_validate_id_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, options)};
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, options)};
   EXPECT_FALSE(identity.has_value());
 }

--- a/test/oidc/oidc_logout_test.cc
+++ b/test/oidc/oidc_logout_test.cc
@@ -39,10 +39,10 @@ static auto sign_logout_token(const std::string_view header,
   return sign_logout_token(header, sourcemeta::core::parse_json(payload));
 }
 
-static constexpr std::array<sourcemeta::core::JWSAlgorithm, 1> allowed_hs256{
+static constexpr std::array<sourcemeta::core::JWSAlgorithm, 1> ALLOWED_HS256{
     {sourcemeta::core::JWSAlgorithm::HS256}};
 
-static const auto reference_now{
+static const auto REFERENCE_NOW{
     std::chrono::system_clock::from_time_t(1700000000)};
 
 static constexpr std::string_view VALID_HEADER{R"JSON({
@@ -108,8 +108,8 @@ TEST(validate_logout_token_accepts_a_valid_token) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_a_wrong_typ) {
@@ -121,8 +121,8 @@ TEST(validate_logout_token_rejects_a_wrong_typ) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_accepts_a_missing_typ) {
@@ -133,8 +133,8 @@ TEST(validate_logout_token_accepts_a_missing_typ) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_accepts_a_mixed_case_typ) {
@@ -146,8 +146,8 @@ TEST(validate_logout_token_accepts_a_mixed_case_typ) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_an_unknown_kid) {
@@ -160,8 +160,8 @@ TEST(validate_logout_token_rejects_an_unknown_kid) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_a_nonce) {
@@ -180,8 +180,8 @@ TEST(validate_logout_token_rejects_a_nonce) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_a_missing_events) {
@@ -196,8 +196,8 @@ TEST(validate_logout_token_rejects_a_missing_events) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_a_missing_subject_and_session) {
@@ -214,8 +214,8 @@ TEST(validate_logout_token_rejects_a_missing_subject_and_session) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_a_missing_jti) {
@@ -232,8 +232,8 @@ TEST(validate_logout_token_rejects_a_missing_jti) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_a_wrong_issuer) {
@@ -241,8 +241,8 @@ TEST(validate_logout_token_rejects_a_wrong_issuer) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://attacker.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://attacker.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_a_missing_exp) {
@@ -259,8 +259,8 @@ TEST(validate_logout_token_rejects_a_missing_exp) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_an_expired_token) {
@@ -278,8 +278,8 @@ TEST(validate_logout_token_rejects_an_expired_token) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_an_exp_at_the_boundary) {
@@ -297,8 +297,8 @@ TEST(validate_logout_token_rejects_an_exp_at_the_boundary) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_accepts_an_exp_near_the_representable_bound) {
@@ -309,8 +309,8 @@ TEST(validate_logout_token_accepts_an_exp_near_the_representable_bound) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, std::chrono::seconds{60}));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, std::chrono::seconds{60}));
 }
 
 TEST(validate_logout_token_accepts_an_exp_near_the_bound_without_skew) {
@@ -319,8 +319,8 @@ TEST(validate_logout_token_accepts_an_exp_near_the_bound_without_skew) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_an_expired_token_under_a_skew) {
@@ -338,12 +338,12 @@ TEST(validate_logout_token_rejects_an_expired_token_under_a_skew) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, std::chrono::seconds{60}));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, std::chrono::seconds{60}));
   // The same token is inside the window once the tolerance covers the gap
   EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, std::chrono::seconds{2000}));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, std::chrono::seconds{2000}));
 }
 
 TEST(validate_logout_token_rejects_a_future_iat_beyond_the_skew) {
@@ -361,11 +361,11 @@ TEST(validate_logout_token_rejects_a_future_iat_beyond_the_skew) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, std::chrono::seconds{60}));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, std::chrono::seconds{60}));
   EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, std::chrono::seconds{2000}));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, std::chrono::seconds{2000}));
 }
 
 TEST(validate_logout_token_tolerates_a_saturating_skew) {
@@ -383,8 +383,8 @@ TEST(validate_logout_token_tolerates_a_saturating_skew) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, std::chrono::seconds::max()));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, std::chrono::seconds::max()));
 }
 
 TEST(validate_logout_token_rejects_a_non_string_subject) {
@@ -402,8 +402,8 @@ TEST(validate_logout_token_rejects_a_non_string_subject) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_a_non_string_session) {
@@ -421,8 +421,8 @@ TEST(validate_logout_token_rejects_a_non_string_session) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(validate_logout_token_rejects_a_non_string_jti) {
@@ -440,8 +440,8 @@ TEST(validate_logout_token_rejects_a_non_string_jti) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }
 
 TEST(build_logout_url_without_parameters_leaves_the_endpoint_untouched) {
@@ -512,11 +512,11 @@ TEST(validate_logout_token_bounds_the_clock_skew_like_the_base_check) {
   const std::chrono::seconds two_years{63113904};
   EXPECT_TRUE(sourcemeta::core::jwt_check_claims(
                   token.value(), "https://issuer.example", "client-id",
-                  reference_now, two_years)
+                  REFERENCE_NOW, two_years)
                   .has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now, two_years));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW, two_years));
 }
 
 TEST(validate_logout_token_rejects_a_future_nbf) {
@@ -537,6 +537,6 @@ TEST(validate_logout_token_rejects_a_future_nbf) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
-      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
-      "client-id", reference_now));
+      token.value(), oct_key_set(), ALLOWED_HS256, "https://issuer.example",
+      "client-id", REFERENCE_NOW));
 }

--- a/test/oidc/oidc_request_object_test.cc
+++ b/test/oidc/oidc_request_object_test.cc
@@ -27,7 +27,7 @@ static auto oct_key_set() -> sourcemeta::core::JWKS {
   return sourcemeta::core::JWKS::from(std::move(document)).value();
 }
 
-static constexpr std::array<sourcemeta::core::JWSAlgorithm, 1> allowed_hs256{
+static constexpr std::array<sourcemeta::core::JWSAlgorithm, 1> ALLOWED_HS256{
     {sourcemeta::core::JWSAlgorithm::HS256}};
 
 TEST(pairing_is_valid_for_at_most_one) {
@@ -55,7 +55,7 @@ TEST(build_and_verify_round_trip) {
   const auto token{sourcemeta::core::JWT::from(object.value())};
   EXPECT_TRUE(token.has_value());
   const auto verified{sourcemeta::core::oidc_verify_request_object(
-      token.value(), oct_key_set(), allowed_hs256, "client",
+      token.value(), oct_key_set(), ALLOWED_HS256, "client",
       "https://op.example")};
   EXPECT_TRUE(verified.has_value());
   EXPECT_EQ(verified.value().at("state").to_string(), "xyz");
@@ -73,7 +73,7 @@ TEST(verify_rejects_a_wrong_issuer) {
   const auto token{sourcemeta::core::JWT::from(object.value())};
   EXPECT_TRUE(token.has_value());
   const auto verified{sourcemeta::core::oidc_verify_request_object(
-      token.value(), oct_key_set(), allowed_hs256, "client",
+      token.value(), oct_key_set(), ALLOWED_HS256, "client",
       "https://op.example")};
   EXPECT_FALSE(verified.has_value());
 }
@@ -90,7 +90,7 @@ TEST(verify_rejects_a_wrong_audience) {
   const auto token{sourcemeta::core::JWT::from(object.value())};
   EXPECT_TRUE(token.has_value());
   const auto verified{sourcemeta::core::oidc_verify_request_object(
-      token.value(), oct_key_set(), allowed_hs256, "client",
+      token.value(), oct_key_set(), ALLOWED_HS256, "client",
       "https://op.example")};
   EXPECT_FALSE(verified.has_value());
 }
@@ -109,7 +109,7 @@ TEST(verify_accepts_a_missing_issuer) {
   const auto token{sourcemeta::core::JWT::from(object.value())};
   EXPECT_TRUE(token.has_value());
   const auto verified{sourcemeta::core::oidc_verify_request_object(
-      token.value(), oct_key_set(), allowed_hs256, "client",
+      token.value(), oct_key_set(), ALLOWED_HS256, "client",
       "https://op.example")};
   EXPECT_TRUE(verified.has_value());
   EXPECT_EQ(verified.value().at("state").to_string(), "xyz");
@@ -130,7 +130,7 @@ TEST(verify_rejects_a_missing_audience) {
   const auto token{sourcemeta::core::JWT::from(object.value())};
   EXPECT_TRUE(token.has_value());
   const auto verified{sourcemeta::core::oidc_verify_request_object(
-      token.value(), oct_key_set(), allowed_hs256, "client",
+      token.value(), oct_key_set(), ALLOWED_HS256, "client",
       "https://op.example")};
   EXPECT_FALSE(verified.has_value());
 }
@@ -146,7 +146,7 @@ TEST(verify_rejects_a_missing_issuer_and_audience) {
   const auto token{sourcemeta::core::JWT::from(object.value())};
   EXPECT_TRUE(token.has_value());
   const auto verified{sourcemeta::core::oidc_verify_request_object(
-      token.value(), oct_key_set(), allowed_hs256, "client",
+      token.value(), oct_key_set(), ALLOWED_HS256, "client",
       "https://op.example")};
   EXPECT_FALSE(verified.has_value());
 }
@@ -166,7 +166,7 @@ TEST(verify_rejects_an_unknown_kid) {
   const auto token{sourcemeta::core::JWT::from(object.value())};
   EXPECT_TRUE(token.has_value());
   const auto verified{sourcemeta::core::oidc_verify_request_object(
-      token.value(), oct_key_set(), allowed_hs256, "client",
+      token.value(), oct_key_set(), ALLOWED_HS256, "client",
       "https://op.example")};
   EXPECT_FALSE(verified.has_value());
 }

--- a/test/oidc/oidc_userinfo_test.cc
+++ b/test/oidc/oidc_userinfo_test.cc
@@ -31,7 +31,7 @@ static auto sign_userinfo(const std::string_view payload) -> std::string {
       .value();
 }
 
-static constexpr std::array<sourcemeta::core::JWSAlgorithm, 1> allowed_hs256{
+static constexpr std::array<sourcemeta::core::JWSAlgorithm, 1> ALLOWED_HS256{
     {sourcemeta::core::JWSAlgorithm::HS256}};
 
 TEST(build_userinfo_ensures_the_subject) {
@@ -81,7 +81,7 @@ TEST(verify_userinfo_accepts_a_valid_signed_response) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto claims{sourcemeta::core::oidc_verify_userinfo(
-      token.value(), oct_key_set(), allowed_hs256, "user-1",
+      token.value(), oct_key_set(), ALLOWED_HS256, "user-1",
       "https://issuer.example", "client-id")};
   EXPECT_TRUE(claims.has_value());
   EXPECT_EQ(claims.value().at("email").to_string(), "a@b.example");
@@ -95,7 +95,7 @@ TEST(verify_userinfo_rejects_a_missing_issuer) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto claims{sourcemeta::core::oidc_verify_userinfo(
-      token.value(), oct_key_set(), allowed_hs256, "user-1",
+      token.value(), oct_key_set(), ALLOWED_HS256, "user-1",
       "https://issuer.example", "client-id")};
   EXPECT_FALSE(claims.has_value());
 }
@@ -108,7 +108,7 @@ TEST(verify_userinfo_rejects_a_missing_audience) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto claims{sourcemeta::core::oidc_verify_userinfo(
-      token.value(), oct_key_set(), allowed_hs256, "user-1",
+      token.value(), oct_key_set(), ALLOWED_HS256, "user-1",
       "https://issuer.example", "client-id")};
   EXPECT_FALSE(claims.has_value());
 }
@@ -119,7 +119,7 @@ TEST(verify_userinfo_rejects_a_missing_issuer_and_audience) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto claims{sourcemeta::core::oidc_verify_userinfo(
-      token.value(), oct_key_set(), allowed_hs256, "user-1",
+      token.value(), oct_key_set(), ALLOWED_HS256, "user-1",
       "https://issuer.example", "client-id")};
   EXPECT_FALSE(claims.has_value());
 }
@@ -129,7 +129,7 @@ TEST(verify_userinfo_rejects_a_substituted_subject) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto claims{sourcemeta::core::oidc_verify_userinfo(
-      token.value(), oct_key_set(), allowed_hs256, "user-1",
+      token.value(), oct_key_set(), ALLOWED_HS256, "user-1",
       "https://issuer.example", "client-id")};
   EXPECT_FALSE(claims.has_value());
 }
@@ -146,7 +146,7 @@ TEST(verify_userinfo_rejects_an_unknown_kid) {
   const auto token{sourcemeta::core::JWT::from(compact.value())};
   EXPECT_TRUE(token.has_value());
   const auto claims{sourcemeta::core::oidc_verify_userinfo(
-      token.value(), oct_key_set(), allowed_hs256, "user-1",
+      token.value(), oct_key_set(), ALLOWED_HS256, "user-1",
       "https://issuer.example", "client-id")};
   EXPECT_FALSE(claims.has_value());
 }
@@ -172,7 +172,7 @@ TEST(verify_userinfo_accepts_a_matching_issuer_and_audience) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto claims{sourcemeta::core::oidc_verify_userinfo(
-      token.value(), oct_key_set(), allowed_hs256, "user-1",
+      token.value(), oct_key_set(), ALLOWED_HS256, "user-1",
       "https://issuer.example", "client-id")};
   EXPECT_TRUE(claims.has_value());
 }
@@ -186,7 +186,7 @@ TEST(verify_userinfo_accepts_an_audience_array_containing_the_client) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto claims{sourcemeta::core::oidc_verify_userinfo(
-      token.value(), oct_key_set(), allowed_hs256, "user-1",
+      token.value(), oct_key_set(), ALLOWED_HS256, "user-1",
       "https://issuer.example", "client-id")};
   EXPECT_TRUE(claims.has_value());
 }
@@ -200,7 +200,7 @@ TEST(verify_userinfo_rejects_a_wrong_issuer) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto claims{sourcemeta::core::oidc_verify_userinfo(
-      token.value(), oct_key_set(), allowed_hs256, "user-1",
+      token.value(), oct_key_set(), ALLOWED_HS256, "user-1",
       "https://issuer.example", "client-id")};
   EXPECT_FALSE(claims.has_value());
 }
@@ -214,7 +214,7 @@ TEST(verify_userinfo_rejects_a_non_string_issuer) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto claims{sourcemeta::core::oidc_verify_userinfo(
-      token.value(), oct_key_set(), allowed_hs256, "user-1",
+      token.value(), oct_key_set(), ALLOWED_HS256, "user-1",
       "https://issuer.example", "client-id")};
   EXPECT_FALSE(claims.has_value());
 }
@@ -228,7 +228,7 @@ TEST(verify_userinfo_rejects_an_audience_for_another_client) {
   const auto token{sourcemeta::core::JWT::from(compact)};
   EXPECT_TRUE(token.has_value());
   const auto claims{sourcemeta::core::oidc_verify_userinfo(
-      token.value(), oct_key_set(), allowed_hs256, "user-1",
+      token.value(), oct_key_set(), ALLOWED_HS256, "user-1",
       "https://issuer.example", "client-id")};
   EXPECT_FALSE(claims.has_value());
 }

--- a/test/test/framework/test_dynamic.cc
+++ b/test/test/framework/test_dynamic.cc
@@ -13,9 +13,9 @@ auto expect_length(const std::string_view value, const std::size_t length)
 } // namespace
 
 auto main(int argc, char **argv) -> int {
-  constexpr std::array<std::string_view, 3> values{{"a", "bb", "ccc"}};
+  constexpr std::array<std::string_view, 3> VALUES{{"a", "bb", "ccc"}};
   std::size_t index{0};
-  for (const std::string_view value : values) {
+  for (const std::string_view value : VALUES) {
     index += 1;
     sourcemeta::core::test_register(
         "length_" + std::to_string(index),

--- a/test/test/framework/test_fixture.cc
+++ b/test/test/framework/test_fixture.cc
@@ -2,21 +2,21 @@
 
 namespace {
 int live_instances{0};
-}
+} // namespace
 
 class ExampleFixture {
 protected:
   ExampleFixture() { live_instances += 1; }
   ~ExampleFixture() { live_instances -= 1; }
-  int value{42};
+  int value_{42};
 };
 
 TEST_F(ExampleFixture, sees_constructed_member) {
-  EXPECT_EQ(this->value, 42);
+  EXPECT_EQ(this->value_, 42);
   EXPECT_EQ(live_instances, 1);
 }
 
 TEST_F(ExampleFixture, teardown_runs_between_tests) {
-  EXPECT_EQ(this->value, 42);
+  EXPECT_EQ(this->value_, 42);
   EXPECT_EQ(live_instances, 1);
 }

--- a/test/text/text_digits_test.cc
+++ b/test/text/text_digits_test.cc
@@ -12,18 +12,18 @@ namespace {
 // Each capacity is exactly the length of the longest spelling of its type:
 // "255", "-128", "4294967295", "-2147483648", "18446744073709551615" and
 // "-9223372036854775808" respectively
-static_assert(sourcemeta::core::digits_capacity<std::uint8_t> == 3);
-static_assert(sourcemeta::core::digits_capacity<std::int8_t> == 4);
-static_assert(sourcemeta::core::digits_capacity<std::uint32_t> == 10);
-static_assert(sourcemeta::core::digits_capacity<std::int32_t> == 11);
-static_assert(sourcemeta::core::digits_capacity<std::uint64_t> == 20);
-static_assert(sourcemeta::core::digits_capacity<std::int64_t> == 20);
+static_assert(sourcemeta::core::DIGITS_CAPACITY<std::uint8_t> == 3);
+static_assert(sourcemeta::core::DIGITS_CAPACITY<std::int8_t> == 4);
+static_assert(sourcemeta::core::DIGITS_CAPACITY<std::uint32_t> == 10);
+static_assert(sourcemeta::core::DIGITS_CAPACITY<std::int32_t> == 11);
+static_assert(sourcemeta::core::DIGITS_CAPACITY<std::uint64_t> == 20);
+static_assert(sourcemeta::core::DIGITS_CAPACITY<std::int64_t> == 20);
 static_assert(std::tuple_size_v<sourcemeta::core::DigitsBuffer> == 20);
 
 } // namespace
 
 TEST(digits_view_accepts_a_buffer_sized_for_a_narrower_type) {
-  std::array<char, sourcemeta::core::digits_capacity<std::uint8_t>> buffer;
+  std::array<char, sourcemeta::core::DIGITS_CAPACITY<std::uint8_t>> buffer;
   EXPECT_EQ(sourcemeta::core::digits_view(std::uint8_t{255}, buffer), "255");
 }
 

--- a/test/text/text_join_test.cc
+++ b/test/text/text_join_test.cc
@@ -42,8 +42,8 @@ TEST(a_line_terminator_as_the_separator) {
 }
 
 TEST(an_array_of_views) {
-  constexpr std::array<std::string_view, 3> items{{"a", "b", "c"}};
-  EXPECT_EQ(sourcemeta::core::join(items, ", "), "a, b, c");
+  constexpr std::array<std::string_view, 3> ITEMS{{"a", "b", "c"}};
+  EXPECT_EQ(sourcemeta::core::join(ITEMS, ", "), "a, b, c");
 }
 
 TEST(a_vector_of_strings) {

--- a/test/time/rfc3339_duration_test.cc
+++ b/test/time/rfc3339_duration_test.cc
@@ -1089,17 +1089,17 @@ TEST(ext_invalid_garbage_8) {
 }
 
 TEST(delta_u0000_u0050_day_0) {
-  static constexpr char value[] = "\x00P1D";
-  static_assert(sizeof(value) - 1 == 4);
+  static constexpr char VALUE[] = "\x00P1D";
+  static_assert(sizeof(VALUE) - 1 == 4);
   EXPECT_FALSE(
-      sourcemeta::core::is_rfc3339_duration(std::string_view{value, 4}));
+      sourcemeta::core::is_rfc3339_duration(std::string_view{VALUE, 4}));
 }
 
 TEST(delta_u0000_u0050_day_u0000_1) {
-  static constexpr char value[] = "\x00P1D\x00";
-  static_assert(sizeof(value) - 1 == 5);
+  static constexpr char VALUE[] = "\x00P1D\x00";
+  static_assert(sizeof(VALUE) - 1 == 5);
   EXPECT_FALSE(
-      sourcemeta::core::is_rfc3339_duration(std::string_view{value, 5}));
+      sourcemeta::core::is_rfc3339_duration(std::string_view{VALUE, 5}));
 }
 
 TEST(delta_u0009_u0050_day_u0009_2) {
@@ -1259,11 +1259,11 @@ TEST(delta_u0078_year_40) {
 }
 
 TEST(delta_u0000_day_41) {
-  static constexpr char value[] = "P1\x00"
+  static constexpr char VALUE[] = "P1\x00"
                                   "D";
-  static_assert(sizeof(value) - 1 == 4);
+  static_assert(sizeof(VALUE) - 1 == 4);
   EXPECT_FALSE(
-      sourcemeta::core::is_rfc3339_duration(std::string_view{value, 4}));
+      sourcemeta::core::is_rfc3339_duration(std::string_view{VALUE, 4}));
 }
 
 TEST(delta_u0009_day_42) {
@@ -1414,10 +1414,10 @@ TEST(delta_u0043_76) {
 }
 
 TEST(delta_day_u0000_77) {
-  static constexpr char value[] = "P1D\x00";
-  static_assert(sizeof(value) - 1 == 4);
+  static constexpr char VALUE[] = "P1D\x00";
+  static_assert(sizeof(VALUE) - 1 == 4);
   EXPECT_FALSE(
-      sourcemeta::core::is_rfc3339_duration(std::string_view{value, 4}));
+      sourcemeta::core::is_rfc3339_duration(std::string_view{VALUE, 4}));
 }
 
 TEST(delta_day_u000b_78) {

--- a/test/uri/uri_path_test.cc
+++ b/test/uri/uri_path_test.cc
@@ -173,7 +173,7 @@ TEST(set_relative_path) {
 
   auto path{"../foo"};
   try {
-    uri.path(std::move(path));
+    uri.path(path);
     FAIL();
   } catch (const sourcemeta::core::URIError &error) {
     EXPECT_STREQ(error.what(),
@@ -183,7 +183,7 @@ TEST(set_relative_path) {
 
   path = "./foo";
   try {
-    uri.path(std::move(path));
+    uri.path(path);
     FAIL();
   } catch (const sourcemeta::core::URIError &error) {
     EXPECT_STREQ(error.what(),

--- a/test/uritemplate/uritemplate_expand_iri_test.cc
+++ b/test/uritemplate/uritemplate_expand_iri_test.cc
@@ -15,9 +15,8 @@ static auto single_value(const std::string_view value) {
           const std::string_view name) -> sourcemeta::core::URITemplateValue {
         if (name == "var") {
           return std::make_tuple(value, std::nullopt, false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       };
 }
 
@@ -280,11 +279,11 @@ TEST(multiple_variables_mix_raw_and_encoded_rules) {
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
         if (name == "x") {
           return std::make_tuple(std::string_view{"café"}, std::nullopt, false);
-        } else if (name == "y") {
-          return std::make_tuple(std::string_view{"a b"}, std::nullopt, false);
-        } else {
-          return std::nullopt;
         }
+        if (name == "y") {
+          return std::make_tuple(std::string_view{"a b"}, std::nullopt, false);
+        }
+        return std::nullopt;
       },
       sourcemeta::core::URITemplateExpansionMode::IRI);
 
@@ -302,10 +301,8 @@ TEST(list_values_pass_through) {
           if (call_count == 1) {
             return std::make_tuple(std::string_view{"café"}, std::nullopt,
                                    true);
-          } else {
-            return std::make_tuple(std::string_view{"menü"}, std::nullopt,
-                                   false);
           }
+          return std::make_tuple(std::string_view{"menü"}, std::nullopt, false);
         }
         return std::nullopt;
       },
@@ -325,10 +322,8 @@ TEST(list_explode_path_values_pass_through) {
           if (call_count == 1) {
             return std::make_tuple(std::string_view{"café"}, std::nullopt,
                                    true);
-          } else {
-            return std::make_tuple(std::string_view{"東京"}, std::nullopt,
-                                   false);
           }
+          return std::make_tuple(std::string_view{"東京"}, std::nullopt, false);
         }
         return std::nullopt;
       },
@@ -349,11 +344,9 @@ TEST(object_explode_keys_and_values_pass_through) {
             return std::make_tuple(std::string_view{"café"},
                                    std::optional<std::string_view>{"clé"},
                                    true);
-          } else {
-            return std::make_tuple(std::string_view{"menü"},
-                                   std::optional<std::string_view>{"öl"},
-                                   false);
           }
+          return std::make_tuple(std::string_view{"menü"},
+                                 std::optional<std::string_view>{"öl"}, false);
         }
         return std::nullopt;
       },

--- a/test/uritemplate/uritemplate_expand_uri_test.cc
+++ b/test/uritemplate/uritemplate_expand_uri_test.cc
@@ -32,9 +32,8 @@ TEST(single_variable) {
         if (name == "var") {
           return std::make_tuple(std::string_view{"value"}, std::nullopt,
                                  false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "value");
@@ -46,9 +45,8 @@ TEST(literal_then_variable) {
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
         if (name == "id") {
           return std::make_tuple(std::string_view{"123"}, std::nullopt, false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "http://example.com/123");
@@ -60,9 +58,8 @@ TEST(variable_then_literal) {
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
         if (name == "id") {
           return std::make_tuple(std::string_view{"456"}, std::nullopt, false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "456/resource");
@@ -75,9 +72,8 @@ TEST(literal_variable_literal) {
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
         if (name == "username") {
           return std::make_tuple(std::string_view{"john"}, std::nullopt, false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "http://example.com/~john/");
@@ -90,11 +86,11 @@ TEST(multiple_variables) {
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
         if (name == "id") {
           return std::make_tuple(std::string_view{"42"}, std::nullopt, false);
-        } else if (name == "postId") {
-          return std::make_tuple(std::string_view{"99"}, std::nullopt, false);
-        } else {
-          return std::nullopt;
         }
+        if (name == "postId") {
+          return std::make_tuple(std::string_view{"99"}, std::nullopt, false);
+        }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "/users/42/posts/99");
@@ -107,12 +103,12 @@ TEST(adjacent_variables) {
         if (name == "x") {
           return std::make_tuple(std::string_view{"hello"}, std::nullopt,
                                  false);
-        } else if (name == "y") {
+        }
+        if (name == "y") {
           return std::make_tuple(std::string_view{"world"}, std::nullopt,
                                  false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "helloworld");
@@ -135,9 +131,8 @@ TEST(partial_variables_defined) {
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
         if (name == "id") {
           return std::make_tuple(std::string_view{"42"}, std::nullopt, false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "/users/42/posts/");
@@ -157,9 +152,8 @@ TEST(empty_value) {
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
         if (name == "var") {
           return std::make_tuple(std::string_view{""}, std::nullopt, false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "");
@@ -172,9 +166,8 @@ TEST(percent_encode_space) {
         if (name == "var") {
           return std::make_tuple(std::string_view{"hello world"}, std::nullopt,
                                  false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "hello%20world");
@@ -187,9 +180,8 @@ TEST(percent_encode_slash) {
         if (name == "var") {
           return std::make_tuple(std::string_view{"foo/bar"}, std::nullopt,
                                  false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "foo%2Fbar");
@@ -202,9 +194,8 @@ TEST(percent_encode_reserved_chars) {
         if (name == "var") {
           return std::make_tuple(std::string_view{":/?#[]@!$&'()*+,;="},
                                  std::nullopt, false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D");
@@ -217,9 +208,8 @@ TEST(unreserved_chars_not_encoded) {
         if (name == "var") {
           return std::make_tuple(std::string_view{"azAZ09-._~"}, std::nullopt,
                                  false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "azAZ09-._~");
@@ -231,9 +221,8 @@ TEST(percent_encode_unicode) {
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
         if (name == "var") {
           return std::make_tuple(std::string_view{"café"}, std::nullopt, false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "caf%C3%A9");
@@ -295,9 +284,8 @@ TEST(reserved_expansion_simple) {
         if (name == "var") {
           return std::make_tuple(std::string_view{"value"}, std::nullopt,
                                  false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "value");
@@ -310,9 +298,8 @@ TEST(reserved_expansion_preserves_reserved) {
         if (name == "path") {
           return std::make_tuple(std::string_view{"/foo/bar"}, std::nullopt,
                                  false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "/foo/bar");
@@ -325,9 +312,8 @@ TEST(reserved_expansion_all_reserved_chars) {
         if (name == "reserved") {
           return std::make_tuple(std::string_view{":/?#[]@!$&'()*+,;="},
                                  std::nullopt, false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, ":/?#[]@!$&'()*+,;=");
@@ -340,9 +326,8 @@ TEST(reserved_expansion_encodes_non_reserved) {
         if (name == "var") {
           return std::make_tuple(std::string_view{"hello world"}, std::nullopt,
                                  false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "hello%20world");
@@ -365,9 +350,8 @@ TEST(fragment_expansion_simple) {
         if (name == "var") {
           return std::make_tuple(std::string_view{"value"}, std::nullopt,
                                  false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "#value");
@@ -380,9 +364,8 @@ TEST(fragment_expansion_preserves_reserved) {
         if (name == "path") {
           return std::make_tuple(std::string_view{"/foo/bar"}, std::nullopt,
                                  false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "#/foo/bar");
@@ -395,9 +378,8 @@ TEST(fragment_expansion_encodes_non_reserved) {
         if (name == "var") {
           return std::make_tuple(std::string_view{"hello world"}, std::nullopt,
                                  false);
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;
       });
 
   EXPECT_EQ(result, "#hello%20world");
@@ -686,13 +668,12 @@ TEST(list_no_explode) {
           call_count++;
           if (call_count == 1) {
             return std::make_tuple(std::string_view{"red"}, std::nullopt, true);
-          } else if (call_count == 2) {
+          }
+          if (call_count == 2) {
             return std::make_tuple(std::string_view{"green"}, std::nullopt,
                                    true);
-          } else {
-            return std::make_tuple(std::string_view{"blue"}, std::nullopt,
-                                   false);
           }
+          return std::make_tuple(std::string_view{"blue"}, std::nullopt, false);
         }
         return std::nullopt;
       });
@@ -710,13 +691,12 @@ TEST(list_explode_path) {
           call_count++;
           if (call_count == 1) {
             return std::make_tuple(std::string_view{"red"}, std::nullopt, true);
-          } else if (call_count == 2) {
+          }
+          if (call_count == 2) {
             return std::make_tuple(std::string_view{"green"}, std::nullopt,
                                    true);
-          } else {
-            return std::make_tuple(std::string_view{"blue"}, std::nullopt,
-                                   false);
           }
+          return std::make_tuple(std::string_view{"blue"}, std::nullopt, false);
         }
         return std::nullopt;
       });
@@ -734,13 +714,12 @@ TEST(list_explode_query) {
           call_count++;
           if (call_count == 1) {
             return std::make_tuple(std::string_view{"red"}, std::nullopt, true);
-          } else if (call_count == 2) {
+          }
+          if (call_count == 2) {
             return std::make_tuple(std::string_view{"green"}, std::nullopt,
                                    true);
-          } else {
-            return std::make_tuple(std::string_view{"blue"}, std::nullopt,
-                                   false);
           }
+          return std::make_tuple(std::string_view{"blue"}, std::nullopt, false);
         }
         return std::nullopt;
       });
@@ -758,13 +737,12 @@ TEST(list_explode_label) {
           call_count++;
           if (call_count == 1) {
             return std::make_tuple(std::string_view{"red"}, std::nullopt, true);
-          } else if (call_count == 2) {
+          }
+          if (call_count == 2) {
             return std::make_tuple(std::string_view{"green"}, std::nullopt,
                                    true);
-          } else {
-            return std::make_tuple(std::string_view{"blue"}, std::nullopt,
-                                   false);
           }
+          return std::make_tuple(std::string_view{"blue"}, std::nullopt, false);
         }
         return std::nullopt;
       });
@@ -783,10 +761,9 @@ TEST(object_no_explode) {
           if (call_count == 1) {
             return std::make_tuple(std::string_view{"1"},
                                    std::string_view{"one"}, true);
-          } else {
-            return std::make_tuple(std::string_view{"2"},
-                                   std::string_view{"two"}, false);
           }
+          return std::make_tuple(std::string_view{"2"}, std::string_view{"two"},
+                                 false);
         }
         return std::nullopt;
       });
@@ -805,10 +782,9 @@ TEST(object_explode_query) {
           if (call_count == 1) {
             return std::make_tuple(std::string_view{"1"},
                                    std::string_view{"one"}, true);
-          } else {
-            return std::make_tuple(std::string_view{"2"},
-                                   std::string_view{"two"}, false);
           }
+          return std::make_tuple(std::string_view{"2"}, std::string_view{"two"},
+                                 false);
         }
         return std::nullopt;
       });
@@ -827,10 +803,9 @@ TEST(object_explode_path_param) {
           if (call_count == 1) {
             return std::make_tuple(std::string_view{";"},
                                    std::string_view{"semi"}, true);
-          } else {
-            return std::make_tuple(std::string_view{"."},
-                                   std::string_view{"dot"}, false);
           }
+          return std::make_tuple(std::string_view{"."}, std::string_view{"dot"},
+                                 false);
         }
         return std::nullopt;
       });

--- a/test/uritemplate/uritemplate_router_view_test.cc
+++ b/test/uritemplate/uritemplate_router_view_test.cc
@@ -22,11 +22,11 @@ class URITemplateRouterViewTest {
 protected:
   ~URITemplateRouterViewTest() {
     std::error_code error;
-    std::filesystem::remove(this->path, error);
+    std::filesystem::remove(this->path_, error);
   }
   // The tests are always sequential, so using the same path is safe
-  std::filesystem::path path{std::filesystem::temp_directory_path() /
-                             "sourcemeta_core_uritemplate_router_test.bin"};
+  std::filesystem::path path_{std::filesystem::temp_directory_path() /
+                              "sourcemeta_core_uritemplate_router_test.bin"};
 };
 
 namespace {
@@ -54,10 +54,10 @@ TEST_F(URITemplateRouterViewTest, single_literal_route) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_1", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -67,10 +67,10 @@ TEST_F(URITemplateRouterViewTest, single_literal_route_no_match) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_2", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/posts", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -80,10 +80,10 @@ TEST_F(URITemplateRouterViewTest, multi_segment_literal) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/list", "op_3", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users/list", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -93,10 +93,10 @@ TEST_F(URITemplateRouterViewTest, single_variable) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}", "op_4", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users/123", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -107,10 +107,10 @@ TEST_F(URITemplateRouterViewTest, multiple_variables) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}/posts/{post_id}", "op_5", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users/42/posts/99", 1, 0, captures);
   EXPECT_EQ(captures.size(), 2);
@@ -123,10 +123,10 @@ TEST_F(URITemplateRouterViewTest, literal_before_variable_precedence) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/me", "op_6", 1);
     router.add("/users/{id}", "op_7", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users/me", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -137,10 +137,10 @@ TEST_F(URITemplateRouterViewTest, variable_fallback) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/me", "op_8", 1);
     router.add("/users/{id}", "op_9", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users/123", 2, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -154,10 +154,10 @@ TEST_F(URITemplateRouterViewTest, multiple_routes_match_users) {
     router.add("/users/{id}", "op_11", 2);
     router.add("/posts", "op_12", 3);
     router.add("/posts/{id}", "op_13", 4);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -170,10 +170,10 @@ TEST_F(URITemplateRouterViewTest, multiple_routes_match_users_id) {
     router.add("/users/{id}", "op_15", 2);
     router.add("/posts", "op_16", 3);
     router.add("/posts/{id}", "op_17", 4);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users/42", 2, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -187,10 +187,10 @@ TEST_F(URITemplateRouterViewTest, multiple_routes_match_posts) {
     router.add("/users/{id}", "op_19", 2);
     router.add("/posts", "op_20", 3);
     router.add("/posts/{id}", "op_21", 4);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/posts", 3, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -203,10 +203,10 @@ TEST_F(URITemplateRouterViewTest, multiple_routes_match_posts_id) {
     router.add("/users/{id}", "op_23", 2);
     router.add("/posts", "op_24", 3);
     router.add("/posts/{id}", "op_25", 4);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/posts/99", 4, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -221,10 +221,10 @@ TEST_F(URITemplateRouterViewTest, binary_search_literals_gamma) {
     router.add("/gamma", "op_28", 3);
     router.add("/delta", "op_29", 4);
     router.add("/epsilon", "op_30", 5);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/gamma", 3, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -238,10 +238,10 @@ TEST_F(URITemplateRouterViewTest, binary_search_literals_alpha) {
     router.add("/gamma", "op_33", 3);
     router.add("/delta", "op_34", 4);
     router.add("/epsilon", "op_35", 5);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/alpha", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -255,10 +255,10 @@ TEST_F(URITemplateRouterViewTest, binary_search_literals_epsilon) {
     router.add("/gamma", "op_38", 3);
     router.add("/delta", "op_39", 4);
     router.add("/epsilon", "op_40", 5);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/epsilon", 5, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -268,10 +268,10 @@ TEST_F(URITemplateRouterViewTest, root_template_matches_root) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/", "op_41", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -281,10 +281,10 @@ TEST_F(URITemplateRouterViewTest, root_template_no_match_empty) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/", "op_42", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -294,10 +294,10 @@ TEST_F(URITemplateRouterViewTest, root_template_no_match_path) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/", "op_43", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/foo", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -307,10 +307,10 @@ TEST_F(URITemplateRouterViewTest, empty_template_matches_empty) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("", "op_44", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -320,10 +320,10 @@ TEST_F(URITemplateRouterViewTest, empty_template_no_match_root) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("", "op_45", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -333,10 +333,10 @@ TEST_F(URITemplateRouterViewTest, empty_template_no_match_path) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("", "op_46", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/foo", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -348,10 +348,10 @@ TEST_F(URITemplateRouterViewTest, root_and_other_routes_match_root) {
     router.add("/", "op_47", 1);
     router.add("/users", "op_48", 2);
     router.add("/users/{id}", "op_49", 3);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -363,10 +363,10 @@ TEST_F(URITemplateRouterViewTest, root_and_other_routes_match_users) {
     router.add("/", "op_50", 1);
     router.add("/users", "op_51", 2);
     router.add("/users/{id}", "op_52", 3);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users", 2, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -378,10 +378,10 @@ TEST_F(URITemplateRouterViewTest, root_and_other_routes_match_users_id) {
     router.add("/", "op_53", 1);
     router.add("/users", "op_54", 2);
     router.add("/users/{id}", "op_55", 3);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users/123", 3, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -393,10 +393,10 @@ TEST_F(URITemplateRouterViewTest, empty_and_root_together_match_empty) {
     sourcemeta::core::URITemplateRouter router;
     router.add("", "op_56", 1);
     router.add("/", "op_57", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -407,10 +407,10 @@ TEST_F(URITemplateRouterViewTest, empty_and_root_together_match_root) {
     sourcemeta::core::URITemplateRouter router;
     router.add("", "op_58", 1);
     router.add("/", "op_59", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/", 2, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -421,10 +421,10 @@ TEST_F(URITemplateRouterViewTest, empty_and_root_together_no_match_path) {
     sourcemeta::core::URITemplateRouter router;
     router.add("", "op_60", 1);
     router.add("/", "op_61", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/foo", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -437,10 +437,10 @@ TEST_F(URITemplateRouterViewTest, empty_and_root_and_others_match_empty) {
     router.add("/", "op_63", 2);
     router.add("/users", "op_64", 3);
     router.add("/users/{id}", "op_65", 4);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -453,10 +453,10 @@ TEST_F(URITemplateRouterViewTest, empty_and_root_and_others_match_root) {
     router.add("/", "op_67", 2);
     router.add("/users", "op_68", 3);
     router.add("/users/{id}", "op_69", 4);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/", 2, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -469,10 +469,10 @@ TEST_F(URITemplateRouterViewTest, empty_and_root_and_others_match_users) {
     router.add("/", "op_71", 2);
     router.add("/users", "op_72", 3);
     router.add("/users/{id}", "op_73", 4);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users", 3, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -485,10 +485,10 @@ TEST_F(URITemplateRouterViewTest, empty_and_root_and_others_match_users_id) {
     router.add("/", "op_75", 2);
     router.add("/users", "op_76", 3);
     router.add("/users/{id}", "op_77", 4);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users/42", 4, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -500,10 +500,10 @@ TEST_F(URITemplateRouterViewTest, same_variable_names_allowed) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}/posts", "op_78", 1);
     router.add("/users/{id}/comments", "op_79", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users/123/comments", 2, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -514,10 +514,10 @@ TEST_F(URITemplateRouterViewTest, reserved_expansion_catch_all) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{+path}", "op_80", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/files/foo/bar/baz.txt", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -528,10 +528,10 @@ TEST_F(URITemplateRouterViewTest, reserved_expansion_with_literal_prefix) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/v1/proxy/{+url}", "op_81", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/api/v1/proxy/https://example.com/path", 1, 0,
                       captures);
@@ -543,10 +543,10 @@ TEST_F(URITemplateRouterViewTest, reserved_expansion_matches_multi_segment) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{+path}", "op_82", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/files/foo/bar", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -558,10 +558,10 @@ TEST_F(URITemplateRouterViewTest, expansion_takes_priority_over_variable) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{path}", "op_83", 1);
     router.add("/files/{+path}", "op_84", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/files/readme.md", 2, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -573,10 +573,10 @@ TEST_F(URITemplateRouterViewTest, expansion_takes_priority_multi_segment) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{path}", "op_85", 1);
     router.add("/files/{+path}", "op_86", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/files/foo/bar/baz", 2, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -588,10 +588,10 @@ TEST_F(URITemplateRouterViewTest, expansion_first_then_variable) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{+path}", "op_87", 1);
     router.add("/files/{path}", "op_88", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/files/readme.md", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -603,10 +603,10 @@ TEST_F(URITemplateRouterViewTest, literal_takes_priority_over_expansion) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{+path}", "op_89", 1);
     router.add("/files/special", "op_90", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/files/special", 2, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -617,10 +617,10 @@ TEST_F(URITemplateRouterViewTest, expansion_fallback_from_literal) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{+path}", "op_91", 1);
     router.add("/files/special", "op_92", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/files/other", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -631,10 +631,10 @@ TEST_F(URITemplateRouterViewTest, trailing_slash_no_match) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_93", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users/", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -644,10 +644,10 @@ TEST_F(URITemplateRouterViewTest, multiple_trailing_slashes_no_match) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_94", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users///", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -657,10 +657,10 @@ TEST_F(URITemplateRouterViewTest, leading_double_slash_no_match) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_95", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "//users", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -670,10 +670,10 @@ TEST_F(URITemplateRouterViewTest, internal_double_slashes_no_match) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/posts", "op_96", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users//posts", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -683,10 +683,10 @@ TEST_F(URITemplateRouterViewTest, trailing_slash_with_variable_no_match) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}", "op_97", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users/123/", 0, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -698,10 +698,10 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}/posts", "op_98", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users//123//posts", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -711,10 +711,10 @@ TEST_F(URITemplateRouterViewTest, expansion_matches_trailing_slash) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{+path}", "op_99", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/files/foo/bar/", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -725,10 +725,10 @@ TEST_F(URITemplateRouterViewTest, expansion_matches_double_slashes) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{+path}", "op_100", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/files/foo//bar", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -745,10 +745,10 @@ TEST_F(URITemplateRouterViewTest, matches_from_unaligned_external_buffer) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_1", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  std::ifstream input{this->path, std::ios::binary};
+  std::ifstream input{this->path_, std::ios::binary};
   const std::vector<std::uint8_t> bytes{std::istreambuf_iterator<char>{input},
                                         std::istreambuf_iterator<char>{}};
 
@@ -1023,10 +1023,10 @@ TEST_F(URITemplateRouterViewTest, arguments_single_string) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"responseSchema", std::string_view{argument_value}}}};
     router.add("/test", "op_101", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1054,10 +1054,10 @@ TEST_F(URITemplateRouterViewTest, arguments_single_integer) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"count", std::int64_t{42}}}};
     router.add("/test", "op_102", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1084,10 +1084,10 @@ TEST_F(URITemplateRouterViewTest, arguments_single_boolean_true) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"enabled", true}}};
     router.add("/test", "op_103", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1113,10 +1113,10 @@ TEST_F(URITemplateRouterViewTest, arguments_single_boolean_false) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"disabled", false}}};
     router.add("/test", "op_104", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1142,10 +1142,10 @@ TEST_F(URITemplateRouterViewTest, arguments_integer_zero) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"value", std::int64_t{0}}}};
     router.add("/test", "op_105", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1172,10 +1172,10 @@ TEST_F(URITemplateRouterViewTest, arguments_integer_negative) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"value", std::int64_t{-1}}}};
     router.add("/test", "op_106", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1202,10 +1202,10 @@ TEST_F(URITemplateRouterViewTest, arguments_integer_min) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"value", INT64_MIN}}};
     router.add("/test", "op_107", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1232,10 +1232,10 @@ TEST_F(URITemplateRouterViewTest, arguments_integer_max) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"value", INT64_MAX}}};
     router.add("/test", "op_108", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1263,10 +1263,10 @@ TEST_F(URITemplateRouterViewTest, arguments_empty_string_value) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"key", std::string_view{argument_value}}}};
     router.add("/test", "op_109", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1294,10 +1294,10 @@ TEST_F(URITemplateRouterViewTest, arguments_string_with_slashes) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"path", std::string_view{argument_value}}}};
     router.add("/test", "op_110", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1326,10 +1326,10 @@ TEST_F(URITemplateRouterViewTest, arguments_string_with_utf8) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"letter", std::string_view{argument_value}}}};
     router.add("/test", "op_111", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1358,10 +1358,10 @@ TEST_F(URITemplateRouterViewTest, arguments_string_with_nulls) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"binary", std::string_view{null_string.data(), 5}}}};
     router.add("/test", "op_112", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1392,10 +1392,10 @@ TEST_F(URITemplateRouterViewTest, arguments_long_string_value) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"payload", std::string_view{argument_value}}}};
     router.add("/test", "op_113", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1428,10 +1428,10 @@ TEST_F(URITemplateRouterViewTest, arguments_multiple_mixed_types) {
                    {"count", std::int64_t{99}},
                    {"active", true}}};
     router.add("/test", "op_114", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1473,10 +1473,10 @@ TEST_F(URITemplateRouterViewTest, arguments_multiple_strings) {
                    {"second", std::string_view{second_value}},
                    {"third", std::string_view{third_value}}}};
     router.add("/test", "op_115", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1516,10 +1516,10 @@ TEST_F(URITemplateRouterViewTest, arguments_multiple_integers) {
                    {"second", std::int64_t{20}},
                    {"third", std::int64_t{30}}}};
     router.add("/test", "op_116", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1563,10 +1563,10 @@ TEST_F(URITemplateRouterViewTest, arguments_five_arguments) {
                    {"string_two", std::string_view{string_two}},
                    {"integer_two", std::int64_t{-50}}}};
     router.add("/test", "op_117", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1618,10 +1618,10 @@ TEST_F(URITemplateRouterViewTest, arguments_two_routes_different_args) {
         second_arguments{{{"data", std::string_view{second_route_value}}}};
     router.add("/first", "op_118", 1, 0, first_arguments);
     router.add("/second", "op_119", 2, 0, second_arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
 
   EXPECT_ROUTER_MATCH(restored, "/first", 1, 0, captures_first);
@@ -1667,10 +1667,10 @@ TEST_F(URITemplateRouterViewTest, arguments_three_routes_one_without_args) {
     router.add("/alpha", "op_120", 1, 0, first_arguments);
     router.add("/beta", "op_121", 2);
     router.add("/gamma", "op_122", 3, 0, third_arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
 
   EXPECT_ROUTER_MATCH(restored, "/alpha", 1, 0, captures_alpha);
@@ -1717,10 +1717,10 @@ TEST_F(URITemplateRouterViewTest, arguments_three_routes_one_without_args) {
 TEST_F(URITemplateRouterViewTest, arguments_empty_router) {
   {
     sourcemeta::core::URITemplateRouter router;
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
 
   std::vector<std::pair<std::string_view,
@@ -1739,10 +1739,10 @@ TEST_F(URITemplateRouterViewTest, arguments_route_without_arguments) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/test", "op_123", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/test", 1, 0, captures);
 
@@ -1765,10 +1765,10 @@ TEST_F(URITemplateRouterViewTest, arguments_identifier_not_found) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"key", std::string_view{argument_value}}}};
     router.add("/test", "op_124", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
 
   std::vector<std::pair<std::string_view,
@@ -1790,10 +1790,10 @@ TEST_F(URITemplateRouterViewTest, arguments_identifier_zero) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"key", std::string_view{argument_value}}}};
     router.add("/test", "op_125", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
 
   std::vector<std::pair<std::string_view,
@@ -1815,10 +1815,10 @@ TEST_F(URITemplateRouterViewTest, arguments_with_variable_capture) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"metadata", std::string_view{argument_value}}}};
     router.add("/users/{id}", "op_126", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/users/42", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -1849,10 +1849,10 @@ TEST_F(URITemplateRouterViewTest, arguments_with_expansion) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"info", std::string_view{argument_value}}}};
     router.add("/files/{+path}", "op_127", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/files/a/b/c", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -1891,10 +1891,10 @@ TEST_F(URITemplateRouterViewTest, arguments_multiple_routes_match_and_args) {
     router.add("/users/{id}", "op_128", 1, 0, user_arguments);
     router.add("/posts/{id}", "op_129", 2, 0, post_arguments);
     router.add("/comments/{id}", "op_130", 3, 0, comment_arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
 
   EXPECT_ROUTER_MATCH(restored, "/users/1", 1, 0, captures_users);
@@ -1952,10 +1952,10 @@ TEST_F(URITemplateRouterViewTest, arguments_do_not_affect_match_precedence) {
         me_arguments{{{"role", std::string_view{me_value}}}};
     router.add("/users/me", "op_131", 1, 0, me_arguments);
     router.add("/users/{id}", "op_132", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
 
   EXPECT_ROUTER_MATCH(restored, "/users/me", 1, 0, captures_me);
@@ -2010,10 +2010,10 @@ TEST_F(URITemplateRouterViewTest, arguments_survive_large_trie) {
     router.add("/api/v1/theta", "op_140", 8);
     router.add("/api/v1/iota", "op_141", 9);
     router.add("/api/v1/kappa", "op_142", 10);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
 
   EXPECT_ROUTER_MATCH(restored, "/api/v1/alpha", 1, 0, captures_alpha);
@@ -2074,10 +2074,10 @@ TEST_F(URITemplateRouterViewTest, base_path_single_segment) {
   {
     sourcemeta::core::URITemplateRouter router{"/prefix"};
     router.add("/foo", "op_143", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/prefix");
   EXPECT_ROUTER_MATCH(restored, "/prefix/foo", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -2087,10 +2087,10 @@ TEST_F(URITemplateRouterViewTest, base_path_without_prefix_no_match) {
   {
     sourcemeta::core::URITemplateRouter router{"/prefix"};
     router.add("/foo", "op_144", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/prefix");
   EXPECT_ROUTER_MATCH(restored, "/foo", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -2101,10 +2101,10 @@ TEST_F(URITemplateRouterViewTest, base_path_multi_segment) {
     sourcemeta::core::URITemplateRouter router{"/v1/catalog"};
     router.add("/api/list", "op_145", 1);
     router.add("/{+path}", "op_146", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/v1/catalog");
   EXPECT_ROUTER_MATCH(restored, "/v1/catalog/api/list", 1, 0, captures_list);
   EXPECT_EQ(captures_list.size(), 0);
@@ -2118,10 +2118,10 @@ TEST_F(URITemplateRouterViewTest, base_path_with_variable) {
   {
     sourcemeta::core::URITemplateRouter router{"/prefix"};
     router.add("/users/{id}", "op_147", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/prefix");
   EXPECT_ROUTER_MATCH(restored, "/prefix/users/42", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -2132,10 +2132,10 @@ TEST_F(URITemplateRouterViewTest, base_path_prefix_boundary_no_match) {
   {
     sourcemeta::core::URITemplateRouter router{"/prefix"};
     router.add("/foo", "op_148", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/prefix");
   EXPECT_ROUTER_MATCH(restored, "/prefixfoo", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -2145,10 +2145,10 @@ TEST_F(URITemplateRouterViewTest, base_path_with_empty_template) {
   {
     sourcemeta::core::URITemplateRouter router{"/v1/catalog"};
     router.add("", "op_149", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/v1/catalog");
   EXPECT_ROUTER_MATCH(restored, "/v1/catalog", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -2158,10 +2158,10 @@ TEST_F(URITemplateRouterViewTest, base_path_no_base_path_unchanged) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo", "op_150", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_ROUTER_MATCH(restored, "/foo", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -2171,10 +2171,10 @@ TEST_F(URITemplateRouterViewTest, base_path_expansion) {
   {
     sourcemeta::core::URITemplateRouter router{"/api"};
     router.add("/files/{+path}", "op_151", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/api");
   EXPECT_ROUTER_MATCH(restored, "/api/files/a/b/c", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
@@ -2185,10 +2185,10 @@ TEST_F(URITemplateRouterViewTest, base_path_trailing_slash_normalized) {
   {
     sourcemeta::core::URITemplateRouter router{"/prefix/"};
     router.add("/foo", "op_152", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/prefix");
   EXPECT_ROUTER_MATCH(restored, "/prefix/foo", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -2199,10 +2199,10 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router{"/prefix///"};
     router.add("/foo", "op_153", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/prefix");
   EXPECT_ROUTER_MATCH(restored, "/prefix/foo", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -2212,10 +2212,10 @@ TEST_F(URITemplateRouterViewTest, base_url_empty_by_default) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo", "op_base_url_default", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_TRUE(restored.base_url().empty());
   EXPECT_ROUTER_MATCH(restored, "/foo", 1, 0, captures);
@@ -2226,10 +2226,10 @@ TEST_F(URITemplateRouterViewTest, base_url_empty_when_only_base_path) {
   {
     sourcemeta::core::URITemplateRouter router{"/prefix"};
     router.add("/foo", "op_base_url_only_path", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/prefix");
   EXPECT_TRUE(restored.base_url().empty());
 }
@@ -2239,10 +2239,10 @@ TEST_F(URITemplateRouterViewTest, base_url_round_trip_with_base_path) {
     sourcemeta::core::URITemplateRouter router{"/v1",
                                                "https://api.example.com"};
     router.add("/foo", "op_base_url_round_trip", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/v1");
   EXPECT_EQ(restored.base_url(), "https://api.example.com");
   EXPECT_ROUTER_MATCH(restored, "/v1/foo", 1, 0, captures);
@@ -2253,10 +2253,10 @@ TEST_F(URITemplateRouterViewTest, base_url_round_trip_without_base_path) {
   {
     sourcemeta::core::URITemplateRouter router{"", "https://api.example.com"};
     router.add("/foo", "op_base_url_no_path", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.base_path().empty());
   EXPECT_EQ(restored.base_url(), "https://api.example.com");
   EXPECT_ROUTER_MATCH(restored, "/foo", 1, 0, captures);
@@ -2267,10 +2267,10 @@ TEST_F(URITemplateRouterViewTest, base_url_trailing_slash_normalized) {
   {
     sourcemeta::core::URITemplateRouter router{"", "https://api.example.com/"};
     router.add("/foo", "op_base_url_trailing", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_url(), "https://api.example.com");
 }
 
@@ -2283,10 +2283,10 @@ TEST_F(URITemplateRouterViewTest, base_url_arguments_still_resolve) {
             {"schema", std::string_view{"schemas/health"}},
         }};
     router.add("/health", "op_base_url_args", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/v1");
   EXPECT_EQ(restored.base_url(), "https://api.example.com");
 
@@ -2309,10 +2309,10 @@ TEST_F(URITemplateRouterViewTest, add_with_context_literal_route) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_154", 1, 7);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/users", 1, 7, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -2321,10 +2321,10 @@ TEST_F(URITemplateRouterViewTest, add_with_context_variable_route) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}", "op_155", 1, 42);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/users/123", 1, 42, captures);
   EXPECT_EQ(captures.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "123");
@@ -2334,10 +2334,10 @@ TEST_F(URITemplateRouterViewTest, add_with_context_default_zero) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_156", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/users", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -2347,10 +2347,10 @@ TEST_F(URITemplateRouterViewTest, add_multiple_routes_different_contexts) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_157", 1, 1);
     router.add("/posts", "op_158", 2, 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   {
     EXPECT_ROUTER_MATCH(restored, "/users", 1, 1, captures);
     EXPECT_EQ(captures.size(), 0);
@@ -2366,10 +2366,10 @@ TEST_F(URITemplateRouterViewTest, add_same_context_multiple_routes) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_159", 1, 99);
     router.add("/posts", "op_160", 2, 99);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   {
     EXPECT_ROUTER_MATCH(restored, "/users", 1, 99, captures);
     EXPECT_EQ(captures.size(), 0);
@@ -2389,10 +2389,10 @@ TEST_F(URITemplateRouterViewTest, add_with_context_and_arguments) {
             {"enabled", true},
         }};
     router.add("/api/health", "op_161", 1, 11, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/health", 1, 11, captures);
   EXPECT_EQ(captures.size(), 0);
 
@@ -2423,10 +2423,10 @@ TEST_F(URITemplateRouterViewTest, add_context_expansion_route) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{+path}", "op_162", 1, 5);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/files/a/b/c", 1, 5, captures);
   EXPECT_EQ(captures.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "a/b/c");
@@ -2436,10 +2436,10 @@ TEST_F(URITemplateRouterViewTest, add_context_base_path) {
   {
     sourcemeta::core::URITemplateRouter router{"/v1/catalog"};
     router.add("/api/list", "op_163", 1, 33);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/v1/catalog");
   EXPECT_ROUTER_MATCH(restored, "/v1/catalog/api/list", 1, 33, captures);
   EXPECT_EQ(captures.size(), 0);
@@ -2449,10 +2449,10 @@ TEST_F(URITemplateRouterViewTest, add_with_context_no_match_returns_zero_pair) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_164", 1, 7);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/posts", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -2463,10 +2463,10 @@ TEST_F(URITemplateRouterViewTest,
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_165", 1, 10);
     router.add("/users", "op_166", 1, 20);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/users", 1, 20, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -2474,10 +2474,10 @@ TEST_F(URITemplateRouterViewTest,
 TEST_F(URITemplateRouterViewTest, size_empty_router) {
   {
     const sourcemeta::core::URITemplateRouter router;
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 0);
 }
 
@@ -2485,10 +2485,10 @@ TEST_F(URITemplateRouterViewTest, size_single_route) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_167", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 1);
 }
 
@@ -2499,10 +2499,10 @@ TEST_F(URITemplateRouterViewTest, size_multiple_routes) {
     router.add("/users/{id}", "op_169", 2);
     router.add("/posts", "op_170", 3);
     router.add("/posts/{id}", "op_171", 4);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 4);
 }
 
@@ -2511,10 +2511,10 @@ TEST_F(URITemplateRouterViewTest, size_duplicate_route_does_not_increase) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_172", 1);
     router.add("/users", "op_173", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 1);
 }
 
@@ -2523,10 +2523,10 @@ TEST_F(URITemplateRouterViewTest, size_with_base_path) {
     sourcemeta::core::URITemplateRouter router{"/v1"};
     router.add("/users", "op_174", 1);
     router.add("/posts", "op_175", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 2);
 }
 
@@ -2535,10 +2535,10 @@ TEST_F(URITemplateRouterViewTest, otherwise_returned_from_unknown_path) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_176", 1, 5);
     router.otherwise(99);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/unknown", 0, 99, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -2548,10 +2548,10 @@ TEST_F(URITemplateRouterViewTest, otherwise_not_returned_from_matching_route) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_177", 1, 5);
     router.otherwise(99);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/users", 1, 5, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -2561,10 +2561,10 @@ TEST_F(URITemplateRouterViewTest, otherwise_returned_for_empty_segment) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_178", 1);
     router.otherwise(77);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/users//", 0, 77, captures);
 }
 
@@ -2573,10 +2573,10 @@ TEST_F(URITemplateRouterViewTest, otherwise_returned_for_root_slash_no_match) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_179", 1);
     router.otherwise(88);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/", 0, 88, captures);
 }
 
@@ -2585,10 +2585,10 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_180", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/unknown", 0, 0, captures);
 }
 
@@ -2600,10 +2600,10 @@ TEST_F(URITemplateRouterViewTest, otherwise_arguments_lookup) {
         arguments{{{"status", std::int64_t{404}},
                    {"message", std::string_view{message_value}}}};
     router.otherwise(55, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
 
   std::vector<std::pair<std::string_view,
                         sourcemeta::core::URITemplateRouter::ArgumentValue>>
@@ -2630,10 +2630,10 @@ TEST_F(URITemplateRouterViewTest, otherwise_boolean_argument) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         arguments{{{"cached", true}}};
     router.otherwise(3, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
 
   std::vector<std::pair<std::string_view,
                         sourcemeta::core::URITemplateRouter::ArgumentValue>>
@@ -2662,10 +2662,10 @@ TEST_F(URITemplateRouterViewTest, otherwise_does_not_affect_other_arguments) {
     const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
         default_args{{{"message", std::string_view{message_value}}}};
     router.otherwise(99, default_args);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
 
   std::vector<std::pair<std::string_view,
                         sourcemeta::core::URITemplateRouter::ArgumentValue>>
@@ -2697,10 +2697,10 @@ TEST_F(URITemplateRouterViewTest, otherwise_does_not_count_as_route_in_size) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_182", 1);
     router.otherwise(99);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 1);
 }
 
@@ -2709,10 +2709,10 @@ TEST_F(URITemplateRouterViewTest, otherwise_with_base_path_and_unmatched) {
     sourcemeta::core::URITemplateRouter router{"/v1"};
     router.add("/users", "op_183", 1);
     router.otherwise(42);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/v1/other", 0, 42, captures);
 }
 
@@ -2721,10 +2721,10 @@ TEST_F(URITemplateRouterViewTest, otherwise_with_partial_trie_walk) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}/posts", "op_184", 1);
     router.otherwise(42);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/users/123", 0, 42, captures);
 }
 
@@ -2733,10 +2733,10 @@ TEST_F(URITemplateRouterViewTest, otherwise_overwrite_context) {
     sourcemeta::core::URITemplateRouter router;
     router.otherwise(10);
     router.otherwise(20);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/nope", 0, 20, captures);
 }
 
@@ -2747,10 +2747,10 @@ TEST_F(URITemplateRouterViewTest, listing_size_matches_router) {
     router.add("/users/{id}", "op_186", 2);
     router.add("/posts/{id}/comments/{comment_id}", "op_187", 3);
     router.add("/files/{+rest}", "op_188", 4);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 4);
 }
 
@@ -2760,10 +2760,10 @@ TEST_F(URITemplateRouterViewTest, listing_size_excludes_otherwise) {
     router.add("/users", "op_189", 1);
     router.add("/posts", "op_190", 2);
     router.otherwise(99);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 2);
 }
 
@@ -2773,10 +2773,10 @@ TEST_F(URITemplateRouterViewTest, operation_returns_identifier_and_context) {
     router.add("/a", "alpha", 1, 11);
     router.add("/b", "beta", 2, 22);
     router.add("/c", "gamma", 3, 33);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
 
   const auto alpha = restored.operation("alpha");
   EXPECT_EQ(alpha.first, 1);
@@ -2796,10 +2796,10 @@ TEST_F(URITemplateRouterViewTest, operation_unknown_returns_zero_zero) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/a", "alpha", 1, 11);
     router.otherwise(99);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   const auto result = restored.operation("missing");
   EXPECT_EQ(result.first, 0);
   EXPECT_EQ(result.second, 0);
@@ -2811,10 +2811,10 @@ TEST_F(URITemplateRouterViewTest, operation_full_character_set_round_trip) {
     router.add("/a", "aZ0_-", 1);
     router.add("/b", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-09",
                2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.operation("aZ0_-").first, 1);
   EXPECT_EQ(
       restored
@@ -2827,10 +2827,10 @@ TEST_F(URITemplateRouterViewTest, operation_full_character_set_round_trip) {
 TEST_F(URITemplateRouterViewTest, operation_empty_router) {
   {
     sourcemeta::core::URITemplateRouter router;
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   const auto result = restored.operation("anything");
   EXPECT_EQ(result.first, 0);
   EXPECT_EQ(result.second, 0);
@@ -2840,12 +2840,12 @@ TEST_F(URITemplateRouterViewTest, operation_rejects_v5_blob) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/a", "alpha", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
   std::vector<std::uint8_t> blob;
   {
-    std::ifstream file{this->path, std::ios::binary | std::ios::ate};
+    std::ifstream file{this->path_, std::ios::binary | std::ios::ate};
     const auto size = static_cast<std::size_t>(file.tellg());
     file.seekg(0, std::ios::beg);
     blob.resize(size);
@@ -2868,12 +2868,12 @@ TEST_F(URITemplateRouterViewTest, operation_rejects_v6_blob) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/a", "alpha", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
   std::vector<std::uint8_t> blob;
   {
-    std::ifstream file{this->path, std::ios::binary | std::ios::ate};
+    std::ifstream file{this->path_, std::ios::binary | std::ios::ate};
     const auto size = static_cast<std::size_t>(file.tellg());
     file.seekg(0, std::ios::beg);
     blob.resize(size);
@@ -2896,9 +2896,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_empty_capture) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "op_v_oex_1", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/list", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "");
@@ -2908,9 +2908,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_single_segment) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "op_v_oex_2", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/list/foo", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
@@ -2920,9 +2920,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_two_segments) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "op_v_oex_3", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/list/foo/bar", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar");
@@ -2932,9 +2932,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_many_segments) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "op_v_oex_4", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/list/foo/bar/baz/qux", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar/baz/qux");
@@ -2944,9 +2944,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_percent_encoded_segment) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "op_v_oex_5", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/list/foo%2Fbar", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo%2Fbar");
@@ -2956,9 +2956,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_rejects_trailing_slash) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "op_v_oex_6", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/list/", 0, 0, captures);
 }
 
@@ -2967,9 +2967,9 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "op_v_oex_7", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/list//foo", 0, 0, captures);
 }
 
@@ -2977,9 +2977,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_rejects_non_prefix) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "op_v_oex_8", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/listing", 0, 0, captures);
 }
 
@@ -2987,9 +2987,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_with_context) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "op_v_oex_9", 1, 7);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/list", 1, 7, captures_empty);
   EXPECT_EQ(captures_empty.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures_empty, 0, "path", "");
@@ -3004,9 +3004,9 @@ TEST_F(URITemplateRouterViewTest,
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "op_v_oex_p1", 1);
     router.add("/api/list/special", "op_v_oex_p2", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/list/special", 2, 0, captures_special);
   EXPECT_EQ(captures_special.size(), 0);
   EXPECT_ROUTER_MATCH(restored, "/api/list/other", 1, 0, captures_other);
@@ -3020,9 +3020,9 @@ TEST_F(URITemplateRouterViewTest,
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list", "op_v_oex_pp1", 1);
     router.add("/api/list{/path*}", "op_v_oex_pp2", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/list", 1, 0, captures_root);
   EXPECT_EQ(captures_root.size(), 0);
   EXPECT_ROUTER_MATCH(restored, "/api/list/foo/bar", 2, 0, captures_nested);
@@ -3035,9 +3035,9 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/{namespace}/list{/path*}", "op_v_oex_idx", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/users/list/foo/bar", 1, 0, captures);
   EXPECT_EQ(captures.size(), 2);
   EXPECT_ROUTER_CAPTURE(captures, 0, "namespace", "users");
@@ -3049,9 +3049,9 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/{namespace}/list{/path*}", "op_v_oex_idx2", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/users/list", 1, 0, captures);
   EXPECT_EQ(captures.size(), 2);
   EXPECT_ROUTER_CAPTURE(captures, 0, "namespace", "users");
@@ -3062,9 +3062,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_operation_lookup) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "list_directory", 1, 42);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   const auto result = restored.operation("list_directory");
   EXPECT_EQ(result.first, 1);
   EXPECT_EQ(result.second, 42);
@@ -3074,9 +3074,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_size) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "op_v_oex_sz", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 1);
 }
 
@@ -3087,9 +3087,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_with_arguments) {
         arguments{
             {{"max", std::int64_t{99}}, {"name", std::string_view{"hello"}}}};
     router.add("/api/list{/path*}", "op_v_oex_args", 1, 0, arguments);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   std::vector<std::pair<std::string_view,
                         sourcemeta::core::URITemplateRouter::ArgumentValue>>
       collected;
@@ -3109,9 +3109,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_with_base_path) {
   {
     sourcemeta::core::URITemplateRouter router{"/v1"};
     router.add("/api/list{/path*}", "op_v_oex_bp", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.base_path(), "/v1");
   EXPECT_ROUTER_MATCH(restored, "/v1/api/list", 1, 0, captures_empty);
   EXPECT_EQ(captures_empty.size(), 1);
@@ -3126,9 +3126,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_otherwise_fallback) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "op_v_oex_o1", 1);
     router.otherwise(99);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/list/", 0, 99, captures_trailing);
   EXPECT_ROUTER_MATCH(restored, "/api/listing", 0, 99, captures_other);
 }
@@ -3137,9 +3137,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_root_template) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/{/path*}", "op_v_oex_root", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/foo", 1, 0, captures_one);
   EXPECT_EQ(captures_one.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures_one, 0, "path", "foo");
@@ -3153,9 +3153,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_under_variable_segment) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/{tenant}{/path*}", "op_v_oex_uv", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/acme", 1, 0, captures_empty);
   EXPECT_EQ(captures_empty.size(), 2);
   EXPECT_ROUTER_CAPTURE(captures_empty, 0, "tenant", "acme");
@@ -3170,9 +3170,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_motivating_use_case) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/self/v1/api/list{/path*}", "list_directory", 1, 7);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/self/v1/api/list", 1, 7, captures_root);
   EXPECT_EQ(captures_root.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures_root, 0, "path", "");
@@ -3193,9 +3193,9 @@ TEST_F(URITemplateRouterViewTest,
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/a{/x*}", "op_v_coex_a", 1);
     router.add("/api/b/{+y}", "op_v_coex_b", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/a", 1, 0, captures_a_empty);
   EXPECT_EQ(captures_a_empty.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures_a_empty, 0, "x", "");
@@ -3218,9 +3218,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_dotted_varname) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/foo.bar*}", "op_v_oex_dot", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/list/x/y", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures, 0, "foo.bar", "x/y");
@@ -3233,9 +3233,9 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_many_routes) {
     router.add("/b{/y*}", "op_v_many_b", 2);
     router.add("/c{/z*}", "op_v_many_c", 3);
     router.add("/d{/w*}", "op_v_many_d", 4);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 4);
   EXPECT_ROUTER_MATCH(restored, "/a", 1, 0, captures_a);
   EXPECT_ROUTER_CAPTURE(captures_a, 0, "x", "");
@@ -3251,9 +3251,9 @@ TEST_F(URITemplateRouterViewTest, variable_does_not_consume_multiple_segments) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}", "v_var_no_consume_1", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/users/42/extra", 0, 0, captures);
 }
 
@@ -3264,9 +3264,9 @@ TEST_F(URITemplateRouterViewTest,
     router.add("/a/{x}", "v_plain_var", 1);
     router.add("/b/{+y}", "v_reserved_exp", 2);
     router.add("/c{/z*}", "v_optional_exp", 3);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/a/one/two", 0, 0, captures_a);
   EXPECT_ROUTER_MATCH(restored, "/b/one/two", 2, 0, captures_b);
   EXPECT_EQ(captures_b.size(), 1);
@@ -3282,10 +3282,10 @@ TEST_F(URITemplateRouterViewTest, listing_at_returns_identifiers_in_add_order) {
     router.add("/users", "list_users", 7);
     router.add("/posts/{id}", "show_post", 3);
     router.add("/{+rest}", "fetch_all", 9);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 3);
   EXPECT_EQ(restored.at(0), 7);
   EXPECT_EQ(restored.at(1), 3);
@@ -3298,10 +3298,10 @@ TEST_F(URITemplateRouterViewTest, listing_context_returns_associated_context) {
     router.add("/users", "list_users", 1, 100);
     router.add("/posts/{id}", "show_post", 2, 200);
     router.add("/comments", "list_comments", 3, 300);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.context(1), 100);
   EXPECT_EQ(restored.context(2), 200);
   EXPECT_EQ(restored.context(3), 300);
@@ -3312,10 +3312,10 @@ TEST_F(URITemplateRouterViewTest, listing_context_default_zero) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "list_users", 1);
     router.add("/posts", "list_posts", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.context(1), 0);
   EXPECT_EQ(restored.context(2), 0);
 }
@@ -3324,10 +3324,10 @@ TEST_F(URITemplateRouterViewTest, listing_path_for_literal_route) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "list_users", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.path(1), "/users");
 }
 
@@ -3335,10 +3335,10 @@ TEST_F(URITemplateRouterViewTest, listing_path_for_variable_route) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}", "show_user", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.path(1), "/users/{id}");
 }
 
@@ -3346,10 +3346,10 @@ TEST_F(URITemplateRouterViewTest, listing_path_for_multi_variable_route) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}/posts/{post_id}", "show_post", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.path(1), "/users/{id}/posts/{post_id}");
 }
 
@@ -3357,10 +3357,10 @@ TEST_F(URITemplateRouterViewTest, listing_path_for_expansion_route) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{+rest}", "fetch_files", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.path(1), "/files/{+rest}");
 }
 
@@ -3368,10 +3368,10 @@ TEST_F(URITemplateRouterViewTest, listing_path_for_optional_expansion_route) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/api/list{/path*}", "list_directory", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.path(1), "/api/list{/path*}");
 }
 
@@ -3379,10 +3379,10 @@ TEST_F(URITemplateRouterViewTest, listing_path_for_root_route) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/", "root_route", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.path(1), "/");
 }
 
@@ -3394,10 +3394,10 @@ TEST_F(URITemplateRouterViewTest,
     router.add("/users/{id}", "show_user", 2);
     router.add("/posts/{id}/comments/{comment_id}", "show_comment", 3);
     router.add("/files/{+rest}", "fetch_files", 4);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.path(1), "/users");
   EXPECT_EQ(restored.path(2), "/users/{id}");
   EXPECT_EQ(restored.path(3), "/posts/{id}/comments/{comment_id}");
@@ -3410,10 +3410,10 @@ TEST_F(URITemplateRouterViewTest, listing_operation_id_round_trip) {
     router.add("/users", "list_users", 1);
     router.add("/posts/{id}", "show_post", 2);
     router.add("/files/{+rest}", "fetch_files", 3);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.operation_id(1), "list_users");
   EXPECT_EQ(restored.operation_id(2), "show_post");
   EXPECT_EQ(restored.operation_id(3), "fetch_files");
@@ -3423,10 +3423,10 @@ TEST_F(URITemplateRouterViewTest, listing_operation_id_zero_returns_empty) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "list_users", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.operation_id(0).empty());
 }
 
@@ -3435,10 +3435,10 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "list_users", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.operation_id(99).empty());
 }
 
@@ -3448,10 +3448,10 @@ TEST_F(URITemplateRouterViewTest, listing_operation_id_inverse_of_operation) {
     router.add("/a", "alpha", 1, 11);
     router.add("/b", "beta", 2, 22);
     router.add("/c", "gamma", 3, 33);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
 
   EXPECT_EQ(restored.operation_id(1), "alpha");
   EXPECT_EQ(restored.operation_id(2), "beta");
@@ -3476,9 +3476,9 @@ TEST_F(URITemplateRouterViewTest, listing_matches_writable_router) {
   router.add("/posts/{id}", "show_post", 2, 20);
   router.add("/files/{+rest}", "fetch_files", 3, 30);
   router.add("/api/list{/path*}", "list_directory", 4, 40);
-  sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  sourcemeta::core::URITemplateRouterView::save(router, this->path_);
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), router.size());
 
   EXPECT_EQ(restored.at(0), router.at(0));
@@ -3505,10 +3505,10 @@ TEST_F(URITemplateRouterViewTest, listing_matches_writable_router) {
 TEST_F(URITemplateRouterViewTest, listing_empty_router_size_zero) {
   {
     sourcemeta::core::URITemplateRouter router;
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 0);
   EXPECT_TRUE(restored.operation_id(0).empty());
   EXPECT_TRUE(restored.operation_id(1).empty());
@@ -3518,10 +3518,10 @@ TEST_F(URITemplateRouterViewTest, listing_only_otherwise_size_zero) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.otherwise(99);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 0);
   EXPECT_TRUE(restored.operation_id(0).empty());
 }
@@ -3530,10 +3530,10 @@ TEST_F(URITemplateRouterViewTest, listing_path_excludes_base_path) {
   {
     sourcemeta::core::URITemplateRouter router{"/api/v1"};
     router.add("/users/{id}", "show_user", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.path(1), "/users/{id}");
 }
 
@@ -3542,9 +3542,9 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo", "op_900", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/foo", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -3554,9 +3554,9 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo", "op_901", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/foo/", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -3566,9 +3566,9 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo/", "op_902", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/foo/", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -3578,9 +3578,9 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo/", "op_903", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/foo", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -3591,9 +3591,9 @@ TEST_F(URITemplateRouterViewTest,
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo", "op_904", 1);
     router.add("/foo/", "op_905", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/foo", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -3604,9 +3604,9 @@ TEST_F(URITemplateRouterViewTest,
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo", "op_906", 1);
     router.add("/foo/", "op_907", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/foo/", 2, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -3615,9 +3615,9 @@ TEST_F(URITemplateRouterViewTest, trailing_slash_after_variable_match_slashed) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}/", "op_908", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/users/42/", 1, 0, captures);
   EXPECT_EQ(captures.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "42");
@@ -3627,9 +3627,9 @@ TEST_F(URITemplateRouterViewTest, trailing_slash_after_variable_no_match_bare) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}/", "op_909", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/users/42", 0, 0, captures);
 }
 
@@ -3638,9 +3638,9 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo/bar", "op_910", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/foo//bar", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -3650,9 +3650,9 @@ TEST_F(URITemplateRouterViewTest, trailing_slash_with_base_path_both_forms) {
     sourcemeta::core::URITemplateRouter router{"/api"};
     router.add("/foo", "op_911", 1);
     router.add("/foo/", "op_912", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/api/foo", 1, 0, captures_bare);
   EXPECT_EQ(captures_bare.size(), 0);
   EXPECT_ROUTER_MATCH(restored, "/api/foo/", 2, 0, captures_slashed);
@@ -3664,9 +3664,9 @@ TEST_F(URITemplateRouterViewTest, trailing_slash_path_reconstruction) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo", "op_913", 1);
     router.add("/foo/", "op_914", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.path(1), "/foo");
   EXPECT_EQ(restored.path(2), "/foo/");
 }
@@ -3676,9 +3676,9 @@ TEST_F(URITemplateRouterViewTest, trailing_slash_size_is_two) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo", "op_915", 1);
     router.add("/foo/", "op_916", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.size(), 2);
 }
 
@@ -3687,9 +3687,9 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo//bar", "op_950", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/foo//bar", 1, 0, captures_verbatim);
   EXPECT_EQ(captures_verbatim.size(), 0);
   EXPECT_ROUTER_MATCH(restored, "/foo/bar", 0, 0, captures_canonical);
@@ -3700,9 +3700,9 @@ TEST_F(URITemplateRouterViewTest,
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("////", "op_951", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "////", 1, 0, captures_match);
   EXPECT_EQ(captures_match.size(), 0);
   EXPECT_ROUTER_MATCH(restored, "///", 0, 0, captures_short);
@@ -3713,9 +3713,9 @@ TEST_F(URITemplateRouterViewTest, strict_variable_does_not_bind_empty_segment) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users/{id}", "op_952", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/users/", 0, 0, captures);
 }
 
@@ -3724,9 +3724,9 @@ TEST_F(URITemplateRouterViewTest, strict_path_reconstruction_preserves_input) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo//bar", "op_954", 1);
     router.add("////", "op_955", 2);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_EQ(restored.path(1), "/foo//bar");
   EXPECT_EQ(restored.path(2), "////");
 }
@@ -3735,9 +3735,9 @@ TEST_F(URITemplateRouterViewTest, strict_root_template_still_works) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/", "op_956", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_ROUTER_MATCH(restored, "/", 1, 0, captures_match);
   EXPECT_EQ(captures_match.size(), 0);
   EXPECT_ROUTER_MATCH(restored, "//", 0, 0, captures_double);
@@ -3752,10 +3752,10 @@ TEST_F(URITemplateRouterViewTest, describes_worked_example_table) {
     router.add("/self/v1/health", "op_960", 4);
     router.add("/self/v1/static/{+path}", "op_961", 5);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/self/v1/api"));
   EXPECT_TRUE(restored.describes("/self/v1/api/schemas/health"));
   EXPECT_TRUE(restored.describes("/self/v1/api/schemas/health/acme"));
@@ -3773,10 +3773,10 @@ TEST_F(URITemplateRouterViewTest, describes_intermediate_prefixes) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/self/v1/mcp", "op_962", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/self"));
   EXPECT_TRUE(restored.describes("/self/v1"));
   EXPECT_TRUE(restored.describes("/self/v1/mcp"));
@@ -3790,10 +3790,10 @@ TEST_F(URITemplateRouterViewTest, describes_expansion_capture) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{+path}", "op_963", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/files"));
   EXPECT_TRUE(restored.describes("/files/a"));
   EXPECT_TRUE(restored.describes("/files/a/b/c"));
@@ -3806,10 +3806,10 @@ TEST_F(URITemplateRouterViewTest, describes_optional_expansion_capture) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/docs/{/rest*}", "op_964", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/docs"));
   EXPECT_TRUE(restored.describes("/docs/a"));
   EXPECT_TRUE(restored.describes("/docs/a/b/c"));
@@ -3823,10 +3823,10 @@ TEST_F(URITemplateRouterViewTest,
     sourcemeta::core::URITemplateRouter router;
     router.add("/foo/{bar}/baz", "op_965", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/foo"));
   EXPECT_TRUE(restored.describes("/foo/anything"));
   EXPECT_TRUE(restored.describes("/foo/anything/baz"));
@@ -3839,10 +3839,10 @@ TEST_F(URITemplateRouterViewTest, describes_whole_segment_discipline) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/internalish", "op_966", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/internalish"));
   EXPECT_FALSE(restored.describes("/internal"));
   EXPECT_FALSE(restored.describes("/internalisher"));
@@ -3853,10 +3853,10 @@ TEST_F(URITemplateRouterViewTest, describes_excludes_otherwise_fallback) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/known", "op_967", 1);
     router.otherwise(7);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/known"));
   EXPECT_FALSE(restored.describes("/unknown"));
   EXPECT_FALSE(restored.describes("/known/deeper"));
@@ -3866,10 +3866,10 @@ TEST_F(URITemplateRouterViewTest, describes_empty_router_describes_nothing) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.otherwise(3);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_FALSE(restored.describes("/"));
   EXPECT_FALSE(restored.describes(""));
   EXPECT_FALSE(restored.describes("/anything"));
@@ -3880,10 +3880,10 @@ TEST_F(URITemplateRouterViewTest, describes_root_and_empty_path) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_968", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/"));
   EXPECT_TRUE(restored.describes(""));
 }
@@ -3893,10 +3893,10 @@ TEST_F(URITemplateRouterViewTest, describes_requires_leading_slash) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_969", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_FALSE(restored.describes("users"));
   EXPECT_FALSE(restored.describes("users/list"));
 }
@@ -3906,10 +3906,10 @@ TEST_F(URITemplateRouterViewTest, describes_with_base_path) {
     sourcemeta::core::URITemplateRouter router{"/api"};
     router.add("/foo", "op_970", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/api/foo"));
   EXPECT_TRUE(restored.describes("/api"));
   EXPECT_FALSE(restored.describes("/foo"));
@@ -3922,10 +3922,10 @@ TEST_F(URITemplateRouterViewTest, describes_literal_preferred_over_variable) {
     router.add("/users/me", "op_971", 1);
     router.add("/users/{id}/posts", "op_972", 2);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/users/me"));
   EXPECT_TRUE(restored.describes("/users/42"));
   EXPECT_TRUE(restored.describes("/users/42/posts"));
@@ -3938,10 +3938,10 @@ TEST_F(URITemplateRouterViewTest, describes_empty_template_root_route) {
     sourcemeta::core::URITemplateRouter router;
     router.add("", "op_973", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes(""));
   EXPECT_TRUE(restored.describes("/"));
   EXPECT_FALSE(restored.describes("/foo"));
@@ -3962,10 +3962,10 @@ TEST_F(URITemplateRouterViewTest,
     router.add("/self/v1/api/{+any}", "op_974", 1);
     router.add("/self/v1/mcp", "op_975", 2);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/api", "/self/v1"));
   EXPECT_TRUE(restored.describes("/self/v1/api"));
   EXPECT_TRUE(restored.describes("/api/foo", "/self/v1"));
@@ -3980,10 +3980,10 @@ TEST_F(URITemplateRouterViewTest,
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{+path}", "op_976", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/files", ""));
   EXPECT_TRUE(restored.describes("/files/a/b", ""));
   EXPECT_TRUE(restored.describes("", "/files"));
@@ -3998,10 +3998,10 @@ TEST_F(URITemplateRouterViewTest,
     sourcemeta::core::URITemplateRouter router;
     router.add("/files/{+path}", "op_977", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/anything", "/files/already"));
 }
 
@@ -4010,10 +4010,10 @@ TEST_F(URITemplateRouterViewTest, describes_with_base_argument_base_mismatch) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/self/v1/mcp", "op_978", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_FALSE(restored.describes("/mcp", "/other"));
   EXPECT_FALSE(restored.describes("/mcp", "/self/v2"));
 }
@@ -4024,10 +4024,10 @@ TEST_F(URITemplateRouterViewTest,
     sourcemeta::core::URITemplateRouter router{"/prefix"};
     router.add("/foo", "op_979", 1);
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_TRUE(restored.describes("/foo", "/prefix"));
   EXPECT_TRUE(restored.describes("/prefix/foo"));
   EXPECT_TRUE(restored.describes("", "/prefix"));
@@ -4038,10 +4038,10 @@ TEST_F(URITemplateRouterViewTest, describes_with_base_argument_empty_router) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.otherwise(0);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const sourcemeta::core::URITemplateRouterView restored{this->path_};
   EXPECT_FALSE(restored.describes("/foo", "/bar"));
   EXPECT_FALSE(restored.describes("", "/bar"));
 }
@@ -4222,10 +4222,10 @@ TEST_F(URITemplateRouterViewTest, serialized_version_matches_corrupt_fixtures) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_1", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  std::ifstream input{this->path, std::ios::binary};
+  std::ifstream input{this->path_, std::ios::binary};
   const std::vector<std::uint8_t> bytes{std::istreambuf_iterator<char>{input},
                                         std::istreambuf_iterator<char>{}};
   std::uint32_t version{0};
@@ -4255,10 +4255,10 @@ TEST_F(URITemplateRouterViewTest, match_without_leading_slash_is_otherwise) {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_1", 1);
     router.otherwise(99);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView view{this->path};
+  const sourcemeta::core::URITemplateRouterView view{this->path_};
   EXPECT_ROUTER_MATCH(view, "users", 0, 99, captures);
   EXPECT_EQ(captures.size(), 0);
 }
@@ -4267,10 +4267,10 @@ TEST_F(URITemplateRouterViewTest, lookup_of_unknown_identifiers_misses) {
   {
     sourcemeta::core::URITemplateRouter router;
     router.add("/users", "op_1", 1);
-    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path_);
   }
 
-  const sourcemeta::core::URITemplateRouterView view{this->path};
+  const sourcemeta::core::URITemplateRouterView view{this->path_};
   EXPECT_EQ(view.at(5), 0);
   EXPECT_EQ(view.context(12345), 0);
   EXPECT_EQ(view.path(12345), "");

--- a/test/uritemplate/uritemplate_suite.cc
+++ b/test/uritemplate/uritemplate_suite.cc
@@ -36,7 +36,8 @@ public:
     if (value.is_string()) {
       return std::make_tuple(std::string_view{value.to_string()}, std::nullopt,
                              false);
-    } else if (value.is_array()) {
+    }
+    if (value.is_array()) {
       if (value.empty()) {
         return std::nullopt;
       }
@@ -53,7 +54,8 @@ public:
       std::advance(iterator, 1);
       return std::make_tuple(std::string_view{element.to_string()},
                              std::nullopt, iterator != array.cend());
-    } else if (value.is_object()) {
+    }
+    if (value.is_object()) {
       if (value.empty()) {
         return std::nullopt;
       }
@@ -71,18 +73,17 @@ public:
       return std::make_tuple(std::string_view{entry.second.to_string()},
                              std::string_view{entry.first},
                              iterator != object.cend());
-    } else {
-      auto cache_entry = this->cache_.find(name);
-      if (cache_entry == this->cache_.end()) {
-        std::ostringstream stream;
-        sourcemeta::core::stringify(value, stream);
-        cache_entry = this->cache_.emplace(name, stream.str()).first;
-      }
-
-      return std::make_tuple(
-          std::string_view{std::get<std::string>(cache_entry->second)},
-          std::nullopt, false);
     }
+    auto cache_entry = this->cache_.find(name);
+    if (cache_entry == this->cache_.end()) {
+      std::ostringstream stream;
+      sourcemeta::core::stringify(value, stream);
+      cache_entry = this->cache_.emplace(name, stream.str()).first;
+    }
+
+    return std::make_tuple(
+        std::string_view{std::get<std::string>(cache_entry->second)},
+        std::nullopt, false);
   }
 
 private:


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

