### PR TITLE
Add a `WWW-Authenticate` challenge type to the http module

### DIFF
--- a/src/core/http/CMakeLists.txt
+++ b/src/core/http/CMakeLists.txt
@@ -16,6 +16,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME http
           field_list.cc
           accept_includes_all.cc content_type_matches.cc parse_bearer.cc
           cache_control_max_age.cc serialize_cookie.cc aws_sigv4.cc
+          serialize_challenge.cc parse_challenges.cc
           scan_quoted_string.cc
           ${SOURCEMETA_CORE_HTTP_CLIENT_SOURCE})
 

--- a/src/core/http/include/sourcemeta/core/http.h
+++ b/src/core/http/include/sourcemeta/core/http.h
@@ -25,6 +25,7 @@
 #include <string>           // std::string
 #include <string_view>      // std::string_view
 #include <utility>          // std::pair
+#include <vector>           // std::vector
 
 /// @defgroup http HTTP
 /// @brief An implementation of HTTP-protocol parsing, formatting, and
@@ -262,6 +263,166 @@ auto http_format_links(std::span<const HTTPLink> links, std::string &out)
 /// ```
 SOURCEMETA_CORE_HTTP_EXPORT
 auto http_format_links(std::span<const HTTPLink> links) -> std::string;
+
+/// @ingroup http
+/// A challenge to serialise into an RFC 9110 §11.6.1 `WWW-Authenticate`
+/// response header value. The caller owns the backing storage for every field.
+///
+/// RFC 9110 §11.3 gives `challenge = auth-scheme [ 1*SP ( token68 /
+/// #auth-param ) ]`, so a challenge carries either a credential or a parameter
+/// list and never both.
+struct HTTPChallenge {
+  /// The authentication scheme
+  std::string_view scheme{};
+  /// The credential the challenge carries in place of parameters
+  std::optional<std::string_view> token68{};
+  /// The authentication parameters
+  std::span<const std::pair<std::string_view, std::string_view>> parameters{};
+};
+
+/// @ingroup http
+/// Test whether a challenge can be serialised into a valid RFC 9110 §11.6.1
+/// `WWW-Authenticate` header value: the scheme is a non-empty RFC 9110 §5.6.2
+/// token, a present credential is a §11.2 token68 and stands alone, every
+/// parameter name is a token, no parameter name repeats under the
+/// case-insensitive matching §11.2 mandates, and every value is encodable as a
+/// §5.6.4 quoted-string.
+///
+/// A challenge naming the Bearer scheme is held to RFC 6750 §3 as well, which
+/// requires at least one parameter and bounds the octets `scope`, `error`,
+/// `error_description` and `error_uri` may carry. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <array>
+/// #include <cassert>
+/// #include <string_view>
+/// #include <utility>
+///
+/// const std::array<std::pair<std::string_view, std::string_view>, 1>
+///     parameters{{{"realm", "example"}}};
+/// assert(sourcemeta::core::http_challenge_valid(
+///     {.scheme = "Bearer", .parameters = parameters}));
+/// ```
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_challenge_valid(const HTTPChallenge &challenge) -> bool;
+
+/// @ingroup http
+/// Append an RFC 9110 §11.6.1 `WWW-Authenticate` challenge to `out`, returning
+/// `true` on success. When the challenge is not `http_challenge_valid`, `out`
+/// is left unchanged and this returns `false`.
+///
+/// Every parameter value is spelled as a §5.6.4 quoted-string, since §11.5
+/// leaves a sender no other choice for a realm, and the encoding escapes a
+/// quote or a backslash rather than letting either close the value early. For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <array>
+/// #include <cassert>
+/// #include <string>
+/// #include <string_view>
+/// #include <utility>
+///
+/// const std::array<std::pair<std::string_view, std::string_view>, 1>
+///     parameters{{{"realm", "example"}}};
+/// std::string buffer;
+/// const auto ok{sourcemeta::core::http_serialize_challenge(
+///     {.scheme = "Bearer", .parameters = parameters}, buffer)};
+/// assert(ok);
+/// assert(buffer == "Bearer realm=\"example\"");
+/// ```
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_serialize_challenge(const HTTPChallenge &challenge, std::string &out)
+    -> bool;
+
+/// @ingroup http
+/// Serialise an RFC 9110 §11.6.1 `WWW-Authenticate` challenge, returning no
+/// value when the challenge is not `http_challenge_valid`.
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_serialize_challenge(const HTTPChallenge &challenge)
+    -> std::optional<std::string>;
+
+/// @ingroup http
+/// Append a whole RFC 9110 §11.6.1 `WWW-Authenticate` header value to `out`,
+/// which is a list of challenges. Returns `false` without touching `out` when
+/// the list is empty, since §11.6.1 requires a 401 to carry at least one
+/// challenge, or when any challenge is not `http_challenge_valid`.
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_serialize_challenges(std::span<const HTTPChallenge> challenges,
+                               std::string &out) -> bool;
+
+/// @ingroup http
+/// Serialise a whole RFC 9110 §11.6.1 `WWW-Authenticate` header value,
+/// returning no value when the list is empty or carries an invalid challenge.
+/// For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <array>
+/// #include <cassert>
+/// #include <string_view>
+/// #include <utility>
+///
+/// const std::array<std::pair<std::string_view, std::string_view>, 1>
+///     parameters{{{"realm", "api"}}};
+/// const std::array<sourcemeta::core::HTTPChallenge, 1> challenges{
+///     {{.scheme = "Bearer", .parameters = parameters}}};
+/// const auto value{sourcemeta::core::http_serialize_challenges(challenges)};
+/// assert(value == "Bearer realm=\"api\"");
+/// ```
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_serialize_challenges(std::span<const HTTPChallenge> challenges)
+    -> std::optional<std::string>;
+
+/// @ingroup http
+/// A challenge read out of an RFC 9110 §11.6.1 `WWW-Authenticate` header
+/// value. Unlike the challenge a caller hands to the serialiser, this one owns
+/// its strings, since a quoted-pair means a value does not always appear
+/// verbatim in the field it was read from.
+struct HTTPParsedChallenge {
+  /// The authentication scheme, as spelled in the field
+  std::string scheme;
+  /// The credential the challenge carried in place of parameters
+  std::optional<std::string> token68;
+  /// The authentication parameters, in the order they appeared
+  std::vector<std::pair<std::string, std::string>> parameters;
+};
+
+/// @ingroup http
+/// Parse an RFC 9110 §11.6.1 `WWW-Authenticate` header value, given without
+/// the field name, into its challenges, returning `false` and leaving the
+/// container empty when the value is malformed or carries no challenge at all.
+///
+/// The field is a list of challenges whose parameters are themselves
+/// comma-separated, so §11.6.1 warns recipients to take special care. A token
+/// followed by an equals sign continues the challenge being read, while one
+/// that is not opens the next, and a run of token characters closed by equals
+/// padding and nothing else is a §11.2 token68 rather than a parameter without
+/// a value. Empty list elements are ignored as §5.6.1.2 requires.
+///
+/// This applies the RFC 9110 grammar alone. A recipient judges nothing beyond
+/// it, so a challenge that `http_challenge_valid` would refuse a sender, such
+/// as a bare Bearer, still parses. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+/// #include <vector>
+///
+/// std::vector<sourcemeta::core::HTTPParsedChallenge> challenges;
+/// const auto ok{sourcemeta::core::http_parse_challenges(
+///     "Bearer realm=\"example\"", challenges)};
+/// assert(ok);
+/// assert(challenges.size() == 1);
+/// assert(challenges.at(0).scheme == "Bearer");
+/// assert(challenges.at(0).parameters.at(0).second == "example");
+/// ```
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_parse_challenges(const std::string_view input,
+                           std::vector<HTTPParsedChallenge> &challenges)
+    -> bool;
 
 /// @ingroup http
 /// The `SameSite` attribute of a cookie per RFC 6265bis §5.2.

--- a/src/core/http/parse_challenges.cc
+++ b/src/core/http/parse_challenges.cc
@@ -1,0 +1,219 @@
+#include <sourcemeta/core/http.h>
+
+#include "helpers.h"
+
+#include <cstddef>     // std::size_t
+#include <optional>    // std::optional, std::nullopt
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <utility>     // std::move
+#include <vector>      // std::vector
+
+namespace {
+
+auto skip_whitespace(const std::string_view input, std::size_t position)
+    -> std::size_t {
+  while (position < input.size() &&
+         sourcemeta::core::http_is_ows(input[position])) {
+    position += 1;
+  }
+
+  return position;
+}
+
+auto scan_token(const std::string_view input, std::size_t position)
+    -> std::size_t {
+  while (position < input.size() &&
+         sourcemeta::core::http_is_tchar(input[position])) {
+    position += 1;
+  }
+
+  return position;
+}
+
+// RFC 9110 §11.2: token68 = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" /
+// "/" ) *"=". The trailing padding is what makes a credential hard to tell
+// from a parameter, since both can put an equals sign after a run of token
+// characters, so the padding is taken greedily and the decision rests on what
+// follows it
+auto scan_token68(const std::string_view input, std::size_t position)
+    -> std::size_t {
+  const auto start{position};
+  while (position < input.size() &&
+         sourcemeta::core::http_is_b64token_char(input[position])) {
+    position += 1;
+  }
+
+  if (position == start) {
+    return start;
+  }
+
+  while (position < input.size() && input[position] == '=') {
+    position += 1;
+  }
+
+  return position;
+}
+
+// A credential stands alone, so nothing but the end of the field or the
+// separator before the next challenge may follow it. A parameter instead has
+// its value there, which is what tells the two apart
+auto ends_an_element(const std::string_view input, std::size_t position)
+    -> bool {
+  const auto next{skip_whitespace(input, position)};
+  return next >= input.size() || input[next] == ',';
+}
+
+// RFC 9110 §5.6.4: a quoted-string carries qdtext and quoted-pair, and a
+// quoted-pair contributes only its second octet
+auto scan_quoted_value(const std::string_view input, std::size_t position,
+                       std::string &value) -> std::optional<std::size_t> {
+  position += 1;
+  while (position < input.size()) {
+    const auto character{input[position]};
+    if (character == '\\') {
+      if (position + 1 >= input.size()) {
+        return std::nullopt;
+      }
+
+      value.push_back(input[position + 1]);
+      position += 2;
+      continue;
+    }
+
+    if (character == '"') {
+      return position + 1;
+    }
+
+    value.push_back(character);
+    position += 1;
+  }
+
+  return std::nullopt;
+}
+
+} // namespace
+
+namespace sourcemeta::core {
+
+auto http_parse_challenges(const std::string_view input,
+                           std::vector<HTTPParsedChallenge> &challenges)
+    -> bool {
+  challenges.clear();
+  std::size_t position{0};
+
+  while (true) {
+    // RFC 9110 §5.6.1.2: "A recipient MUST parse and ignore a reasonable
+    // number of empty list elements"
+    position = skip_whitespace(input, position);
+    while (position < input.size() && input[position] == ',') {
+      position = skip_whitespace(input, position + 1);
+    }
+
+    if (position >= input.size()) {
+      break;
+    }
+
+    // RFC 9110 §11.1: auth-scheme = token
+    const auto scheme_start{position};
+    const auto scheme_end{scan_token(input, scheme_start)};
+    if (scheme_end == scheme_start) {
+      challenges.clear();
+      return false;
+    }
+
+    HTTPParsedChallenge challenge;
+    challenge.scheme =
+        std::string{input.substr(scheme_start, scheme_end - scheme_start)};
+    position = scheme_end;
+
+    // RFC 9110 §11.3: the scheme is followed by at least one space before
+    // either alternative, so without one the challenge carries neither
+    const auto after_scheme{skip_whitespace(input, position)};
+    if (after_scheme == position || after_scheme >= input.size() ||
+        input[after_scheme] == ',') {
+      challenges.push_back(std::move(challenge));
+      position = after_scheme;
+      continue;
+    }
+
+    position = after_scheme;
+    const auto credential_end{scan_token68(input, position)};
+    if (credential_end != position && ends_an_element(input, credential_end)) {
+      challenge.token68 =
+          std::string{input.substr(position, credential_end - position)};
+      challenges.push_back(std::move(challenge));
+      position = credential_end;
+      continue;
+    }
+
+    // RFC 9110 §11.2: auth-param = token BWS "=" BWS ( token / quoted-string )
+    while (true) {
+      const auto name_start{position};
+      const auto name_end{scan_token(input, name_start)};
+      if (name_end == name_start) {
+        challenges.clear();
+        return false;
+      }
+
+      const auto after_name{skip_whitespace(input, name_end)};
+      if (after_name >= input.size() || input[after_name] != '=') {
+        // A token that no equals sign follows opens the next challenge rather
+        // than continuing this one, so it is left for the outer loop to read
+        position = name_start;
+        break;
+      }
+
+      const auto value_start{skip_whitespace(input, after_name + 1)};
+      if (value_start >= input.size()) {
+        challenges.clear();
+        return false;
+      }
+
+      std::string value;
+      if (input[value_start] == '"') {
+        const auto value_end{scan_quoted_value(input, value_start, value)};
+        if (!value_end.has_value()) {
+          challenges.clear();
+          return false;
+        }
+
+        position = value_end.value();
+      } else {
+        const auto value_end{scan_token(input, value_start)};
+        if (value_end == value_start) {
+          challenges.clear();
+          return false;
+        }
+
+        value = std::string{input.substr(value_start, value_end - value_start)};
+        position = value_end;
+      }
+
+      challenge.parameters.emplace_back(
+          std::string{input.substr(name_start, name_end - name_start)},
+          std::move(value));
+
+      position = skip_whitespace(input, position);
+      if (position >= input.size() || input[position] != ',') {
+        break;
+      }
+
+      // The separator between two parameters is the same one that separates
+      // two challenges, so §5.6.1.2 has empty elements ignored here too
+      while (position < input.size() && input[position] == ',') {
+        position = skip_whitespace(input, position + 1);
+      }
+
+      if (position >= input.size()) {
+        break;
+      }
+    }
+
+    challenges.push_back(std::move(challenge));
+  }
+
+  return !challenges.empty();
+}
+
+} // namespace sourcemeta::core

--- a/src/core/http/parse_challenges.cc
+++ b/src/core/http/parse_challenges.cc
@@ -64,34 +64,6 @@ auto ends_an_element(const std::string_view input, std::size_t position)
   return next >= input.size() || input[next] == ',';
 }
 
-// RFC 9110 §5.6.4: a quoted-string carries qdtext and quoted-pair, and a
-// quoted-pair contributes only its second octet
-auto scan_quoted_value(const std::string_view input, std::size_t position,
-                       std::string &value) -> std::optional<std::size_t> {
-  position += 1;
-  while (position < input.size()) {
-    const auto character{input[position]};
-    if (character == '\\') {
-      if (position + 1 >= input.size()) {
-        return std::nullopt;
-      }
-
-      value.push_back(input[position + 1]);
-      position += 2;
-      continue;
-    }
-
-    if (character == '"') {
-      return position + 1;
-    }
-
-    value.push_back(character);
-    position += 1;
-  }
-
-  return std::nullopt;
-}
-
 } // namespace
 
 namespace sourcemeta::core {
@@ -148,6 +120,7 @@ auto http_parse_challenges(const std::string_view input,
     }
 
     // RFC 9110 §11.2: auth-param = token BWS "=" BWS ( token / quoted-string )
+    bool first_parameter{true};
     while (true) {
       const auto name_start{position};
       const auto name_end{scan_token(input, name_start)};
@@ -159,10 +132,19 @@ auto http_parse_challenges(const std::string_view input,
       const auto after_name{skip_whitespace(input, name_end)};
       if (after_name >= input.size() || input[after_name] != '=') {
         // A token that no equals sign follows opens the next challenge rather
-        // than continuing this one, so it is left for the outer loop to read
+        // than continuing this one, so it is left for the outer loop to read.
+        // RFC 9110 §11.6.1 delimits that list with a comma, so one may only
+        // begin where a separator has just been passed
+        if (first_parameter) {
+          challenges.clear();
+          return false;
+        }
+
         position = name_start;
         break;
       }
+
+      first_parameter = false;
 
       const auto value_start{skip_whitespace(input, after_name + 1)};
       if (value_start >= input.size()) {
@@ -170,14 +152,20 @@ auto http_parse_challenges(const std::string_view input,
         return false;
       }
 
+      // The unescaping, and the refusal of any control character a
+      // quoted-string does not admit, is the module's own
+      std::string storage;
+      std::string_view scanned;
       std::string value;
       if (input[value_start] == '"') {
-        const auto value_end{scan_quoted_value(input, value_start, value)};
+        const auto value_end{
+            http_scan_quoted_string(input, value_start, storage, scanned)};
         if (!value_end.has_value()) {
           challenges.clear();
           return false;
         }
 
+        value = std::string{scanned};
         position = value_end.value();
       } else {
         const auto value_end{scan_token(input, value_start)};
@@ -195,8 +183,15 @@ auto http_parse_challenges(const std::string_view input,
           std::move(value));
 
       position = skip_whitespace(input, position);
-      if (position >= input.size() || input[position] != ',') {
+      if (position >= input.size()) {
         break;
+      }
+
+      // RFC 9110 §11.6.1: the field is a comma-delimited list, so nothing but
+      // a separator may follow a parameter
+      if (input[position] != ',') {
+        challenges.clear();
+        return false;
       }
 
       // The separator between two parameters is the same one that separates

--- a/src/core/http/serialize_challenge.cc
+++ b/src/core/http/serialize_challenge.cc
@@ -78,9 +78,9 @@ auto bearer_parameter_valid(const std::string_view name,
   // RFC 6749 Appendix A.9: error-uri = URI-reference, which RFC 6750 §3 notes
   // "thus MUST NOT include characters outside the set %x21 / %x23-5B /
   // %x5D-7E", so the grammar is checked rather than only its consequence.
-  // Unlike the parameters above it carries no repetition bound, and RFC 3986
-  // §4.1 reaches an empty reference through a relative one whose path is
-  // empty, so this is the one value of the four that may be
+  // Alone among the four it carries no repetition bound, and RFC 3986 §4.1
+  // admits an empty reference through a relative one whose path is empty, so
+  // this value may be empty where the others may not
   if (sourcemeta::core::equals_ignore_case(name, "error_uri")) {
     return std::ranges::all_of(value, is_nqchar) &&
            sourcemeta::core::URI::is_uri_reference(value);

--- a/src/core/http/serialize_challenge.cc
+++ b/src/core/http/serialize_challenge.cc
@@ -77,9 +77,12 @@ auto bearer_parameter_valid(const std::string_view name,
 
   // RFC 6749 Appendix A.9: error-uri = URI-reference, which RFC 6750 §3 notes
   // "thus MUST NOT include characters outside the set %x21 / %x23-5B /
-  // %x5D-7E", so the grammar is checked rather than only its consequence
+  // %x5D-7E", so the grammar is checked rather than only its consequence.
+  // Unlike the parameters above it carries no repetition bound, and RFC 3986
+  // §4.1 reaches an empty reference through a relative one whose path is
+  // empty, so this is the one value of the four that may be
   if (sourcemeta::core::equals_ignore_case(name, "error_uri")) {
-    return !value.empty() && std::ranges::all_of(value, is_nqchar) &&
+    return std::ranges::all_of(value, is_nqchar) &&
            sourcemeta::core::URI::is_uri_reference(value);
   }
 

--- a/src/core/http/serialize_challenge.cc
+++ b/src/core/http/serialize_challenge.cc
@@ -1,6 +1,8 @@
 #include <sourcemeta/core/http.h>
 #include <sourcemeta/core/text.h>
+#include <sourcemeta/core/uri.h>
 
+#include <algorithm>   // std::ranges::all_of
 #include <cstddef>     // std::size_t
 #include <optional>    // std::optional, std::nullopt
 #include <span>        // std::span
@@ -13,39 +15,46 @@ constexpr std::string_view CHALLENGE_SCHEME_SEPARATOR{" "};
 constexpr std::string_view CHALLENGE_PARAMETER_SEPARATOR{", "};
 constexpr std::string_view CHALLENGE_PARAMETER_EQUALS{"="};
 
-// RFC 6750 §3: "Values for the 'scope' attribute MUST NOT include characters
-// outside the set %x21 / %x23-5B / %x5D-7E for representing scope values and
-// %x20 for delimiters between scope values"
-auto is_scope_octet(const char character) noexcept -> bool {
-  const auto value{static_cast<unsigned char>(character)};
-  return value == 0x20 || value == 0x21 || (value >= 0x23 && value <= 0x5B) ||
-         (value >= 0x5D && value <= 0x7E);
-}
-
-// RFC 6750 §3: "Values for the 'error' and 'error_description' attributes
-// MUST NOT include characters outside the set %x20-21 / %x23-5B / %x5D-7E"
-auto is_error_octet(const char character) noexcept -> bool {
-  const auto value{static_cast<unsigned char>(character)};
-  return (value >= 0x20 && value <= 0x21) || (value >= 0x23 && value <= 0x5B) ||
-         (value >= 0x5D && value <= 0x7E);
-}
-
-// RFC 6750 §3: "Values for the 'error_uri' attribute MUST conform to the
-// URI-reference syntax and thus MUST NOT include characters outside the set
-// %x21 / %x23-5B / %x5D-7E"
-auto is_error_uri_octet(const char character) noexcept -> bool {
+// RFC 6749 Appendix A: NQCHAR = %x21 / %x23-5B / %x5D-7E
+auto is_nqchar(const char character) noexcept -> bool {
   const auto value{static_cast<unsigned char>(character)};
   return value == 0x21 || (value >= 0x23 && value <= 0x5B) ||
          (value >= 0x5D && value <= 0x7E);
 }
 
-template <typename Predicate>
-auto every_octet(const std::string_view value, Predicate predicate) noexcept
-    -> bool {
+// RFC 6749 Appendix A: NQSCHAR = %x20-21 / %x23-5B / %x5D-7E
+auto is_nqschar(const char character) noexcept -> bool {
+  const auto value{static_cast<unsigned char>(character)};
+  return (value >= 0x20 && value <= 0x21) || (value >= 0x23 && value <= 0x5B) ||
+         (value >= 0x5D && value <= 0x7E);
+}
+
+// RFC 6749 Appendix A.4: scope = scope-token *( SP scope-token ), where
+// scope-token = 1*NQCHAR. The space delimits two values rather than being
+// content, so it can neither open nor close the list nor stand doubled, which
+// is what RFC 6750 §3 means by admitting it only "for delimiters between
+// scope values"
+auto is_scope(const std::string_view value) noexcept -> bool {
+  if (value.empty() || value.front() == ' ' || value.back() == ' ') {
+    return false;
+  }
+
+  bool previous_was_space{false};
   for (const auto character : value) {
-    if (!predicate(character)) {
+    if (character == ' ') {
+      if (previous_was_space) {
+        return false;
+      }
+
+      previous_was_space = true;
+      continue;
+    }
+
+    if (!is_nqchar(character)) {
       return false;
     }
+
+    previous_was_space = false;
   }
 
   return true;
@@ -54,18 +63,24 @@ auto every_octet(const std::string_view value, Predicate predicate) noexcept
 // The parameters RFC 6750 §3 constrains beyond the RFC 9110 grammar, which
 // only bind when the challenge carries the scheme that specification defines
 auto bearer_parameter_valid(const std::string_view name,
-                            const std::string_view value) noexcept -> bool {
+                            const std::string_view value) -> bool {
   if (sourcemeta::core::equals_ignore_case(name, "scope")) {
-    return every_octet(value, is_scope_octet);
+    return is_scope(value);
   }
 
+  // RFC 6749 Appendix A.7 and A.8: error = 1*NQSCHAR and
+  // error-description = 1*NQSCHAR, so neither may be empty
   if (sourcemeta::core::equals_ignore_case(name, "error") ||
       sourcemeta::core::equals_ignore_case(name, "error_description")) {
-    return every_octet(value, is_error_octet);
+    return !value.empty() && std::ranges::all_of(value, is_nqschar);
   }
 
+  // RFC 6749 Appendix A.9: error-uri = URI-reference, which RFC 6750 §3 notes
+  // "thus MUST NOT include characters outside the set %x21 / %x23-5B /
+  // %x5D-7E", so the grammar is checked rather than only its consequence
   if (sourcemeta::core::equals_ignore_case(name, "error_uri")) {
-    return every_octet(value, is_error_uri_octet);
+    return !value.empty() && std::ranges::all_of(value, is_nqchar) &&
+           sourcemeta::core::URI::is_uri_reference(value);
   }
 
   return true;

--- a/src/core/http/serialize_challenge.cc
+++ b/src/core/http/serialize_challenge.cc
@@ -1,0 +1,223 @@
+#include <sourcemeta/core/http.h>
+#include <sourcemeta/core/text.h>
+
+#include <cstddef>     // std::size_t
+#include <optional>    // std::optional, std::nullopt
+#include <span>        // std::span
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace {
+
+constexpr std::string_view CHALLENGE_SCHEME_SEPARATOR{" "};
+constexpr std::string_view CHALLENGE_PARAMETER_SEPARATOR{", "};
+constexpr std::string_view CHALLENGE_PARAMETER_EQUALS{"="};
+
+// RFC 6750 §3: "Values for the 'scope' attribute MUST NOT include characters
+// outside the set %x21 / %x23-5B / %x5D-7E for representing scope values and
+// %x20 for delimiters between scope values"
+auto is_scope_octet(const char character) noexcept -> bool {
+  const auto value{static_cast<unsigned char>(character)};
+  return value == 0x20 || value == 0x21 || (value >= 0x23 && value <= 0x5B) ||
+         (value >= 0x5D && value <= 0x7E);
+}
+
+// RFC 6750 §3: "Values for the 'error' and 'error_description' attributes
+// MUST NOT include characters outside the set %x20-21 / %x23-5B / %x5D-7E"
+auto is_error_octet(const char character) noexcept -> bool {
+  const auto value{static_cast<unsigned char>(character)};
+  return (value >= 0x20 && value <= 0x21) || (value >= 0x23 && value <= 0x5B) ||
+         (value >= 0x5D && value <= 0x7E);
+}
+
+// RFC 6750 §3: "Values for the 'error_uri' attribute MUST conform to the
+// URI-reference syntax and thus MUST NOT include characters outside the set
+// %x21 / %x23-5B / %x5D-7E"
+auto is_error_uri_octet(const char character) noexcept -> bool {
+  const auto value{static_cast<unsigned char>(character)};
+  return value == 0x21 || (value >= 0x23 && value <= 0x5B) ||
+         (value >= 0x5D && value <= 0x7E);
+}
+
+template <typename Predicate>
+auto every_octet(const std::string_view value, Predicate predicate) noexcept
+    -> bool {
+  for (const auto character : value) {
+    if (!predicate(character)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// The parameters RFC 6750 §3 constrains beyond the RFC 9110 grammar, which
+// only bind when the challenge carries the scheme that specification defines
+auto bearer_parameter_valid(const std::string_view name,
+                            const std::string_view value) noexcept -> bool {
+  if (sourcemeta::core::equals_ignore_case(name, "scope")) {
+    return every_octet(value, is_scope_octet);
+  }
+
+  if (sourcemeta::core::equals_ignore_case(name, "error") ||
+      sourcemeta::core::equals_ignore_case(name, "error_description")) {
+    return every_octet(value, is_error_octet);
+  }
+
+  if (sourcemeta::core::equals_ignore_case(name, "error_uri")) {
+    return every_octet(value, is_error_uri_octet);
+  }
+
+  return true;
+}
+
+auto required_size(const sourcemeta::core::HTTPChallenge &challenge) noexcept
+    -> std::size_t {
+  std::size_t size{challenge.scheme.size()};
+  if (challenge.token68.has_value()) {
+    return size + CHALLENGE_SCHEME_SEPARATOR.size() + challenge.token68->size();
+  }
+
+  for (const auto &[name, value] : challenge.parameters) {
+    // Two quotes, and room for escaping every octet of the value
+    size += CHALLENGE_PARAMETER_SEPARATOR.size() + name.size() +
+            CHALLENGE_PARAMETER_EQUALS.size() + (value.size() * 2) + 2;
+  }
+
+  return size;
+}
+
+} // namespace
+
+namespace sourcemeta::core {
+
+auto http_challenge_valid(const HTTPChallenge &challenge) -> bool {
+  // RFC 9110 §11.1: auth-scheme = token
+  if (!http_is_token(challenge.scheme)) {
+    return false;
+  }
+
+  // RFC 9110 §11.3: challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ],
+  // so the two alternatives are exclusive
+  if (challenge.token68.has_value()) {
+    if (!challenge.parameters.empty() ||
+        !http_is_b64token(challenge.token68.value())) {
+      return false;
+    }
+  }
+
+  // RFC 6750 §3: "All challenges defined by this specification MUST use the
+  // auth-scheme value "Bearer". This scheme MUST be followed by one or more
+  // auth-param values", which rules out both a bare scheme and a credential
+  const auto is_bearer{equals_ignore_case(challenge.scheme, "Bearer")};
+  if (is_bearer && challenge.parameters.empty()) {
+    return false;
+  }
+
+  for (std::size_t index{0}; index < challenge.parameters.size(); index += 1) {
+    const auto &[name, value] = challenge.parameters[index];
+    // RFC 9110 §11.2: auth-param = token BWS "=" BWS ( token / quoted-string )
+    if (!http_is_token(name)) {
+      return false;
+    }
+
+    // RFC 9110 §11.2: "each parameter name MUST only occur once per
+    // challenge", where the name "is matched case-insensitively"
+    for (std::size_t other{0}; other < index; other += 1) {
+      if (equals_ignore_case(challenge.parameters[other].first, name)) {
+        return false;
+      }
+    }
+
+    if (is_bearer && !bearer_parameter_valid(name, value)) {
+      return false;
+    }
+
+    // RFC 9110 §11.5 requires a sender to spell a realm as a quoted-string,
+    // and every value is spelled that way, so each one has to be encodable
+    std::string scratch;
+    if (!http_encode_quoted_string(value, scratch)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+auto http_serialize_challenge(const HTTPChallenge &challenge, std::string &out)
+    -> bool {
+  if (!http_challenge_valid(challenge)) {
+    return false;
+  }
+
+  out.reserve(out.size() + required_size(challenge));
+  out.append(challenge.scheme);
+
+  if (challenge.token68.has_value()) {
+    out.append(CHALLENGE_SCHEME_SEPARATOR);
+    out.append(challenge.token68.value());
+    return true;
+  }
+
+  // RFC 9110 §11.2 admits a token as well, but the quoted-string is the only
+  // spelling §11.5 lets a sender use for a realm, so every value takes it and
+  // no caller has to weigh which one a given value needs
+  bool first{true};
+  for (const auto &[name, value] : challenge.parameters) {
+    out.append(first ? CHALLENGE_SCHEME_SEPARATOR
+                     : CHALLENGE_PARAMETER_SEPARATOR);
+    out.append(name);
+    // RFC 9110 §5.6.3: a sender must not generate the bad whitespace the
+    // grammar tolerates around the equals sign
+    out.append(CHALLENGE_PARAMETER_EQUALS);
+    http_encode_quoted_string(value, out);
+    first = false;
+  }
+
+  return true;
+}
+
+auto http_serialize_challenge(const HTTPChallenge &challenge)
+    -> std::optional<std::string> {
+  std::string out;
+  if (!http_serialize_challenge(challenge, out)) {
+    return std::nullopt;
+  }
+
+  return out;
+}
+
+auto http_serialize_challenges(std::span<const HTTPChallenge> challenges,
+                               std::string &out) -> bool {
+  // RFC 9110 §11.6.1: a server answering with a 401 "MUST send a
+  // WWW-Authenticate header field containing at least one challenge"
+  if (challenges.empty()) {
+    return false;
+  }
+
+  for (const auto &challenge : challenges) {
+    if (!http_challenge_valid(challenge)) {
+      return false;
+    }
+  }
+
+  http_serialize_challenge(challenges.front(), out);
+  for (const auto &challenge : challenges.subspan(1)) {
+    out.append(CHALLENGE_PARAMETER_SEPARATOR);
+    http_serialize_challenge(challenge, out);
+  }
+
+  return true;
+}
+
+auto http_serialize_challenges(std::span<const HTTPChallenge> challenges)
+    -> std::optional<std::string> {
+  std::string out;
+  if (!http_serialize_challenges(challenges, out)) {
+    return std::nullopt;
+  }
+
+  return out;
+}
+
+} // namespace sourcemeta::core

--- a/test/http/CMakeLists.txt
+++ b/test/http/CMakeLists.txt
@@ -4,6 +4,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME http
           http_negotiate_encoding_test.cc http_from_date_test.cc
           http_format_link_test.cc http_field_list_contains_any_test.cc
           http_format_vary_test.cc http_expire_cookie_test.cc
+          http_serialize_challenge_test.cc http_parse_challenges_test.cc
           http_accept_includes_all_test.cc http_content_type_matches_test.cc
           http_method_test.cc http_status_from_code_test.cc
           http_is_status_line_test.cc http_accumulate_header_line_test.cc

--- a/test/http/http_parse_challenges_test.cc
+++ b/test/http/http_parse_challenges_test.cc
@@ -253,3 +253,33 @@ TEST(parse_challenges_round_trips_a_serialized_challenge) {
   EXPECT_EQ(challenges.at(0).parameters.at(0).second, "a\"b");
   EXPECT_EQ(challenges.at(0).parameters.at(1).second, "invalid_token");
 }
+
+// RFC 9110 §5.6.4: qdtext and the escaped octet of a quoted-pair admit HTAB,
+// SP, the visible characters and obs-text, so any other control character
+// makes the value unreadable rather than carrying it through
+TEST(parse_challenges_rejects_a_control_character_within_a_value) {
+  Challenges challenges;
+  EXPECT_FALSE(sourcemeta::core::http_parse_challenges(
+      "Bearer realm=\"a\r\nb\"", challenges));
+}
+
+TEST(parse_challenges_admits_a_horizontal_tab_within_a_value) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges("Bearer realm=\"a\tb\"",
+                                                      challenges));
+  EXPECT_EQ(challenges.at(0).parameters.at(0).second, "a\tb");
+}
+
+// RFC 9110 §11.6.1: WWW-Authenticate = #challenge, so a comma delimits two
+// challenges and one cannot simply abut the other
+TEST(parse_challenges_rejects_a_missing_separator_between_challenges) {
+  Challenges challenges;
+  EXPECT_FALSE(sourcemeta::core::http_parse_challenges(
+      "Bearer realm=\"a\" Basic realm=\"b\"", challenges));
+}
+
+TEST(parse_challenges_rejects_a_token_that_opens_no_parameter) {
+  Challenges challenges;
+  EXPECT_FALSE(
+      sourcemeta::core::http_parse_challenges("Bearer abc def", challenges));
+}

--- a/test/http/http_parse_challenges_test.cc
+++ b/test/http/http_parse_challenges_test.cc
@@ -1,0 +1,255 @@
+#include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
+
+#include <array>       // std::array
+#include <cstddef>     // std::size_t
+#include <string_view> // std::string_view
+#include <utility>     // std::pair
+#include <vector>      // std::vector
+
+namespace {
+using Challenges = std::vector<sourcemeta::core::HTTPParsedChallenge>;
+}
+
+// RFC 6750 §3: "WWW-Authenticate: Bearer realm="example""
+TEST(parse_challenges_bearer_with_a_realm) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges(
+      "Bearer realm=\"example\"", challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(1));
+  EXPECT_EQ(challenges.at(0).scheme, "Bearer");
+  EXPECT_FALSE(challenges.at(0).token68.has_value());
+  EXPECT_EQ(challenges.at(0).parameters.size(), static_cast<std::size_t>(1));
+  EXPECT_EQ(challenges.at(0).parameters.at(0).first, "realm");
+  EXPECT_EQ(challenges.at(0).parameters.at(0).second, "example");
+}
+
+TEST(parse_challenges_several_parameters) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges(
+      "Bearer realm=\"example\", error=\"invalid_token\", "
+      "error_description=\"The access token expired\"",
+      challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(1));
+  EXPECT_EQ(challenges.at(0).parameters.size(), static_cast<std::size_t>(3));
+  EXPECT_EQ(challenges.at(0).parameters.at(1).first, "error");
+  EXPECT_EQ(challenges.at(0).parameters.at(1).second, "invalid_token");
+  EXPECT_EQ(challenges.at(0).parameters.at(2).second,
+            "The access token expired");
+}
+
+// RFC 9110 §11.6.1 warns that a field value "might contain more than one
+// challenge, and each challenge can contain a comma-separated list of
+// authentication parameters", so a token that no equals sign follows opens a
+// new challenge rather than continuing the current one
+TEST(parse_challenges_two_challenges) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges(
+      "Bearer realm=\"a\", Basic realm=\"b\"", challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(2));
+  EXPECT_EQ(challenges.at(0).scheme, "Bearer");
+  EXPECT_EQ(challenges.at(0).parameters.at(0).second, "a");
+  EXPECT_EQ(challenges.at(1).scheme, "Basic");
+  EXPECT_EQ(challenges.at(1).parameters.at(0).second, "b");
+}
+
+TEST(parse_challenges_bare_scheme_before_another) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges(
+      "Negotiate, Basic realm=\"b\"", challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(2));
+  EXPECT_EQ(challenges.at(0).scheme, "Negotiate");
+  EXPECT_TRUE(challenges.at(0).parameters.empty());
+  EXPECT_EQ(challenges.at(1).scheme, "Basic");
+}
+
+TEST(parse_challenges_bare_scheme_alone) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges("Negotiate", challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(1));
+  EXPECT_EQ(challenges.at(0).scheme, "Negotiate");
+  EXPECT_TRUE(challenges.at(0).parameters.empty());
+  EXPECT_FALSE(challenges.at(0).token68.has_value());
+}
+
+// RFC 9110 §11.2: token68 ends in optional "=" padding, which has to be told
+// apart from the equals sign that opens a parameter value
+TEST(parse_challenges_token68) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges(
+      "Negotiate YIIFQwYGKwYBBQUCoIIFNzCC", challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(1));
+  EXPECT_TRUE(challenges.at(0).token68.has_value());
+  EXPECT_EQ(challenges.at(0).token68.value(), "YIIFQwYGKwYBBQUCoIIFNzCC");
+  EXPECT_TRUE(challenges.at(0).parameters.empty());
+}
+
+TEST(parse_challenges_token68_with_padding) {
+  Challenges challenges;
+  EXPECT_TRUE(
+      sourcemeta::core::http_parse_challenges("Negotiate YWJj==", challenges));
+  EXPECT_TRUE(challenges.at(0).token68.has_value());
+  EXPECT_EQ(challenges.at(0).token68.value(), "YWJj==");
+}
+
+TEST(parse_challenges_token68_followed_by_another_challenge) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges(
+      "Negotiate YWJj==, Basic realm=\"b\"", challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(2));
+  EXPECT_EQ(challenges.at(0).token68.value(), "YWJj==");
+  EXPECT_EQ(challenges.at(1).scheme, "Basic");
+}
+
+// RFC 9110 §11.2: auth-param = token BWS "=" BWS ( token / quoted-string ), so
+// an unquoted value is equally well formed
+TEST(parse_challenges_token_value) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges("Bearer realm=example",
+                                                      challenges));
+  EXPECT_EQ(challenges.at(0).parameters.at(0).second, "example");
+}
+
+TEST(parse_challenges_token_value_before_another_parameter) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges(
+      "Bearer realm=example, error=invalid_token", challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(1));
+  EXPECT_EQ(challenges.at(0).parameters.size(), static_cast<std::size_t>(2));
+}
+
+// RFC 9110 §5.6.4: a quoted-pair carries only its second octet
+TEST(parse_challenges_unescapes_a_quote) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges("Bearer realm=\"a\\\"b\"",
+                                                      challenges));
+  EXPECT_EQ(challenges.at(0).parameters.at(0).second, "a\"b");
+}
+
+TEST(parse_challenges_unescapes_a_backslash) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges("Bearer realm=\"a\\\\b\"",
+                                                      challenges));
+  EXPECT_EQ(challenges.at(0).parameters.at(0).second, "a\\b");
+}
+
+TEST(parse_challenges_keeps_a_comma_within_a_quoted_value) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges("Bearer realm=\"a,b\"",
+                                                      challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(1));
+  EXPECT_EQ(challenges.at(0).parameters.at(0).second, "a,b");
+}
+
+// RFC 9110 §11.2: auth-param tolerates the bad whitespace the grammar names
+// around the equals sign, which a recipient still has to accept
+TEST(parse_challenges_tolerates_whitespace_around_the_equals_sign) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges(
+      "Bearer realm = \"example\"", challenges));
+  EXPECT_EQ(challenges.at(0).parameters.at(0).second, "example");
+}
+
+TEST(parse_challenges_tolerates_whitespace_around_the_separator) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges(
+      "Bearer realm=\"a\"  ,   error=\"b\"", challenges));
+  EXPECT_EQ(challenges.at(0).parameters.size(), static_cast<std::size_t>(2));
+}
+
+// RFC 9110 §5.6.1.2: "A recipient MUST parse and ignore a reasonable number of
+// empty list elements"
+TEST(parse_challenges_ignores_empty_list_elements) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges(
+      "Bearer realm=\"a\",, Basic realm=\"b\"", challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(2));
+}
+
+TEST(parse_challenges_ignores_a_leading_separator) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges(", Bearer realm=\"a\"",
+                                                      challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(1));
+}
+
+TEST(parse_challenges_ignores_a_trailing_separator) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges("Bearer realm=\"a\", ",
+                                                      challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(1));
+}
+
+TEST(parse_challenges_empty_input) {
+  Challenges challenges;
+  EXPECT_FALSE(sourcemeta::core::http_parse_challenges("", challenges));
+}
+
+TEST(parse_challenges_only_separators) {
+  Challenges challenges;
+  EXPECT_FALSE(sourcemeta::core::http_parse_challenges(",,", challenges));
+}
+
+TEST(parse_challenges_unterminated_quoted_string) {
+  Challenges challenges;
+  EXPECT_FALSE(
+      sourcemeta::core::http_parse_challenges("Bearer realm=\"a", challenges));
+}
+
+// RFC 9110 §11.2: a run of token characters followed by an equals sign and
+// nothing else is a token68 with its padding, not a parameter missing a value,
+// so the grammar settles the ambiguity in favour of the credential
+TEST(parse_challenges_trailing_equals_sign_reads_as_a_credential) {
+  Challenges challenges;
+  EXPECT_TRUE(
+      sourcemeta::core::http_parse_challenges("Bearer realm=", challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(1));
+  EXPECT_TRUE(challenges.at(0).token68.has_value());
+  EXPECT_EQ(challenges.at(0).token68.value(), "realm=");
+  EXPECT_TRUE(challenges.at(0).parameters.empty());
+}
+
+TEST(parse_challenges_missing_parameter_value_before_a_separator) {
+  Challenges challenges;
+  EXPECT_FALSE(sourcemeta::core::http_parse_challenges("Bearer realm=\"a\", b=",
+                                                       challenges));
+}
+
+TEST(parse_challenges_scheme_that_is_not_a_token) {
+  Challenges challenges;
+  EXPECT_FALSE(sourcemeta::core::http_parse_challenges("\"Bearer\" realm=\"a\"",
+                                                       challenges));
+}
+
+TEST(parse_challenges_clears_the_container_first) {
+  Challenges challenges;
+  challenges.emplace_back();
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges("Negotiate", challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(1));
+  EXPECT_EQ(challenges.at(0).scheme, "Negotiate");
+}
+
+// A recipient judges nothing beyond the grammar, so a challenge a sender would
+// have been refused for still parses
+TEST(parse_challenges_accepts_a_bare_bearer) {
+  Challenges challenges;
+  EXPECT_TRUE(sourcemeta::core::http_parse_challenges("Bearer", challenges));
+  EXPECT_EQ(challenges.at(0).scheme, "Bearer");
+  EXPECT_TRUE(challenges.at(0).parameters.empty());
+}
+
+// What this module serialises, it reads back unchanged
+TEST(parse_challenges_round_trips_a_serialized_challenge) {
+  const std::array<std::pair<std::string_view, std::string_view>, 2> parameters{
+      {{"realm", "a\"b"}, {"error", "invalid_token"}}};
+  const auto serialized{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Bearer", .parameters = parameters})};
+  EXPECT_TRUE(serialized.has_value());
+  Challenges challenges;
+  EXPECT_TRUE(
+      sourcemeta::core::http_parse_challenges(serialized.value(), challenges));
+  EXPECT_EQ(challenges.size(), static_cast<std::size_t>(1));
+  EXPECT_EQ(challenges.at(0).scheme, "Bearer");
+  EXPECT_EQ(challenges.at(0).parameters.at(0).second, "a\"b");
+  EXPECT_EQ(challenges.at(0).parameters.at(1).second, "invalid_token");
+}

--- a/test/http/http_serialize_challenge_test.cc
+++ b/test/http/http_serialize_challenge_test.cc
@@ -1,0 +1,311 @@
+#include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
+
+#include <array>       // std::array
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <utility>     // std::pair
+
+namespace {
+using Parameter = std::pair<std::string_view, std::string_view>;
+}
+
+// RFC 6750 §3: "WWW-Authenticate: Bearer realm="example""
+TEST(serialize_challenge_bearer_with_a_realm) {
+  const std::array<Parameter, 1> parameters{{{"realm", "example"}}};
+  const auto value{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Bearer", .parameters = parameters})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Bearer realm=\"example\"");
+}
+
+// RFC 6750 §3: the expired access token example, with its three parameters
+TEST(serialize_challenge_bearer_with_an_error) {
+  const std::array<Parameter, 3> parameters{
+      {{"realm", "example"},
+       {"error", "invalid_token"},
+       {"error_description", "The access token expired"}}};
+  const auto value{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Bearer", .parameters = parameters})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Bearer realm=\"example\", error=\"invalid_token\", "
+                           "error_description=\"The access token expired\"");
+}
+
+// RFC 9728 §5.1: the protected resource metadata URL parameter
+TEST(serialize_challenge_bearer_with_resource_metadata) {
+  const std::array<Parameter, 1> parameters{
+      {{"resource_metadata",
+        "https://resource.example.com/.well-known/oauth-protected-resource"}}};
+  const auto value{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Bearer", .parameters = parameters})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(),
+            "Bearer resource_metadata=\"https://resource.example.com/"
+            ".well-known/oauth-protected-resource\"");
+}
+
+// RFC 9110 §11.5: "a sender MUST only generate the quoted-string syntax", so
+// a realm is quoted even though its value would pass as a bare token
+TEST(serialize_challenge_quotes_a_token_shaped_realm) {
+  const std::array<Parameter, 1> parameters{{{"realm", "registry"}}};
+  const auto value{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Bearer", .parameters = parameters})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Bearer realm=\"registry\"");
+}
+
+// RFC 9110 §5.6.4: a double quote within the value is escaped rather than
+// closing the quoted-string early, which no guard over an already serialized
+// parameter list can achieve
+TEST(serialize_challenge_escapes_a_quote_within_a_value) {
+  const std::array<Parameter, 1> parameters{{{"realm", "a\"b"}}};
+  const auto value{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Bearer", .parameters = parameters})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Bearer realm=\"a\\\"b\"");
+}
+
+TEST(serialize_challenge_escapes_a_backslash_within_a_value) {
+  const std::array<Parameter, 1> parameters{{{"realm", "a\\b"}}};
+  const auto value{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Bearer", .parameters = parameters})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Bearer realm=\"a\\\\b\"");
+}
+
+// A comma inside a value is content, and quoting keeps it from reading as the
+// separator between two challenges
+TEST(serialize_challenge_keeps_a_comma_within_a_value) {
+  const std::array<Parameter, 1> parameters{{{"realm", "a,b"}}};
+  const auto value{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Bearer", .parameters = parameters})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Bearer realm=\"a,b\"");
+}
+
+// RFC 9110 §5.6.4: a control character is outside qdtext and quoted-pair, so
+// the value cannot be encoded at all
+TEST(serialize_challenge_rejects_a_line_break_within_a_value) {
+  const std::array<Parameter, 1> parameters{{{"realm", "a\r\nX-Injected: 1"}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+// RFC 9110 §11.2: "each parameter name MUST only occur once per challenge",
+// matched case-insensitively
+TEST(serialize_challenge_rejects_a_repeated_parameter) {
+  const std::array<Parameter, 2> parameters{
+      {{"realm", "one"}, {"realm", "two"}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+TEST(serialize_challenge_rejects_a_repeated_parameter_differing_in_case) {
+  const std::array<Parameter, 2> parameters{
+      {{"realm", "one"}, {"REALM", "two"}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+// RFC 9110 §11.1: auth-scheme = token
+TEST(serialize_challenge_rejects_an_empty_scheme) {
+  const std::array<Parameter, 1> parameters{{{"realm", "example"}}};
+  EXPECT_FALSE(
+      sourcemeta::core::http_serialize_challenge({.parameters = parameters})
+          .has_value());
+}
+
+TEST(serialize_challenge_rejects_a_scheme_that_is_not_a_token) {
+  const std::array<Parameter, 1> parameters{{{"realm", "example"}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bea rer", .parameters = parameters})
+                   .has_value());
+}
+
+// RFC 9110 §11.2: auth-param = token BWS "=" BWS ( token / quoted-string )
+TEST(serialize_challenge_rejects_a_parameter_name_that_is_not_a_token) {
+  const std::array<Parameter, 1> parameters{{{"re alm", "example"}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+// RFC 9110 §11.3: challenge = auth-scheme [ 1*SP ( token68 / #auth-param ) ],
+// so a challenge carries one or the other and never both
+TEST(serialize_challenge_token68) {
+  const auto value{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Negotiate", .token68 = "YIIFQwYGKwYBBQUCoIIFNzCC"})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Negotiate YIIFQwYGKwYBBQUCoIIFNzCC");
+}
+
+TEST(serialize_challenge_token68_with_padding) {
+  const auto value{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Negotiate", .token68 = "YWJj=="})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Negotiate YWJj==");
+}
+
+TEST(serialize_challenge_rejects_a_token68_alongside_parameters) {
+  const std::array<Parameter, 1> parameters{{{"realm", "example"}}};
+  EXPECT_FALSE(
+      sourcemeta::core::http_serialize_challenge(
+          {.scheme = "Negotiate", .token68 = "YWJj", .parameters = parameters})
+          .has_value());
+}
+
+TEST(serialize_challenge_rejects_a_malformed_token68) {
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Negotiate", .token68 = "a b"})
+                   .has_value());
+}
+
+// RFC 9110 §11.3: the parameter list is optional, so a bare scheme is a well
+// formed challenge for a scheme that does not require one
+TEST(serialize_challenge_bare_scheme) {
+  const auto value{
+      sourcemeta::core::http_serialize_challenge({.scheme = "Negotiate"})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Negotiate");
+}
+
+// RFC 6750 §3: "This scheme MUST be followed by one or more auth-param values"
+TEST(serialize_challenge_rejects_a_bare_bearer) {
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge({.scheme = "Bearer"})
+                   .has_value());
+}
+
+TEST(serialize_challenge_rejects_a_bearer_carrying_a_token68) {
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .token68 = "YWJj"})
+                   .has_value());
+}
+
+// RFC 9110 §11.1: the scheme is matched case-insensitively, so the Bearer
+// rules apply however it is spelled
+TEST(serialize_challenge_rejects_a_bare_bearer_in_any_case) {
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge({.scheme = "bEaReR"})
+                   .has_value());
+}
+
+// RFC 6750 §3: scope values exclude every octet outside %x21 / %x23-5B /
+// %x5D-7E, with %x20 as the delimiter between them
+TEST(serialize_challenge_bearer_scope) {
+  const std::array<Parameter, 1> parameters{
+      {{"scope", "openid profile email"}}};
+  const auto value{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Bearer", .parameters = parameters})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Bearer scope=\"openid profile email\"");
+}
+
+TEST(serialize_challenge_rejects_a_scope_carrying_a_quote) {
+  const std::array<Parameter, 1> parameters{{{"scope", "open\"id"}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+TEST(serialize_challenge_rejects_a_scope_carrying_a_backslash) {
+  const std::array<Parameter, 1> parameters{{{"scope", "open\\id"}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+// RFC 6750 §3: error and error_description exclude every octet outside
+// %x20-21 / %x23-5B / %x5D-7E
+TEST(serialize_challenge_rejects_an_error_carrying_a_quote) {
+  const std::array<Parameter, 1> parameters{{{"error", "invalid\"token"}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+TEST(serialize_challenge_error_description_admits_a_space) {
+  const std::array<Parameter, 1> parameters{
+      {{"error_description", "The access token expired"}}};
+  EXPECT_TRUE(sourcemeta::core::http_serialize_challenge(
+                  {.scheme = "Bearer", .parameters = parameters})
+                  .has_value());
+}
+
+// RFC 6750 §3: error_uri excludes every octet outside %x21 / %x23-5B /
+// %x5D-7E, the space among them
+TEST(serialize_challenge_rejects_an_error_uri_carrying_a_space) {
+  const std::array<Parameter, 1> parameters{
+      {{"error_uri", "https://example.com/a b"}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+TEST(serialize_challenge_error_uri) {
+  const std::array<Parameter, 1> parameters{
+      {{"error_uri", "https://example.com/errors/invalid_token"}}};
+  EXPECT_TRUE(sourcemeta::core::http_serialize_challenge(
+                  {.scheme = "Bearer", .parameters = parameters})
+                  .has_value());
+}
+
+// The scheme-specific rules belong to the scheme, so another one carrying the
+// same parameter name is judged on the general grammar alone
+TEST(serialize_challenge_scope_rules_do_not_apply_to_another_scheme) {
+  const std::array<Parameter, 1> parameters{{{"scope", "open\"id"}}};
+  const auto value{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Custom", .parameters = parameters})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Custom scope=\"open\\\"id\"");
+}
+
+// RFC 9110 §11.6.1: WWW-Authenticate = #challenge
+TEST(serialize_challenges_several) {
+  const std::array<Parameter, 1> bearer{{{"realm", "api"}}};
+  const std::array<Parameter, 1> basic{{{"realm", "site"}}};
+  const std::array<sourcemeta::core::HTTPChallenge, 2> challenges{
+      {{.scheme = "Bearer", .parameters = bearer},
+       {.scheme = "Basic", .parameters = basic}}};
+  const auto value{sourcemeta::core::http_serialize_challenges(challenges)};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Bearer realm=\"api\", Basic realm=\"site\"");
+}
+
+TEST(serialize_challenges_rejects_an_empty_list) {
+  const std::array<sourcemeta::core::HTTPChallenge, 0> challenges{};
+  EXPECT_FALSE(
+      sourcemeta::core::http_serialize_challenges(challenges).has_value());
+}
+
+TEST(serialize_challenges_rejects_a_list_carrying_an_invalid_challenge) {
+  const std::array<Parameter, 1> bearer{{{"realm", "api"}}};
+  const std::array<sourcemeta::core::HTTPChallenge, 2> challenges{
+      {{.scheme = "Bearer", .parameters = bearer}, {.scheme = "Bearer"}}};
+  EXPECT_FALSE(
+      sourcemeta::core::http_serialize_challenges(challenges).has_value());
+}
+
+TEST(serialize_challenge_sink_overload_appends) {
+  const std::array<Parameter, 1> parameters{{{"realm", "example"}}};
+  std::string buffer{"WWW-Authenticate: "};
+  EXPECT_TRUE(sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Bearer", .parameters = parameters}, buffer));
+  EXPECT_EQ(buffer, "WWW-Authenticate: Bearer realm=\"example\"");
+}
+
+TEST(serialize_challenge_sink_overload_leaves_the_buffer_alone_on_failure) {
+  std::string buffer{"WWW-Authenticate: "};
+  EXPECT_FALSE(
+      sourcemeta::core::http_serialize_challenge({.scheme = "Bearer"}, buffer));
+  EXPECT_EQ(buffer, "WWW-Authenticate: ");
+}
+
+TEST(challenge_valid_agrees_with_serialization) {
+  const std::array<Parameter, 1> parameters{{{"realm", "example"}}};
+  EXPECT_TRUE(sourcemeta::core::http_challenge_valid(
+      {.scheme = "Bearer", .parameters = parameters}));
+  EXPECT_FALSE(sourcemeta::core::http_challenge_valid({.scheme = "Bearer"}));
+}

--- a/test/http/http_serialize_challenge_test.cc
+++ b/test/http/http_serialize_challenge_test.cc
@@ -309,3 +309,64 @@ TEST(challenge_valid_agrees_with_serialization) {
       {.scheme = "Bearer", .parameters = parameters}));
   EXPECT_FALSE(sourcemeta::core::http_challenge_valid({.scheme = "Bearer"}));
 }
+
+// RFC 6749 Appendix A.4: scope = scope-token *( SP scope-token ), so the space
+// only ever stands between two non-empty values
+TEST(serialize_challenge_rejects_an_empty_scope) {
+  const std::array<Parameter, 1> parameters{{{"scope", ""}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+TEST(serialize_challenge_rejects_a_scope_with_a_leading_space) {
+  const std::array<Parameter, 1> parameters{{{"scope", " openid"}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+TEST(serialize_challenge_rejects_a_scope_with_a_trailing_space) {
+  const std::array<Parameter, 1> parameters{{{"scope", "openid "}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+TEST(serialize_challenge_rejects_a_scope_with_consecutive_spaces) {
+  const std::array<Parameter, 1> parameters{{{"scope", "openid  profile"}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+// RFC 6749 Appendix A.7 and A.8: both are 1*NQSCHAR
+TEST(serialize_challenge_rejects_an_empty_error) {
+  const std::array<Parameter, 1> parameters{{{"error", ""}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+TEST(serialize_challenge_rejects_an_empty_error_description) {
+  const std::array<Parameter, 1> parameters{{{"error_description", ""}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+// RFC 6749 Appendix A.9: error-uri = URI-reference, which a charset check
+// alone does not decide
+TEST(serialize_challenge_rejects_an_error_uri_that_is_not_a_uri_reference) {
+  const std::array<Parameter, 1> parameters{{{"error_uri", "://bad"}}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_challenge(
+                   {.scheme = "Bearer", .parameters = parameters})
+                   .has_value());
+}
+
+TEST(serialize_challenge_error_uri_relative_reference) {
+  const std::array<Parameter, 1> parameters{{{"error_uri", "/errors/token"}}};
+  EXPECT_TRUE(sourcemeta::core::http_serialize_challenge(
+                  {.scheme = "Bearer", .parameters = parameters})
+                  .has_value());
+}

--- a/test/http/http_serialize_challenge_test.cc
+++ b/test/http/http_serialize_challenge_test.cc
@@ -370,3 +370,15 @@ TEST(serialize_challenge_error_uri_relative_reference) {
                   {.scheme = "Bearer", .parameters = parameters})
                   .has_value());
 }
+
+// RFC 6749 Appendix A.9 bounds this by RFC 3986 alone, where §4.1 reaches an
+// empty reference through a relative one whose path is empty, so unlike the
+// other three parameters it carries no repetition bound to fall foul of. Note
+// that only the quoted-string spelling can express it, since a token is 1*tchar
+TEST(serialize_challenge_empty_error_uri) {
+  const std::array<Parameter, 1> parameters{{{"error_uri", ""}}};
+  const auto value{sourcemeta::core::http_serialize_challenge(
+      {.scheme = "Bearer", .parameters = parameters})};
+  EXPECT_TRUE(value.has_value());
+  EXPECT_EQ(value.value(), "Bearer error_uri=\"\"");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

