### PR TITLE
Merge UserInfo claims into ID Token claims in the OIDC module

### DIFF
--- a/src/core/oidc/include/sourcemeta/core/oidc_userinfo.h
+++ b/src/core/oidc/include/sourcemeta/core/oidc_userinfo.h
@@ -107,11 +107,14 @@ auto oidc_verify_userinfo(
 ///   resolve against. They are taken together or not at all, and are never
 ///   merged across the two answers.
 ///
-/// A claim carries nothing unless it is there with something in it, since
-/// Section 5.3.2 has an unreturned claim omitted rather than "present with a
-/// null or empty string value". So a null or empty-string claim neither
-/// delivers a subject its assertion could speak for, nor blocks the other
-/// answer from filling it, nor is itself carried over. For example:
+/// A claim that is absent, null, or an empty string delivers nothing, those
+/// being the shapes Section 5.3.2 names in having an unreturned claim omitted
+/// rather than "present with a null or empty string value". Such a claim
+/// neither delivers a subject its assertion could speak for, nor blocks the
+/// other answer from filling it, nor is itself carried over. Every other
+/// value, an empty array or object included, is delivered as it stands, save
+/// for the aggregated members, which name and resolve nothing when empty. For
+/// example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/oidc.h>

--- a/src/core/oidc/include/sourcemeta/core/oidc_userinfo.h
+++ b/src/core/oidc/include/sourcemeta/core/oidc_userinfo.h
@@ -81,6 +81,53 @@ auto oidc_verify_userinfo(
     const std::string_view expected_issuer,
     const std::string_view expected_client_id) -> std::optional<JSON>;
 
+/// @ingroup oidc
+/// Combine the claims a provider asserted in an ID Token with those its
+/// UserInfo endpoint returned about the same person, with no result when the
+/// two cannot be established to be about one person. OpenID Connect Core 1.0
+/// Section 5.3.2 requires the UserInfo subject "to exactly match the `sub`
+/// Claim in the ID Token; if they do not match, the UserInfo Response values
+/// MUST NOT be used", and Section 2 makes that claim required of an ID Token,
+/// so a missing subject on either side is refused rather than merged.
+///
+/// Only the ID Token is signed, so its claims stand and UserInfo only fills
+/// what it left out. Three groups are exempt from that filling, because their
+/// members mean nothing apart from one another:
+///
+/// - `email` and `email_verified`, where Section 5.1 defines the latter as
+///   asserting that "the End-User's e-mail address has been verified", which
+///   is the address delivered alongside it. The pair is taken whole from the
+///   answer that carried an address, and an assertion arriving without one is
+///   dropped rather than left to vouch for the other answer's address.
+/// - `phone_number` and `phone_number_verified`, which Section 5.1 relates the
+///   same way, adding that a verified number "MUST be in E.164 format".
+/// - `_claim_names` and `_claim_sources`, where Section 5.6.2 makes the former
+///   "references to the member names in the `_claim_sources` member", so
+///   taking one from each answer would leave a reference with nothing to
+///   resolve against. They are taken together or not at all, and are never
+///   merged across the two answers.
+///
+/// A claim present with a null value carries nothing, since Section 5.3.2 has
+/// an unreturned claim omitted rather than "present with a null or empty
+/// string value". For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oidc.h>
+/// #include <cassert>
+///
+/// const auto token{sourcemeta::core::parse_json(
+///     R"JSON({ "sub": "u1", "email_verified": true })JSON")};
+/// const auto userinfo{sourcemeta::core::parse_json(
+///     R"JSON({ "sub": "u1", "email": "a@b.test" })JSON")};
+/// const auto claims{sourcemeta::core::oidc_merge_claims(token, userinfo)};
+/// assert(claims.has_value());
+/// // The assertion vouched for no address it carried, so it does not stand
+/// assert(!claims.value().defines("email_verified"));
+/// ```
+SOURCEMETA_CORE_OIDC_EXPORT
+auto oidc_merge_claims(const JSON &id_token_claims, const JSON &userinfo)
+    -> std::optional<JSON>;
+
 } // namespace sourcemeta::core
 
 #endif

--- a/src/core/oidc/include/sourcemeta/core/oidc_userinfo.h
+++ b/src/core/oidc/include/sourcemeta/core/oidc_userinfo.h
@@ -107,9 +107,11 @@ auto oidc_verify_userinfo(
 ///   resolve against. They are taken together or not at all, and are never
 ///   merged across the two answers.
 ///
-/// A claim present with a null value carries nothing, since Section 5.3.2 has
-/// an unreturned claim omitted rather than "present with a null or empty
-/// string value". For example:
+/// A claim carries nothing unless it is there with something in it, since
+/// Section 5.3.2 has an unreturned claim omitted rather than "present with a
+/// null or empty string value". So a null or empty-string claim neither
+/// delivers a subject its assertion could speak for, nor blocks the other
+/// answer from filling it, nor is itself carried over. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/oidc.h>

--- a/src/core/oidc/oidc_userinfo.cc
+++ b/src/core/oidc/oidc_userinfo.cc
@@ -12,14 +12,27 @@
 
 namespace {
 
-// A claim carries nothing unless it is there with something in it, since
-// OpenID Connect Core 1.0 Section 5.3.2 has an unreturned claim omitted rather
-// than "present with a null or empty string value"
+// A claim delivers nothing when it is absent, null, or an empty string, which
+// are the shapes OpenID Connect Core 1.0 Section 5.3.2 names in having an
+// unreturned claim omitted rather than "present with a null or empty string
+// value". It names no others, so an empty array or object is a value like any
+// other here and only the aggregated members below read one differently
 auto carries(const sourcemeta::core::JSON &claims,
              const sourcemeta::core::JSON::String &name) -> bool {
   const auto *claim{claims.try_at(name)};
   return claim != nullptr && !claim->is_null() &&
          !(claim->is_string() && claim->empty());
+}
+
+// OpenID Connect Core 1.0 Section 5.6.2 makes `_claim_names` the object whose
+// "member names are the Claim Names for the Aggregated and Distributed
+// Claims" and `_claim_sources` the object those names reference, so a member
+// that is empty names none and provides none, and one that is not an object
+// resolves nothing at all
+auto carries_aggregated(const sourcemeta::core::JSON &claims,
+                        const sourcemeta::core::JSON::String &name) -> bool {
+  const auto *claim{claims.try_at(name)};
+  return claim != nullptr && claim->is_object() && !claim->empty();
 }
 
 // A verified assertion speaks for the value delivered alongside it, so the two
@@ -149,10 +162,10 @@ auto oidc_merge_claims(const JSON &id_token_claims, const JSON &userinfo)
   // member names in the `_claim_sources` member", so the two are taken from
   // one answer or neither, never spliced into a reference with nothing to
   // resolve against
-  const auto aggregated{carries(id_token_claims, "_claim_names") ||
-                        carries(id_token_claims, "_claim_sources")};
-  if (!aggregated && carries(userinfo, "_claim_names") &&
-      carries(userinfo, "_claim_sources")) {
+  const auto aggregated{carries_aggregated(id_token_claims, "_claim_names") ||
+                        carries_aggregated(id_token_claims, "_claim_sources")};
+  if (!aggregated && carries_aggregated(userinfo, "_claim_names") &&
+      carries_aggregated(userinfo, "_claim_sources")) {
     result.assign("_claim_names", userinfo.at("_claim_names"));
     result.assign("_claim_sources", userinfo.at("_claim_sources"));
   }

--- a/src/core/oidc/oidc_userinfo.cc
+++ b/src/core/oidc/oidc_userinfo.cc
@@ -12,13 +12,14 @@
 
 namespace {
 
-// A claim present with a null value carries nothing, since OpenID Connect Core
-// 1.0 Section 5.3.2 has an unreturned claim omitted rather than "present with
-// a null or empty string value"
+// A claim carries nothing unless it is there with something in it, since
+// OpenID Connect Core 1.0 Section 5.3.2 has an unreturned claim omitted rather
+// than "present with a null or empty string value"
 auto carries(const sourcemeta::core::JSON &claims,
              const sourcemeta::core::JSON::String &name) -> bool {
   const auto *claim{claims.try_at(name)};
-  return claim != nullptr && !claim->is_null();
+  return claim != nullptr && !claim->is_null() &&
+         !(claim->is_string() && claim->empty());
 }
 
 // A verified assertion speaks for the value delivered alongside it, so the two
@@ -36,7 +37,7 @@ auto merge_verified_pair(sourcemeta::core::JSON &result,
 
   if (carries(userinfo, subject)) {
     result.assign(subject, userinfo.at(subject));
-    if (userinfo.defines(assertion)) {
+    if (carries(userinfo, assertion)) {
       result.assign(assertion, userinfo.at(assertion));
     } else {
       result.erase(assertion);
@@ -148,10 +149,10 @@ auto oidc_merge_claims(const JSON &id_token_claims, const JSON &userinfo)
   // member names in the `_claim_sources` member", so the two are taken from
   // one answer or neither, never spliced into a reference with nothing to
   // resolve against
-  const auto aggregated{id_token_claims.defines("_claim_names") ||
-                        id_token_claims.defines("_claim_sources")};
-  if (!aggregated && userinfo.defines("_claim_names") &&
-      userinfo.defines("_claim_sources")) {
+  const auto aggregated{carries(id_token_claims, "_claim_names") ||
+                        carries(id_token_claims, "_claim_sources")};
+  if (!aggregated && carries(userinfo, "_claim_names") &&
+      carries(userinfo, "_claim_sources")) {
     result.assign("_claim_names", userinfo.at("_claim_names"));
     result.assign("_claim_sources", userinfo.at("_claim_sources"));
   }
@@ -164,7 +165,9 @@ auto oidc_merge_claims(const JSON &id_token_claims, const JSON &userinfo)
       continue;
     }
 
-    if (!result.defines(claim.first)) {
+    // A second answer only fills what the first left out, and neither side
+    // fills anything with a value that carries nothing
+    if (carries(userinfo, claim.first) && !carries(result, claim.first)) {
       result.assign(claim.first, claim.second);
     }
   }

--- a/src/core/oidc/oidc_userinfo.cc
+++ b/src/core/oidc/oidc_userinfo.cc
@@ -10,6 +10,46 @@
 #include <span>        // std::span
 #include <string_view> // std::string_view
 
+namespace {
+
+// A claim present with a null value carries nothing, since OpenID Connect Core
+// 1.0 Section 5.3.2 has an unreturned claim omitted rather than "present with
+// a null or empty string value"
+auto carries(const sourcemeta::core::JSON &claims,
+             const sourcemeta::core::JSON::String &name) -> bool {
+  const auto *claim{claims.try_at(name)};
+  return claim != nullptr && !claim->is_null();
+}
+
+// A verified assertion speaks for the value delivered alongside it, so the two
+// are taken whole from the answer that carried the value, and an assertion
+// arriving on its own stands for nothing
+auto merge_verified_pair(sourcemeta::core::JSON &result,
+                         const sourcemeta::core::JSON &id_token_claims,
+                         const sourcemeta::core::JSON &userinfo,
+                         const sourcemeta::core::JSON::String &subject,
+                         const sourcemeta::core::JSON::String &assertion)
+    -> void {
+  if (carries(id_token_claims, subject)) {
+    return;
+  }
+
+  if (carries(userinfo, subject)) {
+    result.assign(subject, userinfo.at(subject));
+    if (userinfo.defines(assertion)) {
+      result.assign(assertion, userinfo.at(assertion));
+    } else {
+      result.erase(assertion);
+    }
+
+    return;
+  }
+
+  result.erase(assertion);
+}
+
+} // namespace
+
 namespace sourcemeta::core {
 
 namespace {
@@ -79,6 +119,57 @@ auto oidc_verify_userinfo(
   }
 
   return token.payload();
+}
+
+auto oidc_merge_claims(const JSON &id_token_claims, const JSON &userinfo)
+    -> std::optional<JSON> {
+  if (!id_token_claims.is_object() || !userinfo.is_object()) {
+    return std::nullopt;
+  }
+
+  // OpenID Connect Core 1.0 Section 2 requires the subject of an ID Token, and
+  // Section 5.3.2 requires the UserInfo subject to match it exactly, without
+  // which "the UserInfo Response values MUST NOT be used"
+  const auto *subject{id_token_claims.try_at("sub"sv, HASH_SUB)};
+  if (subject == nullptr || !subject->is_string() ||
+      !oidc_userinfo_matches_subject(userinfo, subject->to_string())) {
+    return std::nullopt;
+  }
+
+  // Only the ID Token is signed, so what it says stands and the second answer
+  // only fills what the first left out
+  auto result{id_token_claims};
+  merge_verified_pair(result, id_token_claims, userinfo, "email",
+                      "email_verified");
+  merge_verified_pair(result, id_token_claims, userinfo, "phone_number",
+                      "phone_number_verified");
+
+  // Section 5.6.2 makes the member values of `_claim_names` "references to the
+  // member names in the `_claim_sources` member", so the two are taken from
+  // one answer or neither, never spliced into a reference with nothing to
+  // resolve against
+  const auto aggregated{id_token_claims.defines("_claim_names") ||
+                        id_token_claims.defines("_claim_sources")};
+  if (!aggregated && userinfo.defines("_claim_names") &&
+      userinfo.defines("_claim_sources")) {
+    result.assign("_claim_names", userinfo.at("_claim_names"));
+    result.assign("_claim_sources", userinfo.at("_claim_sources"));
+  }
+
+  for (const auto &claim : userinfo.as_object()) {
+    if (claim.first == "email" || claim.first == "email_verified" ||
+        claim.first == "phone_number" ||
+        claim.first == "phone_number_verified" ||
+        claim.first == "_claim_names" || claim.first == "_claim_sources") {
+      continue;
+    }
+
+    if (!result.defines(claim.first)) {
+      result.assign(claim.first, claim.second);
+    }
+  }
+
+  return result;
 }
 
 } // namespace sourcemeta::core

--- a/test/oidc/CMakeLists.txt
+++ b/test/oidc/CMakeLists.txt
@@ -2,7 +2,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME oidc
   SOURCES oidc_error_test.cc oidc_metadata_test.cc oidc_discovery_test.cc
     oidc_hash_test.cc oidc_id_token_test.cc oidc_authentication_test.cc
     oidc_claims_test.cc oidc_claim_request_accepts_multi_valued_test.cc
-    oidc_userinfo_test.cc oidc_registration_test.cc
+    oidc_userinfo_test.cc oidc_merge_claims_test.cc oidc_registration_test.cc
     oidc_subject_test.cc oidc_request_object_test.cc oidc_logout_test.cc
     oidc_encryption_test.cc)
 

--- a/test/oidc/oidc_merge_claims_test.cc
+++ b/test/oidc/oidc_merge_claims_test.cc
@@ -2,6 +2,8 @@
 #include <sourcemeta/core/oidc.h>
 #include <sourcemeta/core/test.h>
 
+#include <optional> // std::optional
+
 namespace {
 auto merge(const char *id_token, const char *userinfo)
     -> std::optional<sourcemeta::core::JSON> {
@@ -17,20 +19,23 @@ TEST(merge_claims_userinfo_fills_a_gap) {
   const auto result{merge(R"JSON({ "sub": "u1", "name": "Jane" })JSON",
                           R"JSON({ "sub": "u1", "nickname": "J" })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("name").to_string(), "Jane");
-  EXPECT_EQ(result.value().at("nickname").to_string(), "J");
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(
+                                R"JSON({
+    "sub": "u1", "name": "Jane", "nickname": "J"
+  })JSON"));
 }
 
 TEST(merge_claims_id_token_wins_a_conflict) {
   const auto result{merge(R"JSON({ "sub": "u1", "name": "Jane" })JSON",
                           R"JSON({ "sub": "u1", "name": "Impostor" })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("name").to_string(), "Jane");
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(
+                                R"JSON({ "sub": "u1", "name": "Jane" })JSON"));
 }
 
-// OpenID Connect Core 1.0 Section 5.3.2: "The sub Claim in the UserInfo
-// Response MUST be verified to exactly match the sub Claim in the ID Token; if
-// they do not match, the UserInfo Response values MUST NOT be used"
+// Section 5.3.2: "The sub Claim in the UserInfo Response MUST be verified to
+// exactly match the sub Claim in the ID Token; if they do not match, the
+// UserInfo Response values MUST NOT be used"
 TEST(merge_claims_refuses_a_mismatched_subject) {
   EXPECT_FALSE(merge(R"JSON({ "sub": "u1", "name": "Jane" })JSON",
                      R"JSON({ "sub": "u2", "email": "a@b.test" })JSON")
@@ -53,9 +58,12 @@ TEST(merge_claims_refuses_a_missing_id_token_subject) {
           .has_value());
 }
 
-TEST(merge_claims_refuses_a_non_object) {
+TEST(merge_claims_refuses_a_non_object_id_token) {
   EXPECT_FALSE(
       merge(R"JSON("nope")JSON", R"JSON({ "sub": "u1" })JSON").has_value());
+}
+
+TEST(merge_claims_refuses_a_non_object_userinfo) {
   EXPECT_FALSE(
       merge(R"JSON({ "sub": "u1" })JSON", R"JSON("nope")JSON").has_value());
 }
@@ -64,22 +72,27 @@ TEST(merge_claims_refuses_a_non_object) {
 // been verified", meaning the address delivered with it, so the pair is only
 // ever taken from the answer that carried the address
 TEST(merge_claims_takes_the_email_pair_from_the_id_token) {
-  const auto result{merge(R"JSON({ "sub": "u1", "email": "signed@b.test",
-                     "email_verified": true })JSON",
-                          R"JSON({ "sub": "u1", "email": "other@b.test",
-                     "email_verified": false })JSON")};
+  const auto result{merge(R"JSON({
+    "sub": "u1", "email": "signed@b.test", "email_verified": true
+  })JSON",
+                          R"JSON({
+    "sub": "u1", "email": "other@b.test", "email_verified": false
+  })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("email").to_string(), "signed@b.test");
-  EXPECT_TRUE(result.value().at("email_verified").to_boolean());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "email": "signed@b.test", "email_verified": true
+  })JSON"));
 }
 
 TEST(merge_claims_takes_the_email_pair_from_userinfo_when_absent) {
   const auto result{merge(R"JSON({ "sub": "u1" })JSON",
-                          R"JSON({ "sub": "u1", "email": "a@b.test",
-                     "email_verified": true })JSON")};
+                          R"JSON({
+    "sub": "u1", "email": "a@b.test", "email_verified": true
+  })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("email").to_string(), "a@b.test");
-  EXPECT_TRUE(result.value().at("email_verified").to_boolean());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "email": "a@b.test", "email_verified": true
+  })JSON"));
 }
 
 // An assertion arriving without the address it vouches for would otherwise be
@@ -88,8 +101,9 @@ TEST(merge_claims_drops_an_orphan_assertion_from_the_id_token) {
   const auto result{merge(R"JSON({ "sub": "u1", "email_verified": true })JSON",
                           R"JSON({ "sub": "u1", "email": "a@b.test" })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("email").to_string(), "a@b.test");
-  EXPECT_FALSE(result.value().defines("email_verified"));
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "email": "a@b.test"
+  })JSON"));
 }
 
 TEST(merge_claims_drops_an_orphan_assertion_from_userinfo) {
@@ -97,8 +111,9 @@ TEST(merge_claims_drops_an_orphan_assertion_from_userinfo) {
       merge(R"JSON({ "sub": "u1", "email": "signed@b.test" })JSON",
             R"JSON({ "sub": "u1", "email_verified": true })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("email").to_string(), "signed@b.test");
-  EXPECT_FALSE(result.value().defines("email_verified"));
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "email": "signed@b.test"
+  })JSON"));
 }
 
 TEST(merge_claims_drops_an_orphan_assertion_when_neither_carries_an_address) {
@@ -106,31 +121,63 @@ TEST(merge_claims_drops_an_orphan_assertion_when_neither_carries_an_address) {
       merge(R"JSON({ "sub": "u1", "email_verified": true })JSON",
             R"JSON({ "sub": "u1", "email_verified": true })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().defines("email_verified"));
+  EXPECT_EQ(result.value(),
+            sourcemeta::core::parse_json(R"JSON({ "sub": "u1" })JSON"));
 }
 
 // Section 5.3.2: an unreturned claim "SHOULD be omitted ... it SHOULD NOT be
-// present with a null or empty string value", so a null address carries none
+// present with a null or empty string value", so neither shape delivers an
+// address an assertion could speak for
 TEST(merge_claims_treats_a_null_address_as_carrying_nothing) {
-  const auto result{merge(R"JSON({ "sub": "u1", "email": null,
-                     "email_verified": true })JSON",
-                          R"JSON({ "sub": "u1", "email": "a@b.test",
-                     "email_verified": false })JSON")};
+  const auto result{merge(R"JSON({
+    "sub": "u1", "email": null, "email_verified": true
+  })JSON",
+                          R"JSON({
+    "sub": "u1", "email": "a@b.test", "email_verified": false
+  })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("email").to_string(), "a@b.test");
-  EXPECT_FALSE(result.value().at("email_verified").to_boolean());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "email": "a@b.test", "email_verified": false
+  })JSON"));
 }
 
-// Section 5.1: phone_number_verified carries the same relationship, and adds
-// that "When true, the phone_number Claim MUST be in E.164 format"
-TEST(merge_claims_takes_the_phone_pair_from_the_id_token) {
-  const auto result{
-      merge(R"JSON({ "sub": "u1", "phone_number": "+15551212",
-                     "phone_number_verified": true })JSON",
-            R"JSON({ "sub": "u1", "phone_number": "+15559999" })JSON")};
+TEST(merge_claims_treats_an_empty_address_as_carrying_nothing) {
+  const auto result{merge(R"JSON({
+    "sub": "u1", "email": "", "email_verified": true
+  })JSON",
+                          R"JSON({
+    "sub": "u1", "email": "a@b.test", "email_verified": false
+  })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("phone_number").to_string(), "+15551212");
-  EXPECT_TRUE(result.value().at("phone_number_verified").to_boolean());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "email": "a@b.test", "email_verified": false
+  })JSON"));
+}
+
+TEST(merge_claims_drops_an_assertion_carrying_nothing_beside_an_address) {
+  const auto result{merge(R"JSON({ "sub": "u1" })JSON",
+                          R"JSON({
+    "sub": "u1", "email": "a@b.test", "email_verified": null
+  })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "email": "a@b.test"
+  })JSON"));
+}
+
+// Section 5.1 relates the phone pair the same way, adding that a verified
+// number "MUST be in E.164 format"
+TEST(merge_claims_takes_the_phone_pair_from_the_id_token) {
+  const auto result{merge(R"JSON({
+    "sub": "u1", "phone_number": "+15551212", "phone_number_verified": true
+  })JSON",
+                          R"JSON({
+    "sub": "u1", "phone_number": "+15559999"
+  })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "phone_number": "+15551212", "phone_number_verified": true
+  })JSON"));
 }
 
 TEST(merge_claims_drops_an_orphan_phone_assertion) {
@@ -138,135 +185,177 @@ TEST(merge_claims_drops_an_orphan_phone_assertion) {
       merge(R"JSON({ "sub": "u1", "phone_number_verified": true })JSON",
             R"JSON({ "sub": "u1", "phone_number": "+15551212" })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("phone_number").to_string(), "+15551212");
-  EXPECT_FALSE(result.value().defines("phone_number_verified"));
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "phone_number": "+15551212"
+  })JSON"));
 }
 
 TEST(merge_claims_keeps_the_two_pairs_independent) {
-  const auto result{
-      merge(R"JSON({ "sub": "u1", "email": "signed@b.test" })JSON",
-            R"JSON({ "sub": "u1", "phone_number": "+15551212",
-                     "phone_number_verified": true })JSON")};
+  const auto result{merge(R"JSON({
+    "sub": "u1", "email": "signed@b.test"
+  })JSON",
+                          R"JSON({
+    "sub": "u1", "phone_number": "+15551212", "phone_number_verified": true
+  })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("email").to_string(), "signed@b.test");
-  EXPECT_TRUE(result.value().at("phone_number_verified").to_boolean());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "email": "signed@b.test",
+    "phone_number": "+15551212", "phone_number_verified": true
+  })JSON"));
 }
 
 // Section 5.6.2: the member values of _claim_names "are references to the
 // member names in the _claim_sources member", so taking one from each answer
 // would leave a reference pointing at a source that is not there
 TEST(merge_claims_keeps_aggregated_claims_together_from_the_id_token) {
-  const auto result{merge(R"JSON({ "sub": "u1",
-                     "_claim_names": { "address": "src1" },
-                     "_claim_sources": { "src1": { "JWT": "a.b.c" } } })JSON",
-                          R"JSON({ "sub": "u1",
-                     "_claim_names": { "phone_number": "src2" },
-                     "_claim_sources": { "src2": { "JWT": "d.e.f" } } })JSON")};
+  const auto result{merge(R"JSON({
+    "sub": "u1",
+    "_claim_names": { "address": "src1" },
+    "_claim_sources": { "src1": { "JWT": "a.b.c" } }
+  })JSON",
+                          R"JSON({
+    "sub": "u1",
+    "_claim_names": { "phone_number": "src2" },
+    "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().at("_claim_names").defines("address"));
-  EXPECT_FALSE(result.value().at("_claim_names").defines("phone_number"));
-  EXPECT_TRUE(result.value().at("_claim_sources").defines("src1"));
-  EXPECT_FALSE(result.value().at("_claim_sources").defines("src2"));
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1",
+    "_claim_names": { "address": "src1" },
+    "_claim_sources": { "src1": { "JWT": "a.b.c" } }
+  })JSON"));
 }
 
 TEST(merge_claims_takes_aggregated_claims_from_userinfo_when_absent) {
   const auto result{merge(R"JSON({ "sub": "u1" })JSON",
-                          R"JSON({ "sub": "u1",
-                     "_claim_names": { "phone_number": "src2" },
-                     "_claim_sources": { "src2": { "JWT": "d.e.f" } } })JSON")};
+                          R"JSON({
+    "sub": "u1",
+    "_claim_names": { "phone_number": "src2" },
+    "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().at("_claim_names").defines("phone_number"));
-  EXPECT_TRUE(result.value().at("_claim_sources").defines("src2"));
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1",
+    "_claim_names": { "phone_number": "src2" },
+    "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON"));
 }
 
 // A reference with nothing to resolve against is no better than none
 TEST(merge_claims_does_not_pair_names_with_another_answers_sources) {
   const auto result{
       merge(R"JSON({ "sub": "u1", "_claim_names": { "address": "src1" } })JSON",
-            R"JSON({ "sub": "u1",
-                     "_claim_sources": { "src2": { "JWT": "d.e.f" } } })JSON")};
+            R"JSON({
+    "sub": "u1", "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().defines("_claim_names"));
-  EXPECT_FALSE(result.value().defines("_claim_sources"));
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "_claim_names": { "address": "src1" }
+  })JSON"));
+}
+
+TEST(merge_claims_aggregated_names_carrying_nothing_do_not_block_the_other) {
+  const auto result{merge(R"JSON({ "sub": "u1", "_claim_names": null })JSON",
+                          R"JSON({
+    "sub": "u1",
+    "_claim_names": { "phone_number": "src2" },
+    "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1",
+    "_claim_names": { "phone_number": "src2" },
+    "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON"));
 }
 
 TEST(merge_claims_without_a_userinfo_claim_leaves_the_token_untouched) {
   const auto result{merge(R"JSON({ "sub": "u1", "name": "Jane" })JSON",
                           R"JSON({ "sub": "u1" })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("name").to_string(), "Jane");
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(
+                                R"JSON({ "sub": "u1", "name": "Jane" })JSON"));
 }
 
-// Section 5.3.2 names the empty string alongside null, so an address that is
-// there but empty delivers nothing an assertion could speak for
-TEST(merge_claims_treats_an_empty_address_as_carrying_nothing) {
-  const auto result{merge(R"JSON({ "sub": "u1", "email": "",
-                     "email_verified": true })JSON",
-                          R"JSON({ "sub": "u1", "email": "a@b.test",
-                     "email_verified": false })JSON")};
-  EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("email").to_string(), "a@b.test");
-  EXPECT_FALSE(result.value().at("email_verified").to_boolean());
-}
-
-TEST(merge_claims_drops_an_empty_assertion_arriving_with_an_address) {
-  const auto result{merge(R"JSON({ "sub": "u1" })JSON",
-                          R"JSON({ "sub": "u1", "email": "a@b.test",
-                     "email_verified": null })JSON")};
-  EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("email").to_string(), "a@b.test");
-  EXPECT_FALSE(result.value().defines("email_verified"));
-}
-
-// A reference that is there but carries nothing is no reference at all, so the
-// answer that carried a whole pair supplies it
-TEST(merge_claims_null_aggregated_names_do_not_block_the_other_answer) {
-  const auto result{merge(R"JSON({ "sub": "u1", "_claim_names": null })JSON",
-                          R"JSON({ "sub": "u1",
-                     "_claim_names": { "phone_number": "src2" },
-                     "_claim_sources": { "src2": { "JWT": "d.e.f" } } })JSON")};
-  EXPECT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().at("_claim_names").defines("phone_number"));
-  EXPECT_TRUE(result.value().at("_claim_sources").defines("src2"));
-}
-
-// An ordinary claim that carries nothing neither blocks the other answer from
+// An ordinary claim carrying nothing neither blocks the other answer from
 // filling it nor travels across on its own
 TEST(merge_claims_null_id_token_claim_does_not_block_the_fill) {
   const auto result{merge(R"JSON({ "sub": "u1", "name": null })JSON",
                           R"JSON({ "sub": "u1", "name": "Jane" })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("name").to_string(), "Jane");
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(
+                                R"JSON({ "sub": "u1", "name": "Jane" })JSON"));
 }
 
 TEST(merge_claims_empty_id_token_claim_does_not_block_the_fill) {
   const auto result{merge(R"JSON({ "sub": "u1", "name": "" })JSON",
                           R"JSON({ "sub": "u1", "name": "Jane" })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().at("name").to_string(), "Jane");
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(
+                                R"JSON({ "sub": "u1", "name": "Jane" })JSON"));
 }
 
 TEST(merge_claims_does_not_carry_over_a_null_userinfo_claim) {
   const auto result{merge(R"JSON({ "sub": "u1" })JSON",
                           R"JSON({ "sub": "u1", "nickname": null })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().defines("nickname"));
+  EXPECT_EQ(result.value(),
+            sourcemeta::core::parse_json(R"JSON({ "sub": "u1" })JSON"));
 }
 
 TEST(merge_claims_does_not_carry_over_an_empty_userinfo_claim) {
   const auto result{merge(R"JSON({ "sub": "u1" })JSON",
                           R"JSON({ "sub": "u1", "nickname": "" })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().defines("nickname"));
+  EXPECT_EQ(result.value(),
+            sourcemeta::core::parse_json(R"JSON({ "sub": "u1" })JSON"));
 }
 
 // A claim that is genuinely false or zero carries a value, so the rule reaches
-// only the shapes Section 5.3.2 names
+// only the two shapes Section 5.3.2 names
 TEST(merge_claims_carries_a_false_or_zero_value) {
   const auto result{merge(R"JSON({ "sub": "u1" })JSON",
-                          R"JSON({ "sub": "u1", "flag": false,
-                                   "count": 0 })JSON")};
+                          R"JSON({
+    "sub": "u1", "flag": false, "count": 0
+  })JSON")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().defines("flag"));
-  EXPECT_TRUE(result.value().defines("count"));
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "flag": false, "count": 0
+  })JSON"));
+}
+
+// Every group and the ordinary fill at once, so that no rule quietly consumes
+// a claim another was meant to carry
+TEST(merge_claims_all_groups_and_the_fill_together) {
+  const auto result{merge(R"JSON({
+    "sub": "u1",
+    "name": "Jane",
+    "email_verified": true,
+    "phone_number": "+15551212",
+    "phone_number_verified": true,
+    "_claim_names": { "address": "src1" },
+    "_claim_sources": { "src1": { "JWT": "a.b.c" } }
+  })JSON",
+                          R"JSON({
+    "sub": "u1",
+    "name": "Impostor",
+    "nickname": "J",
+    "email": "a@b.test",
+    "email_verified": false,
+    "phone_number": "+15559999",
+    "_claim_names": { "gender": "src2" },
+    "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1",
+    "name": "Jane",
+    "nickname": "J",
+    "email": "a@b.test",
+    "email_verified": false,
+    "phone_number": "+15551212",
+    "phone_number_verified": true,
+    "_claim_names": { "address": "src1" },
+    "_claim_sources": { "src1": { "JWT": "a.b.c" } }
+  })JSON"));
 }

--- a/test/oidc/oidc_merge_claims_test.cc
+++ b/test/oidc/oidc_merge_claims_test.cc
@@ -196,3 +196,77 @@ TEST(merge_claims_without_a_userinfo_claim_leaves_the_token_untouched) {
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value().at("name").to_string(), "Jane");
 }
+
+// Section 5.3.2 names the empty string alongside null, so an address that is
+// there but empty delivers nothing an assertion could speak for
+TEST(merge_claims_treats_an_empty_address_as_carrying_nothing) {
+  const auto result{merge(R"JSON({ "sub": "u1", "email": "",
+                     "email_verified": true })JSON",
+                          R"JSON({ "sub": "u1", "email": "a@b.test",
+                     "email_verified": false })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("email").to_string(), "a@b.test");
+  EXPECT_FALSE(result.value().at("email_verified").to_boolean());
+}
+
+TEST(merge_claims_drops_an_empty_assertion_arriving_with_an_address) {
+  const auto result{merge(R"JSON({ "sub": "u1" })JSON",
+                          R"JSON({ "sub": "u1", "email": "a@b.test",
+                     "email_verified": null })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("email").to_string(), "a@b.test");
+  EXPECT_FALSE(result.value().defines("email_verified"));
+}
+
+// A reference that is there but carries nothing is no reference at all, so the
+// answer that carried a whole pair supplies it
+TEST(merge_claims_null_aggregated_names_do_not_block_the_other_answer) {
+  const auto result{merge(R"JSON({ "sub": "u1", "_claim_names": null })JSON",
+                          R"JSON({ "sub": "u1",
+                     "_claim_names": { "phone_number": "src2" },
+                     "_claim_sources": { "src2": { "JWT": "d.e.f" } } })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_TRUE(result.value().at("_claim_names").defines("phone_number"));
+  EXPECT_TRUE(result.value().at("_claim_sources").defines("src2"));
+}
+
+// An ordinary claim that carries nothing neither blocks the other answer from
+// filling it nor travels across on its own
+TEST(merge_claims_null_id_token_claim_does_not_block_the_fill) {
+  const auto result{merge(R"JSON({ "sub": "u1", "name": null })JSON",
+                          R"JSON({ "sub": "u1", "name": "Jane" })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("name").to_string(), "Jane");
+}
+
+TEST(merge_claims_empty_id_token_claim_does_not_block_the_fill) {
+  const auto result{merge(R"JSON({ "sub": "u1", "name": "" })JSON",
+                          R"JSON({ "sub": "u1", "name": "Jane" })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("name").to_string(), "Jane");
+}
+
+TEST(merge_claims_does_not_carry_over_a_null_userinfo_claim) {
+  const auto result{merge(R"JSON({ "sub": "u1" })JSON",
+                          R"JSON({ "sub": "u1", "nickname": null })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_FALSE(result.value().defines("nickname"));
+}
+
+TEST(merge_claims_does_not_carry_over_an_empty_userinfo_claim) {
+  const auto result{merge(R"JSON({ "sub": "u1" })JSON",
+                          R"JSON({ "sub": "u1", "nickname": "" })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_FALSE(result.value().defines("nickname"));
+}
+
+// A claim that is genuinely false or zero carries a value, so the rule reaches
+// only the shapes Section 5.3.2 names
+TEST(merge_claims_carries_a_false_or_zero_value) {
+  const auto result{merge(R"JSON({ "sub": "u1" })JSON",
+                          R"JSON({ "sub": "u1", "flag": false,
+                                   "count": 0 })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_TRUE(result.value().defines("flag"));
+  EXPECT_TRUE(result.value().defines("count"));
+}

--- a/test/oidc/oidc_merge_claims_test.cc
+++ b/test/oidc/oidc_merge_claims_test.cc
@@ -1,0 +1,198 @@
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oidc.h>
+#include <sourcemeta/core/test.h>
+
+namespace {
+auto merge(const char *id_token, const char *userinfo)
+    -> std::optional<sourcemeta::core::JSON> {
+  return sourcemeta::core::oidc_merge_claims(
+      sourcemeta::core::parse_json(id_token),
+      sourcemeta::core::parse_json(userinfo));
+}
+} // namespace
+
+// OpenID Connect Core 1.0 Section 5.3.2: a provider answering twice about one
+// person is two halves of one account, and the signed half is authoritative
+TEST(merge_claims_userinfo_fills_a_gap) {
+  const auto result{merge(R"JSON({ "sub": "u1", "name": "Jane" })JSON",
+                          R"JSON({ "sub": "u1", "nickname": "J" })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("name").to_string(), "Jane");
+  EXPECT_EQ(result.value().at("nickname").to_string(), "J");
+}
+
+TEST(merge_claims_id_token_wins_a_conflict) {
+  const auto result{merge(R"JSON({ "sub": "u1", "name": "Jane" })JSON",
+                          R"JSON({ "sub": "u1", "name": "Impostor" })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("name").to_string(), "Jane");
+}
+
+// OpenID Connect Core 1.0 Section 5.3.2: "The sub Claim in the UserInfo
+// Response MUST be verified to exactly match the sub Claim in the ID Token; if
+// they do not match, the UserInfo Response values MUST NOT be used"
+TEST(merge_claims_refuses_a_mismatched_subject) {
+  EXPECT_FALSE(merge(R"JSON({ "sub": "u1", "name": "Jane" })JSON",
+                     R"JSON({ "sub": "u2", "email": "a@b.test" })JSON")
+                   .has_value());
+}
+
+// Section 5.3.2: "The sub (subject) Claim MUST always be returned in the
+// UserInfo Response"
+TEST(merge_claims_refuses_a_missing_userinfo_subject) {
+  EXPECT_FALSE(
+      merge(R"JSON({ "sub": "u1" })JSON", R"JSON({ "email": "a@b.test" })JSON")
+          .has_value());
+}
+
+// Section 2: the subject is REQUIRED in an ID Token, and without it no match
+// can be established
+TEST(merge_claims_refuses_a_missing_id_token_subject) {
+  EXPECT_FALSE(
+      merge(R"JSON({ "name": "Jane" })JSON", R"JSON({ "sub": "u1" })JSON")
+          .has_value());
+}
+
+TEST(merge_claims_refuses_a_non_object) {
+  EXPECT_FALSE(
+      merge(R"JSON("nope")JSON", R"JSON({ "sub": "u1" })JSON").has_value());
+  EXPECT_FALSE(
+      merge(R"JSON({ "sub": "u1" })JSON", R"JSON("nope")JSON").has_value());
+}
+
+// Section 5.1: email_verified is "True if the End-User's e-mail address has
+// been verified", meaning the address delivered with it, so the pair is only
+// ever taken from the answer that carried the address
+TEST(merge_claims_takes_the_email_pair_from_the_id_token) {
+  const auto result{merge(R"JSON({ "sub": "u1", "email": "signed@b.test",
+                     "email_verified": true })JSON",
+                          R"JSON({ "sub": "u1", "email": "other@b.test",
+                     "email_verified": false })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("email").to_string(), "signed@b.test");
+  EXPECT_TRUE(result.value().at("email_verified").to_boolean());
+}
+
+TEST(merge_claims_takes_the_email_pair_from_userinfo_when_absent) {
+  const auto result{merge(R"JSON({ "sub": "u1" })JSON",
+                          R"JSON({ "sub": "u1", "email": "a@b.test",
+                     "email_verified": true })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("email").to_string(), "a@b.test");
+  EXPECT_TRUE(result.value().at("email_verified").to_boolean());
+}
+
+// An assertion arriving without the address it vouches for would otherwise be
+// left to vouch for the other answer's address
+TEST(merge_claims_drops_an_orphan_assertion_from_the_id_token) {
+  const auto result{merge(R"JSON({ "sub": "u1", "email_verified": true })JSON",
+                          R"JSON({ "sub": "u1", "email": "a@b.test" })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("email").to_string(), "a@b.test");
+  EXPECT_FALSE(result.value().defines("email_verified"));
+}
+
+TEST(merge_claims_drops_an_orphan_assertion_from_userinfo) {
+  const auto result{
+      merge(R"JSON({ "sub": "u1", "email": "signed@b.test" })JSON",
+            R"JSON({ "sub": "u1", "email_verified": true })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("email").to_string(), "signed@b.test");
+  EXPECT_FALSE(result.value().defines("email_verified"));
+}
+
+TEST(merge_claims_drops_an_orphan_assertion_when_neither_carries_an_address) {
+  const auto result{
+      merge(R"JSON({ "sub": "u1", "email_verified": true })JSON",
+            R"JSON({ "sub": "u1", "email_verified": true })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_FALSE(result.value().defines("email_verified"));
+}
+
+// Section 5.3.2: an unreturned claim "SHOULD be omitted ... it SHOULD NOT be
+// present with a null or empty string value", so a null address carries none
+TEST(merge_claims_treats_a_null_address_as_carrying_nothing) {
+  const auto result{merge(R"JSON({ "sub": "u1", "email": null,
+                     "email_verified": true })JSON",
+                          R"JSON({ "sub": "u1", "email": "a@b.test",
+                     "email_verified": false })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("email").to_string(), "a@b.test");
+  EXPECT_FALSE(result.value().at("email_verified").to_boolean());
+}
+
+// Section 5.1: phone_number_verified carries the same relationship, and adds
+// that "When true, the phone_number Claim MUST be in E.164 format"
+TEST(merge_claims_takes_the_phone_pair_from_the_id_token) {
+  const auto result{
+      merge(R"JSON({ "sub": "u1", "phone_number": "+15551212",
+                     "phone_number_verified": true })JSON",
+            R"JSON({ "sub": "u1", "phone_number": "+15559999" })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("phone_number").to_string(), "+15551212");
+  EXPECT_TRUE(result.value().at("phone_number_verified").to_boolean());
+}
+
+TEST(merge_claims_drops_an_orphan_phone_assertion) {
+  const auto result{
+      merge(R"JSON({ "sub": "u1", "phone_number_verified": true })JSON",
+            R"JSON({ "sub": "u1", "phone_number": "+15551212" })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("phone_number").to_string(), "+15551212");
+  EXPECT_FALSE(result.value().defines("phone_number_verified"));
+}
+
+TEST(merge_claims_keeps_the_two_pairs_independent) {
+  const auto result{
+      merge(R"JSON({ "sub": "u1", "email": "signed@b.test" })JSON",
+            R"JSON({ "sub": "u1", "phone_number": "+15551212",
+                     "phone_number_verified": true })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("email").to_string(), "signed@b.test");
+  EXPECT_TRUE(result.value().at("phone_number_verified").to_boolean());
+}
+
+// Section 5.6.2: the member values of _claim_names "are references to the
+// member names in the _claim_sources member", so taking one from each answer
+// would leave a reference pointing at a source that is not there
+TEST(merge_claims_keeps_aggregated_claims_together_from_the_id_token) {
+  const auto result{merge(R"JSON({ "sub": "u1",
+                     "_claim_names": { "address": "src1" },
+                     "_claim_sources": { "src1": { "JWT": "a.b.c" } } })JSON",
+                          R"JSON({ "sub": "u1",
+                     "_claim_names": { "phone_number": "src2" },
+                     "_claim_sources": { "src2": { "JWT": "d.e.f" } } })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_TRUE(result.value().at("_claim_names").defines("address"));
+  EXPECT_FALSE(result.value().at("_claim_names").defines("phone_number"));
+  EXPECT_TRUE(result.value().at("_claim_sources").defines("src1"));
+  EXPECT_FALSE(result.value().at("_claim_sources").defines("src2"));
+}
+
+TEST(merge_claims_takes_aggregated_claims_from_userinfo_when_absent) {
+  const auto result{merge(R"JSON({ "sub": "u1" })JSON",
+                          R"JSON({ "sub": "u1",
+                     "_claim_names": { "phone_number": "src2" },
+                     "_claim_sources": { "src2": { "JWT": "d.e.f" } } })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_TRUE(result.value().at("_claim_names").defines("phone_number"));
+  EXPECT_TRUE(result.value().at("_claim_sources").defines("src2"));
+}
+
+// A reference with nothing to resolve against is no better than none
+TEST(merge_claims_does_not_pair_names_with_another_answers_sources) {
+  const auto result{
+      merge(R"JSON({ "sub": "u1", "_claim_names": { "address": "src1" } })JSON",
+            R"JSON({ "sub": "u1",
+                     "_claim_sources": { "src2": { "JWT": "d.e.f" } } })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_TRUE(result.value().defines("_claim_names"));
+  EXPECT_FALSE(result.value().defines("_claim_sources"));
+}
+
+TEST(merge_claims_without_a_userinfo_claim_leaves_the_token_untouched) {
+  const auto result{merge(R"JSON({ "sub": "u1", "name": "Jane" })JSON",
+                          R"JSON({ "sub": "u1" })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().at("name").to_string(), "Jane");
+}

--- a/test/oidc/oidc_merge_claims_test.cc
+++ b/test/oidc/oidc_merge_claims_test.cc
@@ -359,3 +359,65 @@ TEST(merge_claims_all_groups_and_the_fill_together) {
     "_claim_sources": { "src1": { "JWT": "a.b.c" } }
   })JSON"));
 }
+
+// Section 5.6.2 makes _claim_names the object naming the aggregated claims, so
+// one with no members names none and leaves the other answer free to supply a
+// pair, exactly as a null one does
+TEST(merge_claims_empty_aggregated_names_do_not_block_the_other) {
+  const auto result{merge(R"JSON({ "sub": "u1", "_claim_names": {} })JSON",
+                          R"JSON({
+    "sub": "u1",
+    "_claim_names": { "phone_number": "src2" },
+    "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1",
+    "_claim_names": { "phone_number": "src2" },
+    "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON"));
+}
+
+TEST(merge_claims_empty_aggregated_sources_do_not_block_the_other) {
+  const auto result{merge(R"JSON({ "sub": "u1", "_claim_sources": {} })JSON",
+                          R"JSON({
+    "sub": "u1",
+    "_claim_names": { "phone_number": "src2" },
+    "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1",
+    "_claim_names": { "phone_number": "src2" },
+    "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON"));
+}
+
+// A pair that is not the object shape Section 5.6.2 defines resolves nothing
+TEST(merge_claims_malformed_aggregated_names_do_not_block_the_other) {
+  const auto result{merge(R"JSON({ "sub": "u1", "_claim_names": "src1" })JSON",
+                          R"JSON({
+    "sub": "u1",
+    "_claim_names": { "phone_number": "src2" },
+    "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1",
+    "_claim_names": { "phone_number": "src2" },
+    "_claim_sources": { "src2": { "JWT": "d.e.f" } }
+  })JSON"));
+}
+
+// Section 5.3.2 names only the null and the empty string, so an ordinary claim
+// that is an empty array or object is a value the merge carries as it stands
+TEST(merge_claims_carries_an_empty_array_or_object) {
+  const auto result{merge(R"JSON({ "sub": "u1" })JSON",
+                          R"JSON({
+    "sub": "u1", "groups": [], "address": {}
+  })JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), sourcemeta::core::parse_json(R"JSON({
+    "sub": "u1", "groups": [], "address": {}
+  })JSON"));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

