### PR TITLE
Add a `Cache-Control` builder to the HTTP module

### DIFF
--- a/src/core/http/CMakeLists.txt
+++ b/src/core/http/CMakeLists.txt
@@ -17,6 +17,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME http
           accept_includes_all.cc content_type_matches.cc parse_bearer.cc
           cache_control_max_age.cc serialize_cookie.cc aws_sigv4.cc
           serialize_challenge.cc parse_challenges.cc
+          serialize_cache_control.cc
           scan_quoted_string.cc
           ${SOURCEMETA_CORE_HTTP_CLIENT_SOURCE})
 

--- a/src/core/http/include/sourcemeta/core/http.h
+++ b/src/core/http/include/sourcemeta/core/http.h
@@ -265,6 +265,113 @@ SOURCEMETA_CORE_HTTP_EXPORT
 auto http_format_links(std::span<const HTTPLink> links) -> std::string;
 
 /// @ingroup http
+/// Whether a cached response may be stored by a shared cache or only by a
+/// private one (RFC 9111 §5.2.2.7 and §5.2.2.9). The two are alternatives
+/// rather than flags, so a response cannot be marked both.
+enum class HTTPCacheVisibility : std::uint8_t {
+  /// A cache may store the response even where it would otherwise be
+  /// prohibited, which includes a shared cache reusing a response to an
+  /// authorized request.
+  Public,
+  /// A shared cache must not store the response, the response being intended
+  /// for a single user.
+  Private
+};
+
+/// @ingroup http
+/// The response directives to serialise into an RFC 9111 §5.2 `Cache-Control`
+/// header value. The caller owns the backing storage for every field.
+///
+/// Whether a response may be stored by a shared cache is an access decision as
+/// much as a performance one, so it is carried as one alternative rather than
+/// as two independent flags that could both be set.
+struct HTTPCacheControl {
+  /// Which caches may store the response
+  std::optional<HTTPCacheVisibility> visibility{};
+  /// How long the response stays fresh (RFC 9111 §5.2.2.1)
+  std::optional<std::chrono::seconds> max_age{};
+  /// How long the response stays fresh for a shared cache, overriding the
+  /// above for one (RFC 9111 §5.2.2.10)
+  std::optional<std::chrono::seconds> shared_max_age{};
+  /// Whether no cache may store any part of the exchange (RFC 9111 §5.2.2.5)
+  bool no_store{false};
+  /// Whether the response must be validated before every reuse (RFC 9111
+  /// §5.2.2.4), ignored when a field list qualifies it below
+  bool no_cache{false};
+  /// Whether a stale response must be validated before reuse (RFC 9111
+  /// §5.2.2.2)
+  bool must_revalidate{false};
+  /// The same for a shared cache alone (RFC 9111 §5.2.2.8)
+  bool proxy_revalidate{false};
+  /// Whether storing is limited to a cache that implements the status code's
+  /// caching requirements (RFC 9111 §5.2.2.3)
+  bool must_understand{false};
+  /// Whether the payload must not be transformed (RFC 9111 §5.2.2.6)
+  bool no_transform{false};
+  /// Whether the response will not be updated while fresh (RFC 8246)
+  bool immutable{false};
+  /// The fields a shared cache must not store, which qualifies the private
+  /// directive and so requires it (RFC 9111 §5.2.2.7)
+  std::span<const std::string_view> private_fields{};
+  /// The fields that must be revalidated before reuse, which qualifies the
+  /// no-cache directive (RFC 9111 §5.2.2.4)
+  std::span<const std::string_view> no_cache_fields{};
+};
+
+/// @ingroup http
+/// Test whether a set of directives can be serialised into a valid RFC 9111
+/// §5.2 `Cache-Control` header value: every duration is the non-negative
+/// integer §1.2.2 defines, every qualifying field name is an RFC 9110 §5.6.2
+/// token, a private field list is accompanied by the directive it qualifies,
+/// and at least one directive is named, since §5.2 lists them and RFC 9110
+/// §5.6.1.1 forbids a sender from generating an empty list element.
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_cache_control_valid(const HTTPCacheControl &directives) -> bool;
+
+/// @ingroup http
+/// Append an RFC 9111 §5.2 `Cache-Control` header value to `out`, returning
+/// `true` on success. When the directives are not `http_cache_control_valid`,
+/// `out` is left unchanged and this returns `false`.
+///
+/// A duration is written in the token form §5.2.2.1 requires, never quoted,
+/// while a field list is written in the quoted-string form §5.2.2.4 and
+/// §5.2.2.7 ask a sender to use even for a single entry. A qualifying field
+/// list replaces the bare directive rather than joining it. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+/// #include <chrono>
+/// #include <string>
+///
+/// std::string buffer;
+/// const auto ok{sourcemeta::core::http_serialize_cache_control(
+///     {.visibility = sourcemeta::core::HTTPCacheVisibility::Private,
+///      .max_age = std::chrono::seconds{60}}, buffer)};
+/// assert(ok);
+/// assert(buffer == "private, max-age=60");
+/// ```
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_serialize_cache_control(const HTTPCacheControl &directives,
+                                  std::string &out) -> bool;
+
+/// @ingroup http
+/// Serialise an RFC 9111 §5.2 `Cache-Control` header value, returning no value
+/// when the directives are not `http_cache_control_valid`. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// const auto value{sourcemeta::core::http_serialize_cache_control(
+///     {.no_store = true})};
+/// assert(value == "no-store");
+/// ```
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_serialize_cache_control(const HTTPCacheControl &directives)
+    -> std::optional<std::string>;
+
+/// @ingroup http
 /// A challenge to serialise into an RFC 9110 §11.6.1 `WWW-Authenticate`
 /// response header value. The caller owns the backing storage for every field.
 ///

--- a/src/core/http/serialize_cache_control.cc
+++ b/src/core/http/serialize_cache_control.cc
@@ -1,0 +1,171 @@
+#include <sourcemeta/core/http.h>
+#include <sourcemeta/core/text.h>
+
+#include <algorithm>   // std::ranges::all_of
+#include <chrono>      // std::chrono::seconds
+#include <cstddef>     // std::size_t
+#include <optional>    // std::optional, std::nullopt
+#include <span>        // std::span
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace {
+
+constexpr std::string_view DIRECTIVE_SEPARATOR{", "};
+
+auto append_directive(std::string &out, const std::string_view name,
+                      bool &first) -> void {
+  if (!first) {
+    out.append(DIRECTIVE_SEPARATOR);
+  }
+
+  out.append(name);
+  first = false;
+}
+
+// RFC 9111 §5.2.2.1: "This directive uses the token form of the argument
+// syntax: e.g., 'max-age=5' not 'max-age="5"'. A sender MUST NOT generate the
+// quoted-string form"
+auto append_seconds(std::string &out, const std::string_view name,
+                    const std::chrono::seconds value, bool &first) -> void {
+  append_directive(out, name, first);
+  out.push_back('=');
+  sourcemeta::core::DigitsBuffer buffer;
+  out.append(sourcemeta::core::digits_view(value.count(), buffer));
+}
+
+// RFC 9111 §5.2.2.4 and §5.2.2.7: a qualified directive "uses the quoted-string
+// form of the argument syntax. A sender SHOULD NOT generate the token form
+// (even if quoting appears not to be needed for single-entry lists)"
+auto append_fields(std::string &out, const std::string_view name,
+                   const std::span<const std::string_view> fields, bool &first)
+    -> void {
+  append_directive(out, name, first);
+  out.append("=\"");
+  bool leading{true};
+  for (const auto field : fields) {
+    if (!leading) {
+      out.append(DIRECTIVE_SEPARATOR);
+    }
+
+    out.append(field);
+    leading = false;
+  }
+
+  out.push_back('"');
+}
+
+// RFC 9110 §5.1: field-name = token, so a name outside that set could not be
+// carried even by the quoting
+auto fields_valid(const std::span<const std::string_view> fields) -> bool {
+  return std::ranges::all_of(fields, [](const std::string_view field) -> bool {
+    return sourcemeta::core::http_is_token(field);
+  });
+}
+
+} // namespace
+
+namespace sourcemeta::core {
+
+auto http_cache_control_valid(const HTTPCacheControl &directives) -> bool {
+  // RFC 9111 §1.2.2: "The delta-seconds rule specifies a non-negative integer"
+  if ((directives.max_age.has_value() && directives.max_age->count() < 0) ||
+      (directives.shared_max_age.has_value() &&
+       directives.shared_max_age->count() < 0)) {
+    return false;
+  }
+
+  // RFC 9111 §5.2.2.7 qualifies the private directive, so a field list without
+  // it limits nothing and names no directive to qualify
+  if (!directives.private_fields.empty() &&
+      directives.visibility != HTTPCacheVisibility::Private) {
+    return false;
+  }
+
+  if (!fields_valid(directives.private_fields) ||
+      !fields_valid(directives.no_cache_fields)) {
+    return false;
+  }
+
+  // RFC 9111 §5.2: Cache-Control = #cache-directive, and RFC 9110 §5.6.1.1
+  // forbids a sender from generating an empty list element, so a header naming
+  // no directive at all is left unsent rather than emitted blank
+  return directives.visibility.has_value() || directives.max_age.has_value() ||
+         directives.shared_max_age.has_value() || directives.no_store ||
+         directives.no_cache || !directives.no_cache_fields.empty() ||
+         directives.must_revalidate || directives.proxy_revalidate ||
+         directives.must_understand || directives.no_transform ||
+         directives.immutable;
+}
+
+auto http_serialize_cache_control(const HTTPCacheControl &directives,
+                                  std::string &out) -> bool {
+  if (!http_cache_control_valid(directives)) {
+    return false;
+  }
+
+  bool first{true};
+  if (directives.visibility == HTTPCacheVisibility::Public) {
+    append_directive(out, "public", first);
+  } else if (directives.visibility == HTTPCacheVisibility::Private) {
+    if (directives.private_fields.empty()) {
+      append_directive(out, "private", first);
+    } else {
+      append_fields(out, "private", directives.private_fields, first);
+    }
+  }
+
+  if (directives.no_store) {
+    append_directive(out, "no-store", first);
+  }
+
+  if (directives.max_age.has_value()) {
+    append_seconds(out, "max-age", directives.max_age.value(), first);
+  }
+
+  if (directives.shared_max_age.has_value()) {
+    append_seconds(out, "s-maxage", directives.shared_max_age.value(), first);
+  }
+
+  // A field list is the qualified form of the very same directive, so only one
+  // of the two spellings is ever emitted
+  if (!directives.no_cache_fields.empty()) {
+    append_fields(out, "no-cache", directives.no_cache_fields, first);
+  } else if (directives.no_cache) {
+    append_directive(out, "no-cache", first);
+  }
+
+  if (directives.must_revalidate) {
+    append_directive(out, "must-revalidate", first);
+  }
+
+  if (directives.proxy_revalidate) {
+    append_directive(out, "proxy-revalidate", first);
+  }
+
+  if (directives.must_understand) {
+    append_directive(out, "must-understand", first);
+  }
+
+  if (directives.no_transform) {
+    append_directive(out, "no-transform", first);
+  }
+
+  if (directives.immutable) {
+    append_directive(out, "immutable", first);
+  }
+
+  return true;
+}
+
+auto http_serialize_cache_control(const HTTPCacheControl &directives)
+    -> std::optional<std::string> {
+  std::string out;
+  if (!http_serialize_cache_control(directives, out)) {
+    return std::nullopt;
+  }
+
+  return out;
+}
+
+} // namespace sourcemeta::core

--- a/src/core/http/serialize_cache_control.cc
+++ b/src/core/http/serialize_cache_control.cc
@@ -8,6 +8,7 @@
 #include <span>        // std::span
 #include <string>      // std::string
 #include <string_view> // std::string_view
+#include <utility>     // std::unreachable
 
 namespace {
 
@@ -55,6 +56,21 @@ auto append_fields(std::string &out, const std::string_view name,
   out.push_back('"');
 }
 
+// RFC 9111 §5.2.2.7 and §5.2.2.9 name the two, which the shared entry point
+// has already established the value to be one of
+auto visibility_directive(
+    const sourcemeta::core::HTTPCacheVisibility value) noexcept
+    -> std::string_view {
+  switch (value) {
+    case sourcemeta::core::HTTPCacheVisibility::Public:
+      return "public";
+    case sourcemeta::core::HTTPCacheVisibility::Private:
+      return "private";
+  }
+
+  std::unreachable();
+}
+
 // RFC 9110 §5.1: field-name = token, so a name outside that set could not be
 // carried even by the quoting
 auto fields_valid(const std::span<const std::string_view> fields) -> bool {
@@ -68,6 +84,14 @@ auto fields_valid(const std::span<const std::string_view> fields) -> bool {
 namespace sourcemeta::core {
 
 auto http_cache_control_valid(const HTTPCacheControl &directives) -> bool {
+  // A visibility naming neither of the two directives names no directive at
+  // all, so it cannot stand in for one below
+  if (directives.visibility.has_value() &&
+      directives.visibility != HTTPCacheVisibility::Public &&
+      directives.visibility != HTTPCacheVisibility::Private) {
+    return false;
+  }
+
   // RFC 9111 §1.2.2: "The delta-seconds rule specifies a non-negative integer"
   if ((directives.max_age.has_value() && directives.max_age->count() < 0) ||
       (directives.shared_max_age.has_value() &&
@@ -105,13 +129,12 @@ auto http_serialize_cache_control(const HTTPCacheControl &directives,
   }
 
   bool first{true};
-  if (directives.visibility == HTTPCacheVisibility::Public) {
-    append_directive(out, "public", first);
-  } else if (directives.visibility == HTTPCacheVisibility::Private) {
+  if (directives.visibility.has_value()) {
+    const auto directive{visibility_directive(directives.visibility.value())};
     if (directives.private_fields.empty()) {
-      append_directive(out, "private", first);
+      append_directive(out, directive, first);
     } else {
-      append_fields(out, "private", directives.private_fields, first);
+      append_fields(out, directive, directives.private_fields, first);
     }
   }
 

--- a/test/http/CMakeLists.txt
+++ b/test/http/CMakeLists.txt
@@ -5,6 +5,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME http
           http_format_link_test.cc http_field_list_contains_any_test.cc
           http_format_vary_test.cc http_expire_cookie_test.cc
           http_serialize_challenge_test.cc http_parse_challenges_test.cc
+          http_serialize_cache_control_test.cc
           http_accept_includes_all_test.cc http_content_type_matches_test.cc
           http_method_test.cc http_status_from_code_test.cc
           http_is_status_line_test.cc http_accumulate_header_line_test.cc

--- a/test/http/http_serialize_cache_control_test.cc
+++ b/test/http/http_serialize_cache_control_test.cc
@@ -1,0 +1,209 @@
+#include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
+
+#include <array>       // std::array
+#include <chrono>      // std::chrono::seconds
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+// The spellings this replaces across a server, each built rather than written
+TEST(cache_control_no_store) {
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control({.no_store = true}),
+            "no-store");
+}
+
+TEST(cache_control_public_revalidated) {
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.visibility = sourcemeta::core::HTTPCacheVisibility::Public,
+                 .max_age = std::chrono::seconds{0},
+                 .must_revalidate = true}),
+            "public, max-age=0, must-revalidate");
+}
+
+TEST(cache_control_public_short_lived) {
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.visibility = sourcemeta::core::HTTPCacheVisibility::Public,
+                 .max_age = std::chrono::seconds{60}}),
+            "public, max-age=60");
+}
+
+TEST(cache_control_public_immutable) {
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.visibility = sourcemeta::core::HTTPCacheVisibility::Public,
+                 .max_age = std::chrono::seconds{31536000},
+                 .immutable = true}),
+            "public, max-age=31536000, immutable");
+}
+
+TEST(cache_control_private_short_lived) {
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.visibility = sourcemeta::core::HTTPCacheVisibility::Private,
+                 .max_age = std::chrono::seconds{60}}),
+            "private, max-age=60");
+}
+
+TEST(cache_control_private_immutable) {
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.visibility = sourcemeta::core::HTTPCacheVisibility::Private,
+                 .max_age = std::chrono::seconds{31536000},
+                 .immutable = true}),
+            "private, max-age=31536000, immutable");
+}
+
+TEST(cache_control_private_revalidated) {
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.visibility = sourcemeta::core::HTTPCacheVisibility::Private,
+                 .max_age = std::chrono::seconds{0},
+                 .must_revalidate = true}),
+            "private, max-age=0, must-revalidate");
+}
+
+// RFC 9111 §5.2.2.1: "This directive uses the token form of the argument
+// syntax: e.g., 'max-age=5' not 'max-age="5"'. A sender MUST NOT generate the
+// quoted-string form"
+TEST(cache_control_max_age_is_never_quoted) {
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.max_age = std::chrono::seconds{5}}),
+            "max-age=5");
+}
+
+// RFC 9111 §1.2.2: "The delta-seconds rule specifies a non-negative integer"
+TEST(cache_control_refuses_a_negative_max_age) {
+  EXPECT_FALSE(sourcemeta::core::http_serialize_cache_control(
+                   {.max_age = std::chrono::seconds{-1}})
+                   .has_value());
+}
+
+TEST(cache_control_refuses_a_negative_shared_max_age) {
+  EXPECT_FALSE(sourcemeta::core::http_serialize_cache_control(
+                   {.shared_max_age = std::chrono::seconds{-1}})
+                   .has_value());
+}
+
+// RFC 9111 §5.2.2.10: s-maxage overrides max-age for a shared cache
+TEST(cache_control_shared_max_age) {
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.visibility = sourcemeta::core::HTTPCacheVisibility::Public,
+                 .max_age = std::chrono::seconds{60},
+                 .shared_max_age = std::chrono::seconds{120}}),
+            "public, max-age=60, s-maxage=120");
+}
+
+// RFC 9111 §5.2.2.4: the unqualified form
+TEST(cache_control_no_cache) {
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control({.no_cache = true}),
+            "no-cache");
+}
+
+// RFC 9111 §5.2.2.4: "This directive uses the quoted-string form of the
+// argument syntax. A sender SHOULD NOT generate the token form (even if
+// quoting appears not to be needed for single-entry lists)"
+TEST(cache_control_qualified_no_cache_is_quoted) {
+  const std::array<std::string_view, 1> fields{{"Set-Cookie"}};
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.no_cache_fields = fields}),
+            "no-cache=\"Set-Cookie\"");
+}
+
+TEST(cache_control_qualified_no_cache_with_several_fields) {
+  const std::array<std::string_view, 2> fields{{"Set-Cookie", "Authorization"}};
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.no_cache_fields = fields}),
+            "no-cache=\"Set-Cookie, Authorization\"");
+}
+
+// RFC 9111 §5.2.2.7: the qualified private form carries the same requirement
+TEST(cache_control_qualified_private_is_quoted) {
+  const std::array<std::string_view, 1> fields{{"Set-Cookie"}};
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.visibility = sourcemeta::core::HTTPCacheVisibility::Private,
+                 .private_fields = fields}),
+            "private=\"Set-Cookie\"");
+}
+
+// A field list limiting nothing names no directive to qualify
+TEST(cache_control_refuses_private_fields_without_private) {
+  const std::array<std::string_view, 1> fields{{"Set-Cookie"}};
+  EXPECT_FALSE(
+      sourcemeta::core::http_serialize_cache_control({.private_fields = fields})
+          .has_value());
+}
+
+TEST(cache_control_refuses_private_fields_alongside_public) {
+  const std::array<std::string_view, 1> fields{{"Set-Cookie"}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_cache_control(
+                   {.visibility = sourcemeta::core::HTTPCacheVisibility::Public,
+                    .private_fields = fields})
+                   .has_value());
+}
+
+// RFC 9110 §5.1: field-name = token, so a name outside that set cannot be sent
+TEST(cache_control_refuses_a_field_name_that_is_not_a_token) {
+  const std::array<std::string_view, 1> fields{{"Set Cookie"}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_cache_control(
+                   {.no_cache_fields = fields})
+                   .has_value());
+}
+
+TEST(cache_control_refuses_a_field_name_carrying_a_quote) {
+  const std::array<std::string_view, 1> fields{{"a\"b"}};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_cache_control(
+                   {.no_cache_fields = fields})
+                   .has_value());
+}
+
+// RFC 9111 §5.2: Cache-Control = #cache-directive, and a sender must not
+// generate an empty list element, so a header naming no directive is not sent
+TEST(cache_control_refuses_an_empty_directive_set) {
+  EXPECT_FALSE(sourcemeta::core::http_serialize_cache_control({}).has_value());
+}
+
+// RFC 9111 §5.2.2.2, §5.2.2.5, §5.2.2.6, §5.2.2.8, and RFC 8246, each of which
+// takes no argument
+TEST(cache_control_every_valueless_directive) {
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.visibility = sourcemeta::core::HTTPCacheVisibility::Public,
+                 .max_age = std::chrono::seconds{1},
+                 .no_cache = true,
+                 .must_revalidate = true,
+                 .proxy_revalidate = true,
+                 .must_understand = true,
+                 .no_transform = true,
+                 .immutable = true}),
+            "public, max-age=1, no-cache, must-revalidate, proxy-revalidate, "
+            "must-understand, no-transform, immutable");
+}
+
+// RFC 9111 §5.2.2.3: "A response that contains the must-understand directive
+// SHOULD also contain the no-store directive", which is guidance rather than a
+// prohibition, so the pair is emitted as asked
+TEST(cache_control_must_understand_with_no_store) {
+  EXPECT_EQ(sourcemeta::core::http_serialize_cache_control(
+                {.no_store = true, .must_understand = true}),
+            "no-store, must-understand");
+}
+
+TEST(cache_control_sink_overload_appends) {
+  std::string buffer{"Cache-Control: "};
+  EXPECT_TRUE(sourcemeta::core::http_serialize_cache_control({.no_store = true},
+                                                             buffer));
+  EXPECT_EQ(buffer, "Cache-Control: no-store");
+}
+
+TEST(cache_control_sink_overload_leaves_the_buffer_alone_on_failure) {
+  std::string buffer{"Cache-Control: "};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_cache_control({}, buffer));
+  EXPECT_EQ(buffer, "Cache-Control: ");
+}
+
+// What this module writes, its own parser reads back
+TEST(cache_control_round_trips_through_the_parser) {
+  const auto value{sourcemeta::core::http_serialize_cache_control(
+      {.visibility = sourcemeta::core::HTTPCacheVisibility::Public,
+       .max_age = std::chrono::seconds{60}})};
+  EXPECT_TRUE(value.has_value());
+  const auto parsed{
+      sourcemeta::core::http_cache_control_max_age(value.value())};
+  EXPECT_TRUE(parsed.has_value());
+  EXPECT_EQ(parsed.value(), std::chrono::seconds{60});
+}

--- a/test/http/http_serialize_cache_control_test.cc
+++ b/test/http/http_serialize_cache_control_test.cc
@@ -207,3 +207,21 @@ TEST(cache_control_round_trips_through_the_parser) {
   EXPECT_TRUE(parsed.has_value());
   EXPECT_EQ(parsed.value(), std::chrono::seconds{60});
 }
+
+// A visibility naming neither directive names none, so it cannot satisfy the
+// requirement that at least one be present and leave an empty header behind
+TEST(cache_control_refuses_a_visibility_naming_no_directive) {
+  const auto visibility{static_cast<sourcemeta::core::HTTPCacheVisibility>(99)};
+  EXPECT_FALSE(
+      sourcemeta::core::http_cache_control_valid({.visibility = visibility}));
+  EXPECT_FALSE(
+      sourcemeta::core::http_serialize_cache_control({.visibility = visibility})
+          .has_value());
+}
+
+TEST(cache_control_refuses_a_visibility_naming_no_directive_beside_others) {
+  const auto visibility{static_cast<sourcemeta::core::HTTPCacheVisibility>(99)};
+  EXPECT_FALSE(sourcemeta::core::http_serialize_cache_control(
+                   {.visibility = visibility, .no_store = true})
+                   .has_value());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

