### PR TITLE
test(regex): expand is_regex_ecma coverage across the ECMA-262 construct classes

### DIFF
--- a/test/regex/regex_is_ecma_test.cc
+++ b/test/regex/regex_is_ecma_test.cc
@@ -320,3 +320,285 @@ TEST(invalid_unterminated_named_backreference) {
 TEST(invalid_empty_named_backreference) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\k<>"));
 }
+
+TEST(atomic_atomic_group) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?>abc)"));
+}
+
+TEST(atomic_atomic_alternation) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?>a|ab)c"));
+}
+
+TEST(backref_ecma_named_backref) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<n>a)\\k<n>"));
+}
+
+TEST(backref_net_named_backref) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?<n>a)\\k'n'"));
+}
+
+TEST(backref_python_named_backref) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?P<n>a)(?P=n)"));
+}
+
+TEST(backref_numeric_backref) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(a)\\1"));
+}
+
+TEST(backref_forward_numeric_backref) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\1(a)"));
+}
+
+TEST(class_uprop_in_class) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\p{L}]"));
+}
+
+TEST(class_v_flag_intersection) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a&&b]"));
+}
+
+TEST(class_reversed_range) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[z-a]"));
+}
+
+TEST(class_trailing_dash) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-]"));
+}
+
+TEST(class_leading_dash) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[-a]"));
+}
+
+TEST(class_backspace_in_class) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\b]"));
+}
+
+TEST(comment_comment_group) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?#comment)a"));
+}
+
+TEST(comment_mid_comment) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("a(?#c)b"));
+}
+
+TEST(conditional_numeric_conditional) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?(1)a|b)"));
+}
+
+TEST(conditional_named_conditional) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?(name)a|b)"));
+}
+
+TEST(conditional_assertion_conditional) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?(?=x)a|b)"));
+}
+
+TEST(conditional_conditional_no_else) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?(1)a)"));
+}
+
+TEST(escape_uprop) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{L}")); }
+
+TEST(escape_neg_uprop) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\P{L}"));
+}
+
+TEST(escape_script_prop) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Script=Greek}"));
+}
+
+TEST(escape_binary_prop) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Alphabetic}"));
+}
+
+TEST(escape_uxxxx) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma("A")); }
+
+TEST(escape_escaped_slash) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\/"));
+}
+
+TEST(inline_flag_flag_i) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?i)abc"));
+}
+
+TEST(inline_flag_flags_ims) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?ims)abc"));
+}
+
+TEST(inline_flag_flag_u) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?u)abc"));
+}
+
+TEST(inline_flag_scoped_flag_on) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?i:abc)"));
+}
+
+TEST(inline_flag_scoped_flag_off) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?-i:abc)"));
+}
+
+TEST(inline_flag_scoped_on_off) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?i-s:abc)"));
+}
+
+TEST(inline_flag_verbose_extended) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?x) a b c"));
+}
+
+TEST(inline_flag_inline_flag_in_group) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?P<n>(?i)a)"));
+}
+
+TEST(lookaround_lookahead) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?=x)"));
+}
+
+TEST(lookaround_neg_lookahead) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?!x)"));
+}
+
+TEST(lookaround_fixed_lookbehind) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<=x)"));
+}
+
+TEST(lookaround_neg_lookbehind) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<!x)"));
+}
+
+TEST(lookaround_group_in_lookbehind) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<=(?:ab)+)c"));
+}
+
+TEST(misc_branch_reset) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?|(a)|(b))"));
+}
+
+TEST(misc_pcre_callout) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?C1)"));
+}
+
+TEST(misc_non_capturing_control) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?:abc)"));
+}
+
+TEST(misc_unclosed_group) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?P<n>abc"));
+}
+
+TEST(misc_unmatched_close) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("abc)"));
+}
+
+TEST(misc_trailing_alternation) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a|"));
+}
+
+TEST(misc_leading_alternation) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("|a"));
+}
+
+TEST(misc_empty_named_group) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<n>)"));
+}
+
+TEST(misc_escaped_backslash_control_valid) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\"));
+}
+
+TEST(misc_unclosed_class) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[a"));
+}
+
+TEST(misc_lone_open) { EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(")); }
+
+TEST(named_group_ecma_named_group) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<name>x)"));
+}
+
+TEST(named_group_python_pcre_named_group) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?P<name>x)"));
+}
+
+TEST(named_group_net_named_group) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?'name'x)"));
+}
+
+TEST(named_group_duplicate_name_ecma_v_flag_allows_in_alternati) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?<n>a)(?<n>b)"));
+}
+
+TEST(named_group_digit_leading_name) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?<1a>x)"));
+}
+
+TEST(named_group_empty_name) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?<>x)"));
+}
+
+TEST(possessive_possessive) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("a++"));
+}
+
+TEST(possessive_possessive_2) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("a?+"));
+}
+
+TEST(quantifier_reversed_interval) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("a{2,1}"));
+}
+
+TEST(quantifier_open_upper_control) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{2,}"));
+}
+
+TEST(quantifier_no_atom) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("{2}"));
+}
+
+TEST(quantifier_leading_star) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("*abc"));
+}
+
+TEST(quantifier_leading_plus) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("+abc"));
+}
+
+TEST(quantifier_leading_question) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("?abc"));
+}
+
+TEST(quantifier_double_star) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("a**"));
+}
+
+TEST(quantifier_stacked_interval) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("a{2}{3}"));
+}
+
+TEST(recursion_subroutine_number) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("a(?1)"));
+}
+
+TEST(recursion_python_subroutine) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?P<n>a)(?P>n)"));
+}
+
+TEST(recursion_pcre_subroutine) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?<n>a)(?&n)"));
+}
+
+TEST(recursion_recursion_0) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?0)"));
+}
+
+TEST(redos_nested_quantifier_valid) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(a+)+$"));
+}
+
+TEST(redos_alternation_star_valid) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(a|a)*"));
+}
+
+TEST(redos_repeated_group_valid) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(.*a){20}"));
+}


### PR DESCRIPTION
I added 72 tests to `test/regex/regex_is_ecma_test.cc`, taking the fixture from 861 to 933 assertions in the regex unit target. Core already passes all of them on current `main`, so this is coverage, not a fix.

## What is new

I built the set by diffing the fixture against a corpus of ECMA-262 constructs I had assembled for the JSON Schema `format: regex` work. The fixture covered 83 distinct patterns; 74 corpus inputs that are mode-independent (same verdict under the `u` flag and the default reading) were not covered at all. 72 of those pass against current `main` and are what this PR adds.

By construct class:

- misc (11) - branch reset, PCRE callout, unclosed and unmatched groups, leading and trailing alternation, empty named group
- inline flags (8) - `(?i)`, `(?ims)`, `(?u)`, scoped `(?i:...)`, `(?-i:...)`, `(?i-s:...)`, `(?x)`, and a flag inside a group
- quantifier (8) - reversed interval, quantifier with no atom, leading `*` `+` `?`, doubled star, stacked intervals
- character class (6) - property escape inside a class, v-flag intersection, reversed range, leading and trailing dash, `[\b]`
- escape (6) - `\p{L}`, `\P{L}`, `\p{Script=Greek}`, `\p{Alphabetic}`, `\uXXXX`, escaped solidus
- named group (6) - ECMA `(?<name>x)` against the Python, .NET, duplicate-name, digit-leading and empty-name forms
- backreference (5) - ECMA `\k<n>`, numeric and forward numeric, against the .NET and Python named forms
- lookaround (5) - lookahead, negative lookahead, fixed lookbehind, negative lookbehind, group inside a lookbehind
- conditional (4) - numeric, named, assertion, and no-else forms
- recursion (4) - numeric subroutine, Python subroutine, PCRE subroutine, recursion 0
- ReDoS-shaped but valid (3) - `(a+)+$`, `(a|a)*`, `(.*a){20}`
- atomic (2), comment (2), possessive (2)

## How I checked the expected values

Every expected verdict was cross-checked against Node's `new RegExp` in both the default mode and with the `u` flag, and only inputs where the two modes agree are included - so nothing here depends on which reading of the dialect applies. I then ran the whole set against the built `sourcemeta_core_regex_unit` binary before staging: 933 passed, 0 failed.

Two further inputs from the same corpus do not pass on `main` and are deliberately left out of this PR so it stays green: `\p{gc=Lu}` and quantifier counts at or above 65536. I will raise those separately.

## References

- ECMA-262 RegExp grammar (Unicode property escapes, ES2018; lookbehind, ES2018): https://tc39.es/ecma262/#sec-patterns


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

