### PR TITLE
Decide scope rules against granted scope in the OAuth module

### DIFF
--- a/src/core/oauth/include/sourcemeta/core/oauth_bearer.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_bearer.h
@@ -186,8 +186,11 @@ enum class OAuthScopeDecision : std::uint8_t {
 /// code points, as `oauth_has_scope` does it.
 ///
 /// A `null` rule is one "being requested in the default manner" (Section
-/// 5.5.1) and so constrains nothing, exactly as `oidc_claim_request_accepts`
-/// reads it. A rule that is neither null nor an object, or whose `value` is
+/// 5.5.1) rather than a malformed one, and since it constrains neither member
+/// it too asks only that some scope be carried. That is stricter than the
+/// unconditional acceptance `oidc_claim_request_accepts` gives a null request,
+/// which is handed a claim the caller has already found rather than looking
+/// one up. A rule that is neither null nor an object, or whose `value` is
 /// not a string, or whose `values` is not an array of strings, is reported as
 /// unreadable rather than refused. Whether an unreadable rule denies is a
 /// deployment's policy rather than anything these specifications settle, so it

--- a/src/core/oauth/include/sourcemeta/core/oauth_bearer.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_bearer.h
@@ -180,15 +180,20 @@ enum class OAuthScopeDecision : std::uint8_t {
 ///
 /// Because the claim is a set rather than a value, a rule naming a `value` or
 /// any member of `values` is satisfied by that one being granted, and a rule
-/// constraining neither asks only that some scope be carried at all. Matching
-/// is by whole token and code points, as `oauth_has_scope` does it.
+/// constraining neither asks only that some scope be carried at all, which a
+/// claim of nothing but delimiters does not, since Section 3.3 makes every
+/// scope token at least one character long. Matching is by whole token and
+/// code points, as `oauth_has_scope` does it.
 ///
-/// A rule that is not an object, or whose `value` is not a string, or whose
-/// `values` is not an array of strings, is reported as unreadable rather than
-/// refused. Whether an unreadable rule denies is a deployment's policy rather
-/// than anything these specifications settle, so it is not decided here. The
-/// rule is read before the claims are, so an unreadable one is reported as
-/// such even where the token grants nothing. For example:
+/// A `null` rule is one "being requested in the default manner" (Section
+/// 5.5.1) and so constrains nothing, exactly as `oidc_claim_request_accepts`
+/// reads it. A rule that is neither null nor an object, or whose `value` is
+/// not a string, or whose `values` is not an array of strings, is reported as
+/// unreadable rather than refused. Whether an unreadable rule denies is a
+/// deployment's policy rather than anything these specifications settle, so it
+/// is not decided here. The rule is read before the claims are, so an
+/// unreadable one is reported as such even where the token grants nothing. For
+/// example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/oauth.h>

--- a/src/core/oauth/include/sourcemeta/core/oauth_bearer.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_bearer.h
@@ -7,6 +7,7 @@
 
 #include <sourcemeta/core/json.h>
 
+#include <cstdint>     // std::uint8_t
 #include <optional>    // std::optional
 #include <string>      // std::string
 #include <string_view> // std::string_view
@@ -156,6 +157,54 @@ auto oauth_has_audience(const JSON &claims, const std::string_view audience)
 /// ```
 SOURCEMETA_CORE_OAUTH_EXPORT
 auto oauth_has_scope(const JSON &claims, const std::string_view value) -> bool;
+
+/// @ingroup oauth
+/// What a scope rule decides about a set of access token claims.
+enum class OAuthScopeDecision : std::uint8_t {
+  /// The granted scope satisfies the rule.
+  Accepted,
+  /// The granted scope does not satisfy the rule, the token carrying no
+  /// readable scope at all included.
+  Refused,
+  /// The rule is not one this can read, so it decides nothing either way and
+  /// what that means is left to the caller.
+  Unreadable
+};
+
+/// @ingroup oauth
+/// Decide whether the scope an access token grants satisfies a rule shaped
+/// like an individual claim request (OpenID Connect Core 1.0 Section 5.5.1),
+/// bridging that shape onto the `scope` claim, which RFC 6749 Section 3.3
+/// makes "a list of space-delimited, case-sensitive strings" whose "order does
+/// not matter".
+///
+/// Because the claim is a set rather than a value, a rule naming a `value` or
+/// any member of `values` is satisfied by that one being granted, and a rule
+/// constraining neither asks only that some scope be carried at all. Matching
+/// is by whole token and code points, as `oauth_has_scope` does it.
+///
+/// A rule that is not an object, or whose `value` is not a string, or whose
+/// `values` is not an array of strings, is reported as unreadable rather than
+/// refused. Whether an unreadable rule denies is a deployment's policy rather
+/// than anything these specifications settle, so it is not decided here. The
+/// rule is read before the claims are, so an unreadable one is reported as
+/// such even where the token grants nothing. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <sourcemeta/core/json.h>
+/// #include <cassert>
+///
+/// const auto claims{
+///     sourcemeta::core::parse_json(R"JSON({"scope":"read write"})JSON")};
+/// const auto rule{
+///     sourcemeta::core::parse_json(R"JSON({"values":["admin","write"]})JSON")};
+/// assert(sourcemeta::core::oauth_scope_request_accepts(claims, rule) ==
+///        sourcemeta::core::OAuthScopeDecision::Accepted);
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_scope_request_accepts(const JSON &claims, const JSON &request)
+    -> OAuthScopeDecision;
 
 /// @ingroup oauth
 /// Whether a set of access token claims carries the DPoP confirmation that

--- a/src/core/oauth/oauth_bearer.cc
+++ b/src/core/oauth/oauth_bearer.cc
@@ -278,15 +278,20 @@ auto oauth_is_dpop_bound(const JSON &claims) -> bool {
 
 auto oauth_scope_request_accepts(const JSON &claims, const JSON &request)
     -> OAuthScopeDecision {
-  // OpenID Connect Core 1.0 Section 5.5.1 shapes a rule as an object, so
-  // anything else is not a rule this can read, and it is read before the
-  // claims are so that a token granting nothing does not mask a broken one
-  if (!request.is_object()) {
+  // OpenID Connect Core 1.0 Section 5.5.1: a rule's value "MUST be one of the
+  // following: null [...] JSON Object", so anything else is not a rule this
+  // can read, and it is read before the claims are so that a token granting
+  // nothing does not mask a broken one
+  if (!(request.is_null() || request.is_object())) {
     return OAuthScopeDecision::Unreadable;
   }
 
-  const auto *single{request.try_at("value"sv, HASH_VALUE)};
-  const auto *listed{request.try_at("values"sv, HASH_VALUES)};
+  // A null rule "indicates that this Claim is being requested in the default
+  // manner", which constrains no value at all
+  const auto *single{request.is_null() ? nullptr
+                                       : request.try_at("value"sv, HASH_VALUE)};
+  const auto *listed{
+      request.is_null() ? nullptr : request.try_at("values"sv, HASH_VALUES)};
 
   if (single != nullptr && !single->is_string()) {
     return OAuthScopeDecision::Unreadable;
@@ -306,14 +311,20 @@ auto oauth_scope_request_accepts(const JSON &claims, const JSON &request)
 
   // RFC 6749 Section 3.3 makes the granted scope a set, so a rule constraining
   // none of its members asks only that some scope be carried at all. RFC 9068
-  // Section 2.2.3 has that carried as one string of scope tokens, and an empty
-  // one names none
+  // Section 2.2.3 has that carried as one string of scope tokens
   if (single == nullptr && listed == nullptr) {
     const auto *granted{
         claims.is_object() ? claims.try_at("scope"sv, HASH_SCOPE) : nullptr};
-    return (granted != nullptr && granted->is_string() && !granted->empty())
-               ? OAuthScopeDecision::Accepted
-               : OAuthScopeDecision::Refused;
+    if (granted == nullptr || !granted->is_string()) {
+      return OAuthScopeDecision::Refused;
+    }
+
+    // RFC 6749 Section 3.3: scope = scope-token *( SP scope-token ), where a
+    // scope-token is at least one character, so a claim of nothing but the
+    // delimiter names no scope however long it runs
+    return granted->to_string().find_first_not_of(' ') == JSON::String::npos
+               ? OAuthScopeDecision::Refused
+               : OAuthScopeDecision::Accepted;
   }
 
   if (single != nullptr && oauth_has_scope(claims, single->to_string())) {

--- a/src/core/oauth/oauth_bearer.cc
+++ b/src/core/oauth/oauth_bearer.cc
@@ -23,6 +23,8 @@ constexpr auto HASH_AUD{JSON::Object::hash("aud"sv)};
 constexpr auto HASH_CNF{JSON::Object::hash("cnf"sv)};
 constexpr auto HASH_JKT{JSON::Object::hash("jkt"sv)};
 constexpr auto HASH_SCOPE{JSON::Object::hash("scope"sv)};
+constexpr auto HASH_VALUE{JSON::Object::hash("value"sv)};
+constexpr auto HASH_VALUES{JSON::Object::hash("values"sv)};
 
 auto oauth_skip_ows(const std::string_view value, std::size_t position) noexcept
     -> std::size_t {
@@ -272,6 +274,61 @@ auto oauth_is_dpop_bound(const JSON &claims) -> bool {
   // proof-of-possession key as the "jkt" confirmation member
   const auto *thumbprint{confirmation->try_at("jkt"sv, HASH_JKT)};
   return thumbprint != nullptr && thumbprint->is_string();
+}
+
+auto oauth_scope_request_accepts(const JSON &claims, const JSON &request)
+    -> OAuthScopeDecision {
+  // OpenID Connect Core 1.0 Section 5.5.1 shapes a rule as an object, so
+  // anything else is not a rule this can read, and it is read before the
+  // claims are so that a token granting nothing does not mask a broken one
+  if (!request.is_object()) {
+    return OAuthScopeDecision::Unreadable;
+  }
+
+  const auto *single{request.try_at("value"sv, HASH_VALUE)};
+  const auto *listed{request.try_at("values"sv, HASH_VALUES)};
+
+  if (single != nullptr && !single->is_string()) {
+    return OAuthScopeDecision::Unreadable;
+  }
+
+  if (listed != nullptr) {
+    if (!listed->is_array()) {
+      return OAuthScopeDecision::Unreadable;
+    }
+
+    for (const auto &candidate : listed->as_array()) {
+      if (!candidate.is_string()) {
+        return OAuthScopeDecision::Unreadable;
+      }
+    }
+  }
+
+  // RFC 6749 Section 3.3 makes the granted scope a set, so a rule constraining
+  // none of its members asks only that some scope be carried at all. RFC 9068
+  // Section 2.2.3 has that carried as one string of scope tokens, and an empty
+  // one names none
+  if (single == nullptr && listed == nullptr) {
+    const auto *granted{
+        claims.is_object() ? claims.try_at("scope"sv, HASH_SCOPE) : nullptr};
+    return (granted != nullptr && granted->is_string() && !granted->empty())
+               ? OAuthScopeDecision::Accepted
+               : OAuthScopeDecision::Refused;
+  }
+
+  if (single != nullptr && oauth_has_scope(claims, single->to_string())) {
+    return OAuthScopeDecision::Accepted;
+  }
+
+  if (listed != nullptr) {
+    for (const auto &candidate : listed->as_array()) {
+      if (oauth_has_scope(claims, candidate.to_string())) {
+        return OAuthScopeDecision::Accepted;
+      }
+    }
+  }
+
+  return OAuthScopeDecision::Refused;
 }
 
 } // namespace sourcemeta::core

--- a/test/oauth/CMakeLists.txt
+++ b/test/oauth/CMakeLists.txt
@@ -6,7 +6,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME oauth
     oauth_metadata_provider_test.cc
     oauth_conformance_test.cc oauth_token_exchange_test.cc
     oauth_revocation_test.cc oauth_introspection_test.cc oauth_device_test.cc
-    oauth_dpop_test.cc oauth_par_test.cc oauth_assertion_test.cc
+    oauth_dpop_test.cc oauth_par_test.cc oauth_assertion_test.cc oauth_scope_request_test.cc
     oauth_registration_test.cc)
 
 target_link_libraries(sourcemeta_core_oauth_unit

--- a/test/oauth/oauth_scope_request_test.cc
+++ b/test/oauth/oauth_scope_request_test.cc
@@ -1,0 +1,151 @@
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oauth.h>
+#include <sourcemeta/core/test.h>
+
+namespace {
+auto decide(const char *claims, const char *request)
+    -> sourcemeta::core::OAuthScopeDecision {
+  return sourcemeta::core::oauth_scope_request_accepts(
+      sourcemeta::core::parse_json(claims),
+      sourcemeta::core::parse_json(request));
+}
+} // namespace
+
+// OpenID Connect Core 1.0 Section 5.5.1 gives the rule its shape, and RFC 6749
+// Section 3.3 makes the granted scope "a list of space-delimited,
+// case-sensitive strings" whose "order does not matter"
+TEST(scope_request_value_that_is_granted) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "read write" })JSON",
+                   R"JSON({ "value": "write" })JSON"),
+            sourcemeta::core::OAuthScopeDecision::Accepted);
+}
+
+TEST(scope_request_value_that_is_not_granted) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "read write" })JSON",
+                   R"JSON({ "value": "admin" })JSON"),
+            sourcemeta::core::OAuthScopeDecision::Refused);
+}
+
+// The strings are case-sensitive, so a differing spelling is a different scope
+TEST(scope_request_value_differing_in_case) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "read" })JSON",
+                   R"JSON({ "value": "READ" })JSON"),
+            sourcemeta::core::OAuthScopeDecision::Refused);
+}
+
+// A scope is a set, so a rule naming several is satisfied by any one of them
+TEST(scope_request_values_with_one_granted) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "read" })JSON",
+                   R"JSON({ "values": [ "admin", "read" ] })JSON"),
+            sourcemeta::core::OAuthScopeDecision::Accepted);
+}
+
+TEST(scope_request_values_with_none_granted) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "read" })JSON",
+                   R"JSON({ "values": [ "admin", "write" ] })JSON"),
+            sourcemeta::core::OAuthScopeDecision::Refused);
+}
+
+TEST(scope_request_empty_values_grant_nothing) {
+  EXPECT_EQ(
+      decide(R"JSON({ "scope": "read" })JSON", R"JSON({ "values": [] })JSON"),
+      sourcemeta::core::OAuthScopeDecision::Refused);
+}
+
+// A rule naming both is satisfied by either
+TEST(scope_request_value_and_values_with_the_value_granted) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "read" })JSON",
+                   R"JSON({ "value": "read", "values": [ "admin" ] })JSON"),
+            sourcemeta::core::OAuthScopeDecision::Accepted);
+}
+
+TEST(scope_request_value_and_values_with_a_listed_one_granted) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "admin" })JSON",
+                   R"JSON({ "value": "read", "values": [ "admin" ] })JSON"),
+            sourcemeta::core::OAuthScopeDecision::Accepted);
+}
+
+// A rule constraining nothing asks only that a scope be carried at all
+TEST(scope_request_unconstrained_rule_with_a_scope) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "read" })JSON", R"JSON({})JSON"),
+            sourcemeta::core::OAuthScopeDecision::Accepted);
+}
+
+TEST(scope_request_unconstrained_rule_carrying_only_essential) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "read" })JSON",
+                   R"JSON({ "essential": true })JSON"),
+            sourcemeta::core::OAuthScopeDecision::Accepted);
+}
+
+TEST(scope_request_unconstrained_rule_without_a_scope) {
+  EXPECT_EQ(decide(R"JSON({ "sub": "u1" })JSON", R"JSON({})JSON"),
+            sourcemeta::core::OAuthScopeDecision::Refused);
+}
+
+// A token carrying no readable scope grants none, whatever the rule asks
+TEST(scope_request_absent_scope_claim) {
+  EXPECT_EQ(
+      decide(R"JSON({ "sub": "u1" })JSON", R"JSON({ "value": "read" })JSON"),
+      sourcemeta::core::OAuthScopeDecision::Refused);
+}
+
+TEST(scope_request_scope_claim_that_is_not_a_string) {
+  EXPECT_EQ(decide(R"JSON({ "scope": [ "read" ] })JSON",
+                   R"JSON({ "value": "read" })JSON"),
+            sourcemeta::core::OAuthScopeDecision::Refused);
+}
+
+TEST(scope_request_empty_scope_claim) {
+  EXPECT_EQ(
+      decide(R"JSON({ "scope": "" })JSON", R"JSON({ "value": "read" })JSON"),
+      sourcemeta::core::OAuthScopeDecision::Refused);
+}
+
+TEST(scope_request_empty_scope_claim_against_an_unconstrained_rule) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "" })JSON", R"JSON({})JSON"),
+            sourcemeta::core::OAuthScopeDecision::Refused);
+}
+
+// A rule this cannot read is neither satisfied nor unsatisfied, so what it
+// means is the caller's to decide rather than this predicate's
+TEST(scope_request_rule_that_is_not_an_object) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "read" })JSON", R"JSON("read")JSON"),
+            sourcemeta::core::OAuthScopeDecision::Unreadable);
+}
+
+TEST(scope_request_rule_that_is_null) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "read" })JSON", R"JSON(null)JSON"),
+            sourcemeta::core::OAuthScopeDecision::Unreadable);
+}
+
+TEST(scope_request_value_that_is_not_a_string) {
+  EXPECT_EQ(
+      decide(R"JSON({ "scope": "read" })JSON", R"JSON({ "value": 42 })JSON"),
+      sourcemeta::core::OAuthScopeDecision::Unreadable);
+}
+
+TEST(scope_request_values_that_is_not_an_array) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "read" })JSON",
+                   R"JSON({ "values": "read" })JSON"),
+            sourcemeta::core::OAuthScopeDecision::Unreadable);
+}
+
+TEST(scope_request_values_carrying_a_member_that_is_not_a_string) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "read" })JSON",
+                   R"JSON({ "values": [ "admin", 42 ] })JSON"),
+            sourcemeta::core::OAuthScopeDecision::Unreadable);
+}
+
+// An unreadable rule is unreadable whether or not the token would satisfy a
+// readable one, so the decision does not depend on the claims
+TEST(scope_request_unreadable_rule_without_a_scope_claim) {
+  EXPECT_EQ(decide(R"JSON({ "sub": "u1" })JSON", R"JSON({ "value": 42 })JSON"),
+            sourcemeta::core::OAuthScopeDecision::Unreadable);
+}
+
+// A rule is read before the token is, so a malformed one is reported as such
+// rather than being masked by a token that grants nothing
+TEST(scope_request_unreadable_rule_outranks_a_missing_scope) {
+  EXPECT_EQ(decide(R"JSON({})JSON", R"JSON("read")JSON"),
+            sourcemeta::core::OAuthScopeDecision::Unreadable);
+}

--- a/test/oauth/oauth_scope_request_test.cc
+++ b/test/oauth/oauth_scope_request_test.cc
@@ -113,9 +113,16 @@ TEST(scope_request_rule_that_is_not_an_object) {
             sourcemeta::core::OAuthScopeDecision::Unreadable);
 }
 
-TEST(scope_request_rule_that_is_null) {
+// OpenID Connect Core 1.0 Section 5.5.1: a null rule "indicates that this
+// Claim is being requested in the default manner", so it constrains nothing
+TEST(scope_request_null_rule_with_a_scope) {
   EXPECT_EQ(decide(R"JSON({ "scope": "read" })JSON", R"JSON(null)JSON"),
-            sourcemeta::core::OAuthScopeDecision::Unreadable);
+            sourcemeta::core::OAuthScopeDecision::Accepted);
+}
+
+TEST(scope_request_null_rule_without_a_scope) {
+  EXPECT_EQ(decide(R"JSON({ "sub": "u1" })JSON", R"JSON(null)JSON"),
+            sourcemeta::core::OAuthScopeDecision::Refused);
 }
 
 TEST(scope_request_value_that_is_not_a_string) {
@@ -148,4 +155,27 @@ TEST(scope_request_unreadable_rule_without_a_scope_claim) {
 TEST(scope_request_unreadable_rule_outranks_a_missing_scope) {
   EXPECT_EQ(decide(R"JSON({})JSON", R"JSON("read")JSON"),
             sourcemeta::core::OAuthScopeDecision::Unreadable);
+}
+
+// RFC 6749 Section 3.3: scope-token = 1*( %x21 / %x23-5B / %x5D-7E ), so a
+// claim of nothing but delimiters names no scope and grants none
+TEST(scope_request_whitespace_only_scope_claim) {
+  EXPECT_EQ(decide(R"JSON({ "scope": " " })JSON", R"JSON({})JSON"),
+            sourcemeta::core::OAuthScopeDecision::Refused);
+}
+
+TEST(scope_request_several_delimiters_only_scope_claim) {
+  EXPECT_EQ(decide(R"JSON({ "scope": "   " })JSON", R"JSON({})JSON"),
+            sourcemeta::core::OAuthScopeDecision::Refused);
+}
+
+TEST(scope_request_whitespace_only_scope_claim_against_a_null_rule) {
+  EXPECT_EQ(decide(R"JSON({ "scope": " " })JSON", R"JSON(null)JSON"),
+            sourcemeta::core::OAuthScopeDecision::Refused);
+}
+
+// A claim padded around a real token still names one
+TEST(scope_request_padded_scope_claim_names_a_scope) {
+  EXPECT_EQ(decide(R"JSON({ "scope": " read " })JSON", R"JSON({})JSON"),
+            sourcemeta::core::OAuthScopeDecision::Accepted);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

