### PR TITLE
Accept only registered tags in RFC 5321 address literals

### DIFF
--- a/src/core/email/helpers.h
+++ b/src/core/email/helpers.h
@@ -47,28 +47,6 @@ constexpr auto is_qtext_smtp(const unsigned char character) -> bool {
          (character >= 93 && character <= 126);
 }
 
-// RFC 5321 §4.1.3: dcontent = %d33-90 / %d94-126
-constexpr auto is_dcontent(const unsigned char character) -> bool {
-  return (character >= 33 && character <= 90) ||
-         (character >= 94 && character <= 126);
-}
-
-// RFC 5321 §4.1.2: Ldh-str = *( ALPHA / DIGIT / "-" ) Let-dig
-// RFC 5321 §4.1.3: Standardized-tag = Ldh-str
-constexpr auto is_ldh_str(const std::string_view value) -> bool {
-  if (value.empty() || !sourcemeta::core::is_alphanum(value.back())) {
-    return false;
-  }
-  for (std::string_view::size_type position{0}; position + 1 < value.size();
-       position += 1) {
-    const auto character{value[position]};
-    if (!sourcemeta::core::is_alphanum(character) && character != '-') {
-      return false;
-    }
-  }
-  return true;
-}
-
 // RFC 5321 §4.1.3: Snum = 1*3DIGIT ; representing a decimal integer
 // value in the range 0 through 255. Leading zeros are permitted, unlike
 // the RFC 3986 dec-octet that backs is_ipv4
@@ -122,30 +100,8 @@ constexpr auto matches_ipv6_tag(const std::string_view value) -> bool {
          value[4] == ':';
 }
 
-// RFC 5321 §4.1.3: General-address-literal = Standardized-tag ":" 1*dcontent
-constexpr auto is_general_address_literal(const std::string_view value)
-    -> bool {
-  const auto colon_position{value.find(':')};
-  if (colon_position == std::string_view::npos) {
-    return false;
-  }
-  if (!is_ldh_str(value.substr(0, colon_position))) {
-    return false;
-  }
-  const auto content{value.substr(colon_position + 1)};
-  if (content.empty()) {
-    return false;
-  }
-  for (const auto character : content) {
-    if (!is_dcontent(static_cast<unsigned char>(character))) {
-      return false;
-    }
-  }
-  return true;
-}
-
 // RFC 5321 §4.1.3: validate the address-literal payload (between "[" and "]")
-// as IPv6, IPv4, or General-address-literal. Always ASCII; no IDNA applies
+// as IPv6 or IPv4. Always ASCII; no IDNA applies
 inline auto is_address_literal(const std::string_view domain) -> bool {
   if (domain.back() != ']') {
     return false;
@@ -155,18 +111,18 @@ inline auto is_address_literal(const std::string_view domain) -> bool {
     return false;
   }
   const auto inner{domain.substr(1, domain.size() - 2)};
-  // RFC 5321 §4.1.3: IPv6-address-literal = "IPv6:" IPv6-addr
-  if (matches_ipv6_tag(inner) && sourcemeta::core::is_ipv6(inner.substr(5))) {
-    return true;
+  // RFC 5321 §4.1.3: IPv6-address-literal = "IPv6:" IPv6-addr. The tag names
+  // the syntax that the rest of the literal follows, so a payload that is not
+  // an address is turned down rather than read as general content, which
+  // would otherwise leave the IPv6 form unable to ever fail
+  if (matches_ipv6_tag(inner)) {
+    return sourcemeta::core::is_ipv6(inner.substr(5));
   }
-  // RFC 5234 §3.2: ABNF alternatives are unordered. A failed IPv6 match
-  // falls through to IPv4 or General-address-literal.
-  // RFC 5321 §4.1.3: IPv4-address-literal has no ":";
-  // General-address-literal requires ":"
-  if (!inner.contains(':')) {
-    return is_ipv4_address_literal(inner);
-  }
-  return is_general_address_literal(inner);
+  // RFC 5321 §4.1.3: a Standardized-tag must be registered with IANA before
+  // being used, and the registry carries the IPv6 tag alone, so the general
+  // form admits nothing that the branch above does not already cover. What
+  // remains is the IPv4 form, which has no colon to begin with
+  return !inner.contains(':') && is_ipv4_address_literal(inner);
 }
 
 // RFC 3986 §2.1: "For consistency, URI producers and normalizers should use

--- a/src/core/email/include/sourcemeta/core/email.h
+++ b/src/core/email/include/sourcemeta/core/email.h
@@ -39,9 +39,11 @@ namespace sourcemeta::core {
 /// prose specifies the IPv6 syntax as that of RFC 4291, while the `IPv6-addr`
 /// ABNF in the same section is stricter and conflicts with it, so the prose is
 /// followed. A bracketed `[IPv6:...]` whose body is not a valid address is
-/// still accepted, because Section 4.1.3 also permits any
-/// General-address-literal (a registered tag, a colon, and content) and ABNF
-/// alternatives are unordered.
+/// turned down rather than read as a General-address-literal, since the tag
+/// names the syntax that has to follow it. That general form is not accepted
+/// under any other tag either, as Section 4.1.3 requires a Standardized-tag to
+/// be registered with IANA before being used and that registry carries the
+/// IPv6 tag alone.
 ///
 /// For example:
 ///
@@ -108,9 +110,8 @@ auto is_idn_email_uts46(const std::string_view value) -> bool;
 /// Produce the domain half of a valid RFC 5321 `Mailbox`, returning an empty
 /// view when the input is not one, which no valid mailbox can otherwise yield
 /// since a domain is never empty. The separator is located by parsing the
-/// address, since neither the first nor the last at sign reliably marks it:
-/// RFC 5321 Section 4.1.2 admits one inside a quoted local part, and Section
-/// 4.1.3 admits one inside the content of a General-address-literal. The
+/// address, since the first at sign does not reliably mark it: RFC 5321
+/// Section 4.1.2 admits one inside a quoted local part. The
 /// result borrows from the input and keeps its spelling, so a caller comparing
 /// domains applies the RFC 5321 Section 2.4 case insensitivity itself. Only
 /// the ASCII grammar is accepted, so an internationalized address per RFC 6531

--- a/test/email/email_domain_test.cc
+++ b/test/email/email_domain_test.cc
@@ -14,11 +14,11 @@ TEST(email_domain_quoted_local_part_carrying_an_at_sign) {
             "example.org");
 }
 
-// RFC 5321 §4.1.3: General-address-literal content is 1*dcontent, and
-// dcontent = %d33-90 / %d94-126 admits the at sign, so the separator is not
-// the last one in the string either
+// RFC 5321 §4.1.3: no address-literal carries an at sign, as the only tag the
+// registry holds is the IPv6 one and no address spells one, so a literal that
+// does is not a Mailbox and reports no domain at all
 TEST(email_domain_address_literal_carrying_an_at_sign) {
-  EXPECT_EQ(sourcemeta::core::email_domain("user@[tag:a@b]"), "[tag:a@b]");
+  EXPECT_TRUE(sourcemeta::core::email_domain("user@[tag:a@b]").empty());
 }
 
 TEST(email_domain_ipv4_address_literal) {

--- a/test/email/email_test.cc
+++ b/test/email/email_test.cc
@@ -886,14 +886,6 @@ TEST(valid_ipv6_literal_v4_compat) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6:::192.168.1.1]"));
 }
 
-// RFC 5321 §4.1.3: without the "IPv6:" tag the literal is parsed as
-// General-address-literal (tag "2001", content "db8::1"), which is valid
-// because ":" is in dcontent (%d58 is within %d33-90)
-TEST(valid_no_ipv6_prefix_as_general) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[2001:db8::1]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[2001:db8::1]"));
-}
-
 // RFC 5234 §2.3: ABNF literal strings are case-insensitive by default, so the
 // "IPv6:" prefix matches "ipv6:"
 TEST(valid_lowercase_ipv6_literal) {
@@ -913,19 +905,18 @@ TEST(valid_mixed_case_ipv6_literal) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[iPv6:::1]"));
 }
 
-// RFC 5234 §3.2: ABNF alternatives are unordered. The literal five-byte
-// prefix "IPv6:" is stripped, ":1" fails IPv6-addr, and the input falls
-// through to General-address-literal with tag "IPv6" and content ":1"
-TEST(valid_ipv6_prefix_no_colon_as_general) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv6::1]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6::1]"));
+// RFC 5321 §4.1.3: a single colon after the tag leaves ":1", which is not an
+// address, and the tag names the syntax that has to follow it
+TEST(invalid_ipv6_prefix_single_colon) {
+  EXPECT_FALSE(sourcemeta::core::is_email("a@[IPv6::1]"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[IPv6::1]"));
 }
 
-// RFC 5234 §3.2: a failed IPv6-addr match falls through to General-address-
-// literal with tag "IPv6" and content "not-an-address" (all dcontent)
-TEST(valid_ipv6_body_garbage_as_general) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv6:not-an-address]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6:not-an-address]"));
+// RFC 5321 §4.1.3: the IPv6 tag is the only one the registry carries, and it
+// names the address syntax, so its payload is not read as general content
+TEST(invalid_ipv6_body_garbage) {
+  EXPECT_FALSE(sourcemeta::core::is_email("a@[IPv6:not-an-address]"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[IPv6:not-an-address]"));
 }
 
 // RFC 5321 §4.1.3: IPv6-addr requires at least one group
@@ -934,11 +925,45 @@ TEST(invalid_ipv6_body_empty) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[IPv6:]"));
 }
 
-// RFC 5234 §3.2: nine groups fail IPv6-addr but the input still matches
-// General-address-literal with tag "IPv6" and content "1:2:3:4:5:6:7:8:9"
-TEST(valid_ipv6_too_many_groups_as_general) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv6:1:2:3:4:5:6:7:8:9]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6:1:2:3:4:5:6:7:8:9]"));
+// RFC 5321 §4.1.3: nine groups are not an address, and reading them as
+// general content instead would leave the IPv6 form unable to ever fail
+TEST(invalid_ipv6_too_many_groups) {
+  EXPECT_FALSE(sourcemeta::core::is_email("a@[IPv6:1:2:3:4:5:6:7:8:9]"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[IPv6:1:2:3:4:5:6:7:8:9]"));
+}
+
+// RFC 5321 §4.1.3: a Standardized-tag MUST be registered with IANA before
+// being used, and that registry carries the IPv6 tag alone, so no other tag
+// names an address-literal however well formed the rest of it is
+TEST(invalid_general_literal_unregistered_tag) {
+  EXPECT_FALSE(sourcemeta::core::is_email("a@[X400:foo]"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[X400:foo]"));
+}
+
+TEST(invalid_general_literal_shortest_unregistered_tag) {
+  EXPECT_FALSE(sourcemeta::core::is_email("a@[X:y]"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[X:y]"));
+}
+
+// RFC 5321 §4.1.3: the tag is taken whole, so one that merely resembles the
+// registered spelling is still not it
+TEST(invalid_general_literal_ipv7_like_tag) {
+  EXPECT_FALSE(sourcemeta::core::is_email("a@[IPv7:foo]"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[IPv7:foo]"));
+}
+
+// RFC 5321 §4.1.3: an address written without the tag that names its syntax
+// is not an address-literal either
+TEST(invalid_untagged_ipv6_literal) {
+  EXPECT_FALSE(sourcemeta::core::is_email("a@[2001:db8::1]"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[2001:db8::1]"));
+}
+
+// RFC 5321 §4.1.2 + §4.1.3: a Quoted-string local part does not lend
+// standing to a literal under an unregistered tag
+TEST(invalid_quoted_local_with_general_literal) {
+  EXPECT_FALSE(sourcemeta::core::is_email("\"foo\"@[X400:bar]"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("\"foo\"@[X400:bar]"));
 }
 
 // RFC 5321 §4.1.3: address-literal needs a closing "]"
@@ -951,99 +976,6 @@ TEST(invalid_ipv6_missing_close_bracket) {
 TEST(invalid_ipv6_trailing_garbage) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[IPv6:::1]x"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[IPv6:::1]x"));
-}
-
-// RFC 5321 §4.1.3: General-address-literal = Standardized-tag ":" 1*dcontent
-TEST(valid_general_literal_minimal) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[X:y]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[X:y]"));
-}
-
-// RFC 5321 §4.1.3: typical X400 tag from the IANA Standardized-tag registry
-TEST(valid_general_literal_x400) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[X400:foo]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[X400:foo]"));
-}
-
-// RFC 5321 §4.1.2: Ldh-str body permits DIGIT before the terminal Let-dig
-TEST(valid_general_literal_tag_with_digits) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[tag1:foo]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[tag1:foo]"));
-}
-
-// RFC 5321 §4.1.2: Ldh-str body permits interior "-"
-TEST(valid_general_literal_tag_with_interior_hyphen) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[tag-name:foo]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[tag-name:foo]"));
-}
-
-// RFC 5321 §4.1.2: Ldh-str = *( ALPHA / DIGIT / "-" ) Let-dig permits a
-// leading "-" because Standardized-tag is Ldh-str, not Let-dig [Ldh-str]
-TEST(valid_general_literal_tag_leading_hyphen) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[-tag:foo]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[-tag:foo]"));
-}
-
-// RFC 5321 §4.1.3: dcontent starts at %d33 "!"
-TEST(valid_general_literal_dcontent_lower_bound) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[Tag:!]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[Tag:!]"));
-}
-
-// RFC 5321 §4.1.3: dcontent %d33-90 ends at "Z"
-TEST(valid_general_literal_dcontent_upper_first_range) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[Tag:Z]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[Tag:Z]"));
-}
-
-// RFC 5321 §4.1.3: dcontent %d94-126 starts at "^"
-TEST(valid_general_literal_dcontent_lower_second_range) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[Tag:^]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[Tag:^]"));
-}
-
-// RFC 5321 §4.1.3: dcontent ends at "~" (%d126)
-TEST(valid_general_literal_dcontent_upper_bound) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[Tag:~]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[Tag:~]"));
-}
-
-// RFC 5321 §4.1.3: dcontent %d33-90 includes ":" (%d58)
-TEST(valid_general_literal_dcontent_with_colon) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[Tag:foo:bar]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[Tag:foo:bar]"));
-}
-
-// RFC 5321 §4.1.3: 1*dcontent permits long content
-TEST(valid_general_literal_dcontent_long) {
-  EXPECT_TRUE(
-      sourcemeta::core::is_email("a@[Tag:" + std::string(200, 'a') + "]"));
-  EXPECT_TRUE(
-      sourcemeta::core::is_idn_email("a@[Tag:" + std::string(200, 'a') + "]"));
-}
-
-// RFC 5321 §4.1.2: Ldh-str must end with Let-dig, trailing "-" is invalid
-TEST(invalid_general_tag_trailing_hyphen) {
-  EXPECT_FALSE(sourcemeta::core::is_email("a@[tag-:x]"));
-  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[tag-:x]"));
-}
-
-// RFC 5321 §4.1.2: Ldh-str requires a terminal Let-dig, lone "-" is invalid
-TEST(invalid_general_tag_single_hyphen) {
-  EXPECT_FALSE(sourcemeta::core::is_email("a@[-:x]"));
-  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[-:x]"));
-}
-
-// RFC 5321 §4.1.2: Ldh-str alphabet excludes "_"
-TEST(invalid_general_tag_with_underscore) {
-  EXPECT_FALSE(sourcemeta::core::is_email("a@[tag_name:x]"));
-  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[tag_name:x]"));
-}
-
-// RFC 5321 §4.1.2: Standardized-tag = Ldh-str, minimum length is one byte
-TEST(invalid_general_tag_empty) {
-  EXPECT_FALSE(sourcemeta::core::is_email("a@[:x]"));
-  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[:x]"));
 }
 
 // RFC 5321 §4.1.3: General-address-literal = tag ":" 1*dcontent, empty content
@@ -1142,13 +1074,6 @@ TEST(valid_quoted_local_with_ipv6_literal) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"foo\"@[IPv6:::1]"));
 }
 
-// RFC 5321 §4.1.2 + §4.1.3: Quoted-string Local-part with General-address-
-// literal
-TEST(valid_quoted_local_with_general_literal) {
-  EXPECT_TRUE(sourcemeta::core::is_email("\"foo\"@[X400:bar]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("\"foo\"@[X400:bar]"));
-}
-
 // RFC 5321 §4.1.2 + §4.1.3: Dot-string Local-part with IPv4 address-literal
 TEST(valid_dot_string_with_ipv4_literal) {
   EXPECT_TRUE(sourcemeta::core::is_email("foo@[192.168.1.1]"));
@@ -1159,12 +1084,6 @@ TEST(valid_dot_string_with_ipv4_literal) {
 TEST(valid_dot_string_with_ipv6_literal) {
   EXPECT_TRUE(sourcemeta::core::is_email("foo@[IPv6:::1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("foo@[IPv6:::1]"));
-}
-
-// RFC 5321 §4.1.2 + §4.1.3: Dot-string Local-part with General-address-literal
-TEST(valid_dot_string_with_general_literal) {
-  EXPECT_TRUE(sourcemeta::core::is_email("foo@[X400:bar]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("foo@[X400:bar]"));
 }
 
 // RFC 5321 §4.5.3.1.2: an address-literal whose total length equals the
@@ -1273,12 +1192,6 @@ TEST(invalid_lone_at) {
 TEST(valid_minimum_length_mailbox) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@b"));
-}
-
-// RFC 5321 §4.1.3: a single dcontent byte is the minimum 1*dcontent
-TEST(valid_general_literal_minimum_dcontent) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[A:B]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[A:B]"));
 }
 
 // RFC 5321 §4.1.2 ALPHA upper bound: "Z" (%d90) is in atext
@@ -1403,39 +1316,11 @@ TEST(invalid_bracket_with_leading_space) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[ 1.2.3.4]"));
 }
 
-// RFC 5321 §4.1.3 + RFC 5234 §3.2: a case-insensitive "IPv6:" match that
-// fails IPv6-addr still falls through to General-address-literal
-TEST(valid_lowercase_ipv6_fallthrough_to_general) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[ipv6:not-an-address]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[ipv6:not-an-address]"));
-}
-
-// RFC 5321 §4.1.2 Ldh-str: leading "-" before another "-" before Let-dig is
-// still a valid Ldh-str
-TEST(valid_general_literal_multiple_leading_hyphens) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[--a:b]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[--a:b]"));
-}
-
-// RFC 5321 §4.1.3: any Ldh-str is a valid Standardized-tag per the grammar,
-// including ones not registered with IANA such as "IPv7"
-TEST(valid_general_literal_ipv7_like_tag) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv7:foo]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv7:foo]"));
-}
-
-// RFC 5321 §4.1.2 Ldh-str alphabet excludes ".", so a tag with "." cannot
-// match Standardized-tag
-TEST(invalid_general_tag_with_dot) {
-  EXPECT_FALSE(sourcemeta::core::is_email("a@[a.b:c]"));
-  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[a.b:c]"));
-}
-
-// RFC 5321 §4.1.3: General-address-literal content of just ":" is a single
-// dcontent byte (%d58 is in %d33-90)
-TEST(valid_general_literal_content_just_colon) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[a::]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[a::]"));
+// RFC 5234 §2.3: the tag matches without regard to case, so the lowercase
+// spelling is held to the same address syntax
+TEST(invalid_lowercase_ipv6_body_garbage) {
+  EXPECT_FALSE(sourcemeta::core::is_email("a@[ipv6:not-an-address]"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[ipv6:not-an-address]"));
 }
 
 // RFC 5321 §4.1.3 + RFC 5234 §3.2: bracketed input where the first colon
@@ -2014,40 +1899,4 @@ TEST(invalid_general_address_literal_trailing_hyphen_tag) {
 TEST(invalid_general_address_literal_no_dcontent) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[x:]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[x:]"));
-}
-
-// RFC 5321 4.1.3: dcontent = %d33-90 / %d94-126 excludes %d32
-TEST(invalid_dcontent_space) {
-  EXPECT_FALSE(sourcemeta::core::is_email("a@[x: ]"));
-  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[x: ]"));
-}
-
-// RFC 5321 4.1.3: dcontent = %d33-90 / %d94-126 includes %d33
-TEST(valid_dcontent_bang) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[x:!]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[x:!]"));
-}
-
-// RFC 5321 4.1.3: dcontent = %d33-90 / %d94-126 includes %d90
-TEST(valid_dcontent_upper_z) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[x:Z]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[x:Z]"));
-}
-
-// RFC 5321 4.1.3: dcontent = %d33-90 / %d94-126 includes %d94
-TEST(valid_dcontent_caret) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[x:^]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[x:^]"));
-}
-
-// RFC 5321 4.1.3: dcontent = %d33-90 / %d94-126 includes %d126
-TEST(valid_dcontent_tilde) {
-  EXPECT_TRUE(sourcemeta::core::is_email("a@[x:~]"));
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[x:~]"));
-}
-
-// RFC 5321 4.1.3: dcontent = %d33-90 / %d94-126 excludes %d127
-TEST(invalid_dcontent_del) {
-  EXPECT_FALSE(sourcemeta::core::is_email("a@[x:\x7f]"));
-  EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[x:\x7f]"));
 }

--- a/test/email/idn_email_test.cc
+++ b/test/email/idn_email_test.cc
@@ -597,46 +597,36 @@ TEST(invalid_address_literal_empty_octet) {
   EXPECT_FALSE(sourcemeta::core::is_email("user@[1..2.3]"));
 }
 
-// General-address-literal = Standardized-tag ":" 1*dcontent
-TEST(valid_general_address_literal) {
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("user@[unknown-tag:abc]"));
-  EXPECT_TRUE(sourcemeta::core::is_email("user@[unknown-tag:abc]"));
+// RFC 5321 §4.1.3: a Standardized-tag MUST be registered with IANA before
+// being used, and the registry carries the IPv6 tag alone, so the general
+// form admits nothing beyond what the IPv6 branch already covers
+TEST(invalid_general_address_literal_unregistered_tag) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@[unknown-tag:abc]"));
+  EXPECT_FALSE(sourcemeta::core::is_email("user@[unknown-tag:abc]"));
 }
 
-TEST(valid_general_address_literal_shortest) {
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("user@[a:b]"));
-  EXPECT_TRUE(sourcemeta::core::is_email("user@[a:b]"));
+// RFC 5321 §4.1.3: the tag names the syntax that the rest of the literal
+// follows, so a payload under the IPv6 tag that is not an address is turned
+// down rather than read as a general literal, which would otherwise leave the
+// IPv6 form unable to fail
+TEST(invalid_address_literal_ipv6_tag_with_letters) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@[IPv6:zzz]"));
+  EXPECT_FALSE(sourcemeta::core::is_email("user@[IPv6:zzz]"));
 }
 
-// RFC 5321 §4.1.2: Ldh-str = *( ALPHA / DIGIT / "-" ) Let-dig constrains only
-// the final character, so unlike sub-domain (Let-dig [Ldh-str]) a
-// Standardized-tag may begin with a hyphen
-TEST(valid_general_address_literal_leading_hyphen_tag) {
-  EXPECT_TRUE(sourcemeta::core::is_idn_email("user@[-tag:abc]"));
-  EXPECT_TRUE(sourcemeta::core::is_email("user@[-tag:abc]"));
+TEST(invalid_address_literal_ipv6_tag_with_non_hexadecimal_groups) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@[IPv6:g:g:g:g:g:g:g:g]"));
+  EXPECT_FALSE(sourcemeta::core::is_email("user@[IPv6:g:g:g:g:g:g:g:g]"));
 }
 
-TEST(invalid_general_address_literal_trailing_hyphen_tag) {
-  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@[tag-:abc]"));
-  EXPECT_FALSE(sourcemeta::core::is_email("user@[tag-:abc]"));
+TEST(invalid_address_literal_ipv6_tag_with_two_elisions) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@[IPv6:2001:db8::1::2]"));
+  EXPECT_FALSE(sourcemeta::core::is_email("user@[IPv6:2001:db8::1::2]"));
 }
 
-// 1*dcontent requires at least one octet
-TEST(invalid_general_address_literal_empty_content) {
-  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@[tag:]"));
-  EXPECT_FALSE(sourcemeta::core::is_email("user@[tag:]"));
-}
-
-TEST(invalid_general_address_literal_empty_tag) {
-  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@[:abc]"));
-  EXPECT_FALSE(sourcemeta::core::is_email("user@[:abc]"));
-}
-
-// RFC 5321 §4.1.3: dcontent = %d33-90 / %d94-126, which excludes SP, "[",
-// "\" and "]"
-TEST(invalid_general_address_literal_space_in_content) {
-  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@[tag:ab c]"));
-  EXPECT_FALSE(sourcemeta::core::is_email("user@[tag:ab c]"));
+TEST(invalid_address_literal_ipv6_tag_with_only_colons) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@[IPv6:::::::::]"));
+  EXPECT_FALSE(sourcemeta::core::is_email("user@[IPv6:::::::::]"));
 }
 
 TEST(invalid_general_address_literal_open_bracket_in_content) {

--- a/test/email/mailto_iri_test.cc
+++ b/test/email/mailto_iri_test.cc
@@ -316,12 +316,11 @@ TEST(mailto_iri_encodes_ipv6_address_literal) {
   EXPECT_EQ(result.value(), "mailto:user@%5BIPv6:2001:db8::1%5D");
 }
 
-// RFC 5321 §4.1.3: General-address-literal = Standardized-tag ":"
-// 1*dcontent, characters reserved by RFC 6068 §2 inside it are encoded
-TEST(mailto_iri_encodes_general_address_literal) {
-  const auto result{sourcemeta::core::mailto_iri("user@[foo:bar/baz]")};
-  EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value(), "mailto:user@%5Bfoo:bar%2Fbaz%5D");
+// RFC 5321 §4.1.3: a Standardized-tag has to be registered with IANA before
+// being used, and only the IPv6 tag is, so a literal under any other tag is
+// not a Mailbox to render
+TEST(mailto_iri_rejects_general_address_literal) {
+  EXPECT_FALSE(sourcemeta::core::mailto_iri("user@[foo:bar/baz]").has_value());
 }
 
 // RFC 5321 §4.1.2: Mailbox = Local-part "@" ( Domain / address-literal ),


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/2742
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

