### PR TITLE
Fix `Decimal::to_integral` rounding and `is_integer` on arithmetic fast paths

### DIFF
--- a/src/lang/numeric/big_coefficient.h
+++ b/src/lang/numeric/big_coefficient.h
@@ -1,13 +1,14 @@
 #ifndef SOURCEMETA_CORE_NUMERIC_BIG_COEFFICIENT_H_
 #define SOURCEMETA_CORE_NUMERIC_BIG_COEFFICIENT_H_
 
-#include <algorithm> // std::max, std::copy, std::fill
-#include <array>     // std::array
-#include <cstdint>   // std::int32_t, std::int64_t, std::uint32_t,
-                     // std::uint64_t, std::uintptr_t, std::uint8_t
-#include <cstring>   // std::memcpy
-#include <string>    // std::string, std::to_string
-#include <utility>   // std::pair, std::move
+#include <algorithm>   // std::max, std::copy, std::fill
+#include <array>       // std::array
+#include <cstdint>     // std::int32_t, std::int64_t, std::uint32_t,
+                       // std::uint64_t, std::uintptr_t, std::uint8_t
+#include <cstring>     // std::memcpy
+#include <string>      // std::string, std::to_string
+#include <string_view> // std::string_view
+#include <utility>     // std::pair, std::move
 
 #include <sourcemeta/core/numeric_uint128.h>
 
@@ -781,6 +782,25 @@ auto modular_pow10(std::uint32_t exponent, std::uint64_t modulus)
 // Round-half-even (banker's rounding) to WORKING_PRECISION significant digits
 constexpr std::int32_t WORKING_PRECISION = 16;
 
+auto rounds_up_half_even(const std::string_view kept,
+                         const std::string_view dropped) -> bool {
+  if (dropped.empty() || dropped.front() < '5') {
+    return false;
+  }
+
+  if (dropped.front() > '5') {
+    return true;
+  }
+
+  for (std::size_t index = 1; index < dropped.size(); index++) {
+    if (dropped[index] != '0') {
+      return true;
+    }
+  }
+
+  return !kept.empty() && (kept.back() - '0') % 2 != 0;
+}
+
 auto round_to_precision(std::int64_t &coefficient,
                         std::uint64_t &coefficient_high, std::int32_t &exponent,
                         std::uint8_t &flags) -> void {
@@ -803,26 +823,7 @@ auto round_to_precision(std::int64_t &coefficient,
     auto dropped =
         digit_string.substr(static_cast<std::size_t>(WORKING_PRECISION));
 
-    bool round_up = false;
-    if (!dropped.empty()) {
-      if (dropped[0] > '5') {
-        round_up = true;
-      } else if (dropped[0] == '5') {
-        bool has_trailing = false;
-        for (std::size_t index = 1; index < dropped.size(); index++) {
-          if (dropped[index] != '0') {
-            has_trailing = true;
-            break;
-          }
-        }
-
-        if (has_trailing) {
-          round_up = true;
-        } else {
-          round_up = (kept.back() - '0') % 2 != 0;
-        }
-      }
-    }
+    const auto round_up = rounds_up_half_even(kept, dropped);
 
     if ((flags & FLAG_HEAP) != 0) {
       delete load_big_pointer(coefficient);

--- a/src/lang/numeric/decimal.cc
+++ b/src/lang/numeric/decimal.cc
@@ -3,20 +3,21 @@
 
 #include "big_coefficient.h"
 
-#include <array>     // std::array
-#include <cassert>   // assert
-#include <charconv>  // std::to_chars
-#include <cmath>     // std::isfinite, std::isnan, std::isinf, std::abs,
-                     // std::frexp, std::ldexp, std::signbit
-#include <cstddef>   // std::size_t
-#include <cstring>   // std::strlen
-#include <iomanip>   // std::setprecision
-#include <limits>    // std::numeric_limits
-#include <optional>  // std::optional, std::nullopt
-#include <sstream>   // std::ostringstream
-#include <stdexcept> // std::out_of_range
-#include <string>    // std::string, std::stof, std::stod
-#include <vector>    // std::vector
+#include <array>       // std::array
+#include <cassert>     // assert
+#include <charconv>    // std::to_chars
+#include <cmath>       // std::isfinite, std::isnan, std::isinf, std::abs,
+                       // std::frexp, std::ldexp, std::signbit
+#include <cstddef>     // std::size_t
+#include <cstring>     // std::strlen
+#include <iomanip>     // std::setprecision
+#include <limits>      // std::numeric_limits
+#include <optional>    // std::optional, std::nullopt
+#include <sstream>     // std::ostringstream
+#include <stdexcept>   // std::out_of_range
+#include <string>      // std::string, std::stof, std::stod
+#include <string_view> // std::string_view
+#include <vector>      // std::vector
 
 namespace {
 
@@ -990,7 +991,10 @@ auto Decimal::to_integral() const -> Decimal {
   }
 
   if (this->exponent_ >= 0) {
-    return *this;
+    Decimal result{*this};
+    result.flags_ =
+        static_cast<std::uint8_t>(result.flags_ & ~FLAG_INTEGER_LITERAL);
+    return result;
   }
 
   if ((this->flags_ & FLAG_BIG) != 0) {
@@ -999,14 +1003,28 @@ auto Decimal::to_integral() const -> Decimal {
     auto number_of_digits = static_cast<std::int32_t>(digit_string.size());
     auto digits_to_remove = -this->exponent_;
 
-    if (digits_to_remove >= number_of_digits) {
+    if (digits_to_remove > number_of_digits) {
       Decimal result;
+      if ((this->flags_ & FLAG_SIGN) != 0) {
+        result.flags_ = FLAG_SIGN;
+      }
+
       return result;
     }
 
-    auto integer_string = digit_string.substr(
-        0, static_cast<std::size_t>(number_of_digits - digits_to_remove));
-    Decimal result{integer_string};
+    const auto kept_digits =
+        static_cast<std::size_t>(number_of_digits - digits_to_remove);
+    const std::string_view kept{digit_string.data(), kept_digits};
+    const std::string_view dropped{digit_string.data() + kept_digits,
+                                   digit_string.size() - kept_digits};
+    Decimal result{kept_digits == 0 ? std::string{"0"}
+                                    : digit_string.substr(0, kept_digits)};
+    if (rounds_up_half_even(kept, dropped)) {
+      result += Decimal{1};
+    }
+
+    result.flags_ =
+        static_cast<std::uint8_t>(result.flags_ & ~FLAG_INTEGER_LITERAL);
     if ((this->flags_ & FLAG_SIGN) != 0) {
       result.flags_ |= FLAG_SIGN;
     }
@@ -1017,9 +1035,14 @@ auto Decimal::to_integral() const -> Decimal {
   auto coefficient = this->coefficient_;
   auto digits_to_remove = -this->exponent_;
 
-  if (static_cast<std::uint32_t>(digits_to_remove) >=
+  if (static_cast<std::uint32_t>(digits_to_remove) >
       digit_count(static_cast<std::uint64_t>(coefficient))) {
-    return Decimal{};
+    Decimal result;
+    if ((this->flags_ & FLAG_SIGN) != 0) {
+      result.flags_ = FLAG_SIGN;
+    }
+
+    return result;
   }
 
   std::int64_t divisor = 1;
@@ -1751,11 +1774,15 @@ auto Decimal::operator+=(const Decimal &other) -> Decimal & {
       this->flags_ = static_cast<std::uint8_t>(this->flags_ & ~FLAG_SIGN);
     }
 
+    this->flags_ =
+        static_cast<std::uint8_t>(this->flags_ & ~FLAG_INTEGER_LITERAL);
     return *this;
   }
 
   if (this->is_zero()) {
     *this = other;
+    this->flags_ =
+        static_cast<std::uint8_t>(this->flags_ & ~FLAG_INTEGER_LITERAL);
     return *this;
   }
 
@@ -2032,6 +2059,8 @@ auto Decimal::operator%=(const Decimal &other) -> Decimal & {
   divisor_magnitude.flags_ =
       static_cast<std::uint8_t>(divisor_magnitude.flags_ & ~FLAG_SIGN);
   if (dividend_magnitude < divisor_magnitude) {
+    this->flags_ =
+        static_cast<std::uint8_t>(this->flags_ & ~FLAG_INTEGER_LITERAL);
     return *this;
   }
 

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -4172,7 +4172,7 @@ TEST(multiply_bigs_with_carry) {
 
 TEST(to_integral_of_big_fraction) {
   const sourcemeta::core::Decimal value{"12345678901234567890123456789.5"};
-  EXPECT_EQ(value.to_integral().to_string(), "12345678901234567890123456789");
+  EXPECT_EQ(value.to_integral().to_string(), "12345678901234567890123456790");
 }
 
 TEST(remainder_of_sixteen_digit_dividend) {
@@ -4246,11 +4246,11 @@ TEST(heap_coefficient_negation) {
             "-123456789012345678901234567890123456789012345");
 }
 
-TEST(heap_coefficient_to_integral_truncates) {
+TEST(heap_coefficient_to_integral_rounds) {
   const sourcemeta::core::Decimal value{
       "123456789012345678901234567890123456789012345.75"};
   EXPECT_EQ(value.to_integral().to_string(),
-            "123456789012345678901234567890123456789012345");
+            "123456789012345678901234567890123456789012346");
 }
 
 TEST(heap_coefficient_is_integral) {
@@ -4791,4 +4791,214 @@ TEST(subtract_equal_negative_values_gives_positive_zero) {
   EXPECT_EQ(result.to_string(), "0");
   EXPECT_TRUE(result.is_zero());
   EXPECT_FALSE(result.is_signed());
+}
+
+TEST(divide_integer_hundred_digit_dividend_by_one) {
+  const sourcemeta::core::Decimal value{
+      "1234567890123456789012345678901234567890"
+      "1234567890123456789012345678901234567890"
+      "12345678901234567890"};
+  const auto quotient{value.divide_integer(sourcemeta::core::Decimal{1})};
+  EXPECT_EQ(quotient, value);
+  EXPECT_EQ(quotient.to_string(), value.to_string());
+  EXPECT_FALSE(quotient.is_nan());
+}
+
+TEST(divide_integer_thirty_six_digits_by_single_limb) {
+  const sourcemeta::core::Decimal dividend{
+      "999999999999999999999999999999999999"};
+  const sourcemeta::core::Decimal divisor{"1000000000000000000"};
+  const auto quotient{dividend.divide_integer(divisor)};
+  EXPECT_EQ(quotient, sourcemeta::core::Decimal{"999999999999999999"});
+  EXPECT_EQ(quotient.to_string(), "999999999999999999");
+}
+
+TEST(divide_integer_thirty_six_digits_by_nearby_divisor) {
+  const sourcemeta::core::Decimal dividend{
+      "999999999999999999999999999999999999"};
+  const sourcemeta::core::Decimal divisor{"1000000000000000001"};
+  const auto quotient{dividend.divide_integer(divisor)};
+  EXPECT_TRUE(quotient.is_finite());
+  EXPECT_EQ(quotient, sourcemeta::core::Decimal{"999999999999999999"});
+  EXPECT_EQ(quotient.to_string(), "999999999999999999");
+}
+
+TEST(nan_with_oversized_payload_saturates) {
+  const sourcemeta::core::Decimal value{"NaN99999999999999999999"};
+  EXPECT_TRUE(value.is_qnan());
+  EXPECT_EQ(value.nan_payload(), static_cast<std::uint64_t>(
+                                     std::numeric_limits<std::int64_t>::max()));
+  EXPECT_EQ(value.to_string(), "NaN9223372036854775807");
+}
+
+TEST(is_integer_add_zero_clears_flag) {
+  auto value{sourcemeta::core::Decimal{3}};
+  EXPECT_TRUE(value.is_integer());
+  value += sourcemeta::core::Decimal{0};
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_TRUE(value.is_integral());
+  EXPECT_EQ(value.to_string(), "3");
+}
+
+TEST(is_integer_zero_plus_integer_clears_flag) {
+  auto value{sourcemeta::core::Decimal{0}};
+  value += sourcemeta::core::Decimal{3};
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_TRUE(value.is_integral());
+  EXPECT_EQ(value.to_string(), "3");
+}
+
+TEST(is_integer_subtract_zero_clears_flag) {
+  auto value{sourcemeta::core::Decimal{3}};
+  value -= sourcemeta::core::Decimal{0};
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_TRUE(value.is_integral());
+  EXPECT_EQ(value.to_string(), "3");
+}
+
+TEST(is_integer_modulo_smaller_dividend_clears_flag) {
+  const sourcemeta::core::Decimal dividend{3};
+  const sourcemeta::core::Decimal divisor{5};
+  const auto result{dividend % divisor};
+  EXPECT_FALSE(result.is_integer());
+  EXPECT_TRUE(result.is_integral());
+  EXPECT_EQ(result.to_string(), "3");
+}
+
+TEST(is_integer_modulo_larger_dividend_clears_flag) {
+  const sourcemeta::core::Decimal dividend{7};
+  const sourcemeta::core::Decimal divisor{5};
+  const auto result{dividend % divisor};
+  EXPECT_FALSE(result.is_integer());
+  EXPECT_TRUE(result.is_integral());
+  EXPECT_EQ(result.to_string(), "2");
+}
+
+TEST(is_integer_to_integral_of_integer_clears_flag) {
+  const sourcemeta::core::Decimal value{3};
+  const auto result{value.to_integral()};
+  EXPECT_FALSE(result.is_integer());
+  EXPECT_TRUE(result.is_integral());
+  EXPECT_EQ(result.to_string(), "3");
+}
+
+TEST(is_integer_to_integral_of_real_clears_flag) {
+  const sourcemeta::core::Decimal value{"3.7"};
+  const auto result{value.to_integral()};
+  EXPECT_FALSE(result.is_integer());
+  EXPECT_TRUE(result.is_integral());
+  EXPECT_EQ(result.to_string(), "4");
+}
+
+TEST(is_integer_to_integral_of_big_real_clears_flag) {
+  const sourcemeta::core::Decimal value{"123456789012345678901234567890.7"};
+  const auto result{value.to_integral()};
+  EXPECT_FALSE(result.is_integer());
+  EXPECT_TRUE(result.is_integral());
+  EXPECT_EQ(result.to_string(), "123456789012345678901234567891");
+}
+
+TEST(to_integral_rounds_fraction_below_one_up) {
+  const sourcemeta::core::Decimal value{"0.7"};
+  const auto result{value.to_integral()};
+  EXPECT_EQ(result, sourcemeta::core::Decimal{1});
+  EXPECT_EQ(result.to_string(), "1");
+}
+
+TEST(to_integral_rounds_fraction_below_one_down) {
+  const sourcemeta::core::Decimal value{"0.4"};
+  const auto result{value.to_integral()};
+  EXPECT_EQ(result, sourcemeta::core::Decimal{0});
+  EXPECT_EQ(result.to_string(), "0");
+}
+
+TEST(to_integral_rounds_half_to_even_below_one) {
+  const sourcemeta::core::Decimal value{"0.5"};
+  const auto result{value.to_integral()};
+  EXPECT_EQ(result, sourcemeta::core::Decimal{0});
+  EXPECT_EQ(result.to_string(), "0");
+}
+
+TEST(to_integral_rounds_half_to_even_above_one) {
+  const sourcemeta::core::Decimal value{"1.5"};
+  const auto result{value.to_integral()};
+  EXPECT_EQ(result, sourcemeta::core::Decimal{2});
+  EXPECT_EQ(result.to_string(), "2");
+}
+
+TEST(to_integral_negative_fraction_below_one_keeps_sign) {
+  const sourcemeta::core::Decimal value{"-0.1"};
+  const auto result{value.to_integral()};
+  EXPECT_TRUE(result.is_zero());
+  EXPECT_TRUE(result.is_signed());
+  EXPECT_EQ(result.to_string(), "-0");
+}
+
+TEST(to_integral_negative_fraction_rounds_away_from_zero) {
+  const sourcemeta::core::Decimal value{"-0.7"};
+  const auto result{value.to_integral()};
+  EXPECT_EQ(result, sourcemeta::core::Decimal{-1});
+  EXPECT_EQ(result.to_string(), "-1");
+}
+
+TEST(to_integral_tiny_fraction_keeps_sign) {
+  const sourcemeta::core::Decimal value{"-0.07"};
+  const auto result{value.to_integral()};
+  EXPECT_TRUE(result.is_zero());
+  EXPECT_TRUE(result.is_signed());
+  EXPECT_EQ(result.to_string(), "-0");
+}
+
+TEST(to_integral_big_coefficient_rounds_up_with_carry) {
+  const sourcemeta::core::Decimal value{"123456789012345678901234567899.9"};
+  const auto result{value.to_integral()};
+  EXPECT_EQ(result,
+            sourcemeta::core::Decimal{"123456789012345678901234567900"});
+  EXPECT_EQ(result.to_string(), "123456789012345678901234567900");
+}
+
+TEST(to_integral_big_coefficient_rounds_half_to_even) {
+  const sourcemeta::core::Decimal value{"123456789012345678901234567890.5"};
+  const auto result{value.to_integral()};
+  EXPECT_EQ(result,
+            sourcemeta::core::Decimal{"123456789012345678901234567890"});
+  EXPECT_EQ(result.to_string(), "123456789012345678901234567890");
+}
+
+TEST(to_integral_big_coefficient_negative_rounds_up) {
+  const sourcemeta::core::Decimal value{"-123456789012345678901234567890.7"};
+  const auto result{value.to_integral()};
+  EXPECT_EQ(result,
+            sourcemeta::core::Decimal{"-123456789012345678901234567891"});
+  EXPECT_EQ(result.to_string(), "-123456789012345678901234567891");
+}
+
+TEST(to_integral_big_fraction_below_one_rounds_up) {
+  const sourcemeta::core::Decimal value{"0.99999999999999999999999999999"};
+  const auto result{value.to_integral()};
+  EXPECT_EQ(result, sourcemeta::core::Decimal{1});
+  EXPECT_EQ(result.to_string(), "1");
+}
+
+TEST(is_integer_unary_minus_preserves_flag) {
+  const sourcemeta::core::Decimal value{3};
+  const auto result{-value};
+  EXPECT_TRUE(result.is_integer());
+  EXPECT_EQ(result, sourcemeta::core::Decimal{-3});
+  EXPECT_EQ(result.to_string(), "-3");
+}
+
+TEST(is_integer_unary_plus_preserves_flag) {
+  const sourcemeta::core::Decimal value{3};
+  const auto result{+value};
+  EXPECT_TRUE(result.is_integer());
+  EXPECT_EQ(result, sourcemeta::core::Decimal{3});
+  EXPECT_EQ(result.to_string(), "3");
+}
+
+TEST(is_integer_unary_minus_of_real_stays_cleared) {
+  const sourcemeta::core::Decimal value{"3.5"};
+  const auto result{-value};
+  EXPECT_FALSE(result.is_integer());
+  EXPECT_EQ(result.to_string(), "-3.5");
 }

--- a/test/numeric/numeric_uint128_test.cc
+++ b/test/numeric/numeric_uint128_test.cc
@@ -374,3 +374,55 @@ TEST(bitwise_and_mask_low_byte) {
   EXPECT_EQ(static_cast<std::uint64_t>(result), 0xFF);
   EXPECT_EQ(static_cast<std::uint64_t>(result >> 64), 0);
 }
+
+TEST(divide_by_high_divisor) {
+  const auto dividend = (sourcemeta::core::uint128_t{0xFF} << 64) |
+                        sourcemeta::core::uint128_t{0x1234};
+  const auto divisor = sourcemeta::core::uint128_t{1} << 63;
+  const auto result = dividend / divisor;
+  EXPECT_EQ(static_cast<std::uint64_t>(result), 0x1FE);
+  EXPECT_EQ(static_cast<std::uint64_t>(result >> 64), 0);
+}
+
+TEST(divide_with_high_half_dividend) {
+  const auto dividend = sourcemeta::core::uint128_t{1} << 100;
+  const auto divisor = sourcemeta::core::uint128_t{1} << 36;
+  const auto result = dividend / divisor;
+  EXPECT_EQ(static_cast<std::uint64_t>(result), 0);
+  EXPECT_EQ(static_cast<std::uint64_t>(result >> 64), 1);
+}
+
+TEST(shift_at_64_bits) {
+  const sourcemeta::core::uint128_t value{0xDEADBEEFULL};
+  const auto shifted = value << 64;
+  EXPECT_EQ(static_cast<std::uint64_t>(shifted), 0);
+  EXPECT_EQ(static_cast<std::uint64_t>(shifted >> 64), 0xDEADBEEFULL);
+  EXPECT_EQ(static_cast<std::uint64_t>(shifted >> 64 >> 64), 0);
+}
+
+TEST(shift_at_127_bits) {
+  const sourcemeta::core::uint128_t value{1};
+  const auto shifted = value << 127;
+  EXPECT_EQ(static_cast<std::uint64_t>(shifted), 0);
+  EXPECT_EQ(static_cast<std::uint64_t>(shifted >> 64), 1ULL << 63);
+  EXPECT_EQ(static_cast<std::uint64_t>(shifted >> 127), 1);
+}
+
+TEST(bitwise_or_across_words) {
+  const auto left = sourcemeta::core::uint128_t{0xAAAAAAAAAAAAAAAAULL} << 64;
+  const sourcemeta::core::uint128_t right{0x5555555555555555ULL};
+  const auto result = left | right;
+  EXPECT_EQ(static_cast<std::uint64_t>(result), 0x5555555555555555ULL);
+  EXPECT_EQ(static_cast<std::uint64_t>(result >> 64), 0xAAAAAAAAAAAAAAAAULL);
+}
+
+TEST(bitwise_and_across_words) {
+  const auto left = (sourcemeta::core::uint128_t{0xFFFFFFFFFFFFFFFFULL} << 64) |
+                    sourcemeta::core::uint128_t{0xFFFFFFFFFFFFFFFFULL};
+  const auto right =
+      (sourcemeta::core::uint128_t{0x00FF00FF00FF00FFULL} << 64) |
+      sourcemeta::core::uint128_t{0xFF00FF00FF00FF00ULL};
+  const auto result = left & right;
+  EXPECT_EQ(static_cast<std::uint64_t>(result), 0xFF00FF00FF00FF00ULL);
+  EXPECT_EQ(static_cast<std::uint64_t>(result >> 64), 0x00FF00FF00FF00FFULL);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

