### PR TITLE
Turn `make_set` into a `constexpr` helper

### DIFF
--- a/src/core/json/include/sourcemeta/core/json.h
+++ b/src/core/json/include/sourcemeta/core/json.h
@@ -331,7 +331,7 @@ auto operator<<(std::basic_ostream<JSON::Char, JSON::CharTraits> &stream,
 ///     {sourcemeta::core::JSON::Type::Object,
 ///      sourcemeta::core::JSON::Type::Array});
 /// ```
-SOURCEMETA_FORCEINLINE inline auto
+SOURCEMETA_FORCEINLINE constexpr auto
 make_set(std::initializer_list<JSON::Type> types) -> JSON::TypeSet {
   JSON::TypeSet result;
   for (const auto type : types) {

--- a/test/json/json_type_test.cc
+++ b/test/json/json_type_test.cc
@@ -107,3 +107,25 @@ TEST(make_set_no_intersection) {
   const auto intersection = types_a & types_b;
   EXPECT_TRUE(intersection.none());
 }
+
+TEST(make_set_constexpr) {
+  constexpr auto types =
+      sourcemeta::core::make_set({sourcemeta::core::JSON::Type::Integer,
+                                  sourcemeta::core::JSON::Type::Real});
+  static_assert(types.test(
+      static_cast<std::size_t>(sourcemeta::core::JSON::Type::Integer)));
+  static_assert(
+      types.test(static_cast<std::size_t>(sourcemeta::core::JSON::Type::Real)));
+  static_assert(!types.test(
+      static_cast<std::size_t>(sourcemeta::core::JSON::Type::String)));
+  static_assert(!types.test(
+      static_cast<std::size_t>(sourcemeta::core::JSON::Type::Object)));
+  EXPECT_TRUE(types.test(
+      static_cast<std::size_t>(sourcemeta::core::JSON::Type::Integer)));
+  EXPECT_TRUE(
+      types.test(static_cast<std::size_t>(sourcemeta::core::JSON::Type::Real)));
+  EXPECT_FALSE(types.test(
+      static_cast<std::size_t>(sourcemeta::core::JSON::Type::String)));
+  EXPECT_FALSE(types.test(
+      static_cast<std::size_t>(sourcemeta::core::JSON::Type::Object)));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

