### PR TITLE
More Decimal fixes (NaN payloads, mixed storage `divisible_by`)

### DIFF
--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -802,6 +802,20 @@ auto JSON::operator-=(const JSON &substractive) -> JSON & {
     return divisor_value != 0 && this->to_integer() % divisor_value == 0;
   }
 
+  // Reading an integer operand as a real rounds it once it no longer fits the
+  // mantissa, which both misses and invents divisors, so each operand is
+  // converted from the storage that holds it exactly
+  if (this->is_integer() && divisor.is_real()) {
+    const Decimal dividend_decimal{this->to_integer()};
+    return dividend_decimal.divisible_by(
+        Decimal::strict_from(divisor.to_real()));
+  }
+
+  if (this->is_real() && divisor.is_integer()) {
+    const Decimal divisor_decimal{divisor.to_integer()};
+    return Decimal::strict_from(this->to_real()).divisible_by(divisor_decimal);
+  }
+
   if (!this->is_decimal() && !divisor.is_decimal()) {
     const auto divisor_value(divisor.as_real());
     if (divisor_value == 0.0) {

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -39,6 +39,13 @@ auto reverse_ordering(const std::strong_ordering ordering)
   return std::strong_ordering::equal;
 }
 
+// Check whether an integer converts to a real without rounding, which IEEE 754
+// guarantees only within the 53-bit significand of a binary64
+auto integer_fits_real(const std::int64_t value) -> bool {
+  constexpr std::int64_t LIMIT{9007199254740992};
+  return value >= -LIMIT && value <= LIMIT;
+}
+
 // Order a 64-bit integer against a real by exact value, without ever converting
 // the integer to a double, which would lose precision beyond 2^53
 auto integer_real_ordering(const std::int64_t left, const double right)
@@ -803,15 +810,17 @@ auto JSON::operator-=(const JSON &substractive) -> JSON & {
   }
 
   // Reading an integer operand as a real rounds it once it no longer fits the
-  // mantissa, which both misses and invents divisors, so each operand is
-  // converted from the storage that holds it exactly
-  if (this->is_integer() && divisor.is_real()) {
+  // significand, which both misses and invents divisors, so past that point
+  // each operand is converted from the storage that holds it exactly
+  if (this->is_integer() && divisor.is_real() &&
+      !integer_fits_real(this->to_integer())) {
     const Decimal dividend_decimal{this->to_integer()};
     return dividend_decimal.divisible_by(
         Decimal::strict_from(divisor.to_real()));
   }
 
-  if (this->is_real() && divisor.is_integer()) {
+  if (this->is_real() && divisor.is_integer() &&
+      !integer_fits_real(divisor.to_integer())) {
     const Decimal divisor_decimal{divisor.to_integer()};
     return Decimal::strict_from(this->to_real()).divisible_by(divisor_decimal);
   }

--- a/src/lang/numeric/decimal.cc
+++ b/src/lang/numeric/decimal.cc
@@ -489,6 +489,31 @@ auto format_special_value(std::string &result, std::uint8_t flags,
   return false;
 }
 
+// The General Decimal Arithmetic Specification states that the result of an
+// arithmetic operation with a NaN operand carries a sign and diagnostic
+// information "copied from the first operand which is a signaling NaN, or if
+// neither is signaling then from the first operand which is a NaN"
+auto left_nan_has_precedence(const sourcemeta::core::Decimal &left,
+                             const sourcemeta::core::Decimal &right) -> bool {
+  if (left.is_snan()) {
+    return true;
+  }
+
+  if (right.is_snan()) {
+    return false;
+  }
+
+  return left.is_nan();
+}
+
+auto propagate_nan(const sourcemeta::core::Decimal &left,
+                   const sourcemeta::core::Decimal &right)
+    -> sourcemeta::core::Decimal {
+  const auto &source{left_nan_has_precedence(left, right) ? left : right};
+  const auto result{sourcemeta::core::Decimal::nan(source.nan_payload())};
+  return source.is_signed() ? -result : result;
+}
+
 } // namespace
 
 namespace sourcemeta::core {
@@ -1467,12 +1492,8 @@ auto Decimal::divide_integer(const Decimal &other) const -> Decimal {
     throw NumericInvalidOperationError{};
   }
 
-  if (this->is_nan()) {
-    return Decimal::nan(this->nan_payload());
-  }
-
-  if (other.is_nan()) {
-    return Decimal::nan(other.nan_payload());
+  if (this->is_nan() || other.is_nan()) {
+    return propagate_nan(*this, other);
   }
 
   if (this->is_infinite() && other.is_infinite()) {
@@ -1743,7 +1764,7 @@ auto Decimal::operator>=(const Decimal &other) const -> bool {
 auto Decimal::operator+=(const Decimal &other) -> Decimal & {
   if (!this->is_finite() || !other.is_finite()) {
     if (this->is_nan() || other.is_nan()) {
-      *this = Decimal::nan();
+      *this = propagate_nan(*this, other);
       return *this;
     }
 
@@ -1878,13 +1899,20 @@ auto Decimal::operator+=(const Decimal &other) -> Decimal & {
 }
 
 auto Decimal::operator-=(const Decimal &other) -> Decimal & {
+  // Negating the right operand first would flip the sign that a NaN operand
+  // must contribute to the result unchanged
+  if (this->is_nan() || other.is_nan()) {
+    *this = propagate_nan(*this, other);
+    return *this;
+  }
+
   return *this += (-other);
 }
 
 auto Decimal::operator*=(const Decimal &other) -> Decimal & {
   if (!this->is_finite() || !other.is_finite()) {
     if (this->is_nan() || other.is_nan()) {
-      *this = Decimal::nan();
+      *this = propagate_nan(*this, other);
       return *this;
     }
 
@@ -1972,7 +2000,7 @@ auto Decimal::operator*=(const Decimal &other) -> Decimal & {
 
 auto Decimal::operator/=(const Decimal &other) -> Decimal & {
   if (this->is_nan() || other.is_nan()) {
-    *this = Decimal::nan();
+    *this = propagate_nan(*this, other);
     return *this;
   }
 
@@ -2030,7 +2058,7 @@ auto Decimal::operator/=(const Decimal &other) -> Decimal & {
 
 auto Decimal::operator%=(const Decimal &other) -> Decimal & {
   if (this->is_nan() || other.is_nan()) {
-    *this = Decimal::nan();
+    *this = propagate_nan(*this, other);
     return *this;
   }
 

--- a/test/json/json_number_test.cc
+++ b/test/json/json_number_test.cc
@@ -291,6 +291,30 @@ TEST(divisible_by_real_real_false) {
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
+TEST(divisible_by_integer_real_true_above_double_precision) {
+  const sourcemeta::core::JSON dividend{std::int64_t{9007199254740993}};
+  EXPECT_TRUE(dividend.is_integer());
+  const sourcemeta::core::JSON divisor{3.0};
+  EXPECT_TRUE(divisor.is_real());
+  EXPECT_TRUE(dividend.divisible_by(divisor));
+}
+
+TEST(divisible_by_integer_real_false_above_double_precision) {
+  const sourcemeta::core::JSON dividend{std::int64_t{9007199254740993}};
+  EXPECT_TRUE(dividend.is_integer());
+  const sourcemeta::core::JSON divisor{2.0};
+  EXPECT_TRUE(divisor.is_real());
+  EXPECT_FALSE(dividend.divisible_by(divisor));
+}
+
+TEST(divisible_by_real_integer_false_above_double_precision) {
+  const sourcemeta::core::JSON dividend{9007199254740992.0};
+  EXPECT_TRUE(dividend.is_real());
+  const sourcemeta::core::JSON divisor{std::int64_t{9007199254740993}};
+  EXPECT_TRUE(divisor.is_integer());
+  EXPECT_FALSE(dividend.divisible_by(divisor));
+}
+
 TEST(divisible_by_infinity) {
   const sourcemeta::core::JSON dividend{1e308};
   const sourcemeta::core::JSON divisor{0.123456789};

--- a/test/json/json_number_test.cc
+++ b/test/json/json_number_test.cc
@@ -307,6 +307,22 @@ TEST(divisible_by_integer_real_false_above_double_precision) {
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
+TEST(divisible_by_integer_real_true_at_double_precision_limit) {
+  const sourcemeta::core::JSON dividend{std::int64_t{9007199254740992}};
+  EXPECT_TRUE(dividend.is_integer());
+  const sourcemeta::core::JSON divisor{2.0};
+  EXPECT_TRUE(divisor.is_real());
+  EXPECT_TRUE(dividend.divisible_by(divisor));
+}
+
+TEST(divisible_by_integer_real_false_at_double_precision_limit) {
+  const sourcemeta::core::JSON dividend{std::int64_t{9007199254740992}};
+  EXPECT_TRUE(dividend.is_integer());
+  const sourcemeta::core::JSON divisor{3.0};
+  EXPECT_TRUE(divisor.is_real());
+  EXPECT_FALSE(dividend.divisible_by(divisor));
+}
+
 TEST(divisible_by_real_integer_false_above_double_precision) {
   const sourcemeta::core::JSON dividend{9007199254740992.0};
   EXPECT_TRUE(dividend.is_real());

--- a/test/numeric/decimal_ibm_dectest.cc
+++ b/test/numeric/decimal_ibm_dectest.cc
@@ -4,6 +4,7 @@
 
 #include <algorithm>   // std::transform, std::any_of
 #include <cctype>      // std::tolower, std::isalnum
+#include <cstddef>     // std::size_t
 #include <filesystem>  // std::filesystem
 #include <iostream>    // std::cerr
 #include <sstream>     // std::istringstream
@@ -114,9 +115,22 @@ static auto make_decimal(const std::string &raw) -> sourcemeta::core::Decimal {
   return sourcemeta::core::Decimal{value};
 }
 
-static auto decimal_abs(const sourcemeta::core::Decimal &value)
+// The copy family manipulates the sign directly, including on a NaN
+static auto decimal_copy_abs(const sourcemeta::core::Decimal &value)
     -> sourcemeta::core::Decimal {
   return value.is_signed() ? -value : value;
+}
+
+// The General Decimal Arithmetic Specification defines the arithmetic
+// operations "plus(a) and minus(a) [...] as the operations add('0', a) and
+// subtract('0', b)", and abs as "the same as using the minus operation on the
+// operand" when it is negative and "the same as using the plus operation"
+// otherwise, so a NaN operand is propagated rather than having its sign
+// rewritten
+static auto decimal_abs(const sourcemeta::core::Decimal &value)
+    -> sourcemeta::core::Decimal {
+  const sourcemeta::core::Decimal zero{0};
+  return value.is_signed() ? zero - value : zero + value;
 }
 
 static auto expect_comparison_result(const sourcemeta::core::Decimal &left,
@@ -145,6 +159,8 @@ static auto expect_decimal_eq(const sourcemeta::core::Decimal &result,
     } else {
       EXPECT_TRUE(result.is_qnan());
     }
+    EXPECT_EQ(result.nan_payload(), expected.nan_payload());
+    EXPECT_EQ(result.is_signed(), expected.is_signed());
   } else if (expected.is_infinite()) {
     EXPECT_TRUE(result.is_infinite());
     EXPECT_EQ(result.is_signed(), expected.is_signed());
@@ -245,9 +261,9 @@ static auto run_conversion(const DecTestCase &test_case) -> void {
 static auto run_copysign(const DecTestCase &test_case) -> void {
   const auto left{make_decimal(test_case.operand1)};
   const auto right{make_decimal(test_case.operand2)};
-  auto result = decimal_abs(left);
+  auto result = decimal_copy_abs(left);
   if (right.is_signed()) {
-    result = -decimal_abs(result);
+    result = -decimal_copy_abs(result);
   }
 
   expect_decimal_eq(result, make_decimal(test_case.expected));
@@ -339,12 +355,21 @@ static auto run_dectest_case(const DecTestCase &test_case) -> void {
     run_binary(test_case, [](const auto &left, const auto &right) {
       return left % right;
     });
-  } else if (operation == "minus" || operation == "copynegate") {
+  } else if (operation == "copynegate") {
     run_unary(test_case, [](const auto &value) { return -value; });
+  } else if (operation == "minus") {
+    run_unary(test_case, [](const auto &value) {
+      return sourcemeta::core::Decimal{0} - value;
+    });
   } else if (operation == "plus") {
-    run_unary(test_case, [](const auto &value) { return +value; });
-  } else if (operation == "abs" || operation == "copyabs") {
+    run_unary(test_case, [](const auto &value) {
+      return sourcemeta::core::Decimal{0} + value;
+    });
+  } else if (operation == "abs") {
     run_unary(test_case, [](const auto &value) { return decimal_abs(value); });
+  } else if (operation == "copyabs") {
+    run_unary(test_case,
+              [](const auto &value) { return decimal_copy_abs(value); });
   } else if (operation == "tointegral" || operation == "tointegralx") {
     run_unary(test_case, [](const auto &value) { return value.to_integral(); });
   } else if (operation == "tosci" || operation == "toeng") {
@@ -359,7 +384,7 @@ static auto run_dectest_case(const DecTestCase &test_case) -> void {
     });
   } else if (operation == "comparetotmag") {
     run_binary(test_case, [](const auto &left, const auto &right) {
-      return decimal_abs(left).compare_total(decimal_abs(right));
+      return decimal_copy_abs(left).compare_total(decimal_copy_abs(right));
     });
   } else if (operation == "max") {
     run_max_min(test_case, true, false);
@@ -525,6 +550,16 @@ static auto should_skip_file(const std::string &filename) -> bool {
          lower == "rounding.dectest" || lower == "powersqrt.dectest";
 }
 
+static auto nan_payload_digits(const std::string &operand) -> std::size_t {
+  const auto lower{to_lower(operand)};
+  const auto position{lower.find("nan")};
+  if (position == std::string::npos) {
+    return 0;
+  }
+
+  return lower.size() - position - 3;
+}
+
 static auto should_skip_test(const DecTestCase &test_case,
                              const DecTestContext &context) -> bool {
   const auto operation{to_lower(test_case.operation)};
@@ -562,6 +597,16 @@ static auto should_skip_test(const DecTestCase &test_case,
   // expecting results with more significant digits would produce
   // different (truncated) results in our context.
   if (count_significant_digits(test_case.expected) > 16) {
+    return true;
+  }
+
+  // The corpus truncates a NaN payload longer than the context precision,
+  // while our Decimal has no context bound and keeps every digit the operand
+  // carried
+  if (nan_payload_digits(test_case.operand1) >
+          static_cast<std::size_t>(context.precision) ||
+      nan_payload_digits(test_case.operand2) >
+          static_cast<std::size_t>(context.precision)) {
     return true;
   }
 

--- a/test/numeric/decimal_ibm_dectest.cc
+++ b/test/numeric/decimal_ibm_dectest.cc
@@ -551,13 +551,26 @@ static auto should_skip_file(const std::string &filename) -> bool {
 }
 
 static auto nan_payload_digits(const std::string &operand) -> std::size_t {
-  const auto lower{to_lower(operand)};
+  const auto lower{to_lower(strip_quotes(operand))};
   const auto position{lower.find("nan")};
   if (position == std::string::npos) {
     return 0;
   }
 
-  return lower.size() - position - 3;
+  std::size_t count{0};
+  bool found_nonzero{false};
+  for (auto index = position + 3; index < lower.size(); index++) {
+    if (!std::isdigit(static_cast<unsigned char>(lower[index]))) {
+      break;
+    }
+
+    if (lower[index] != '0' || found_nonzero) {
+      found_nonzero = true;
+      count++;
+    }
+  }
+
+  return count;
 }
 
 static auto should_skip_test(const DecTestCase &test_case,

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -970,6 +970,42 @@ TEST(divisible_by_negative) {
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
+TEST(divisible_by_huge_exponent_power_of_two) {
+  const sourcemeta::core::Decimal dividend{"1e100001"};
+  const sourcemeta::core::Decimal divisor{2};
+  EXPECT_TRUE(dividend.divisible_by(divisor));
+}
+
+TEST(divisible_by_huge_exponent_power_of_five) {
+  const sourcemeta::core::Decimal dividend{"1e100001"};
+  const sourcemeta::core::Decimal divisor{5};
+  EXPECT_TRUE(dividend.divisible_by(divisor));
+}
+
+TEST(divisible_by_huge_exponent_product_of_two_and_five) {
+  const sourcemeta::core::Decimal dividend{"1e100001"};
+  const sourcemeta::core::Decimal divisor{20};
+  EXPECT_TRUE(dividend.divisible_by(divisor));
+}
+
+TEST(divisible_by_huge_exponent_multiple_of_eleven_is_false) {
+  const sourcemeta::core::Decimal dividend{"1e100001"};
+  const sourcemeta::core::Decimal divisor{22};
+  EXPECT_FALSE(dividend.divisible_by(divisor));
+}
+
+TEST(divisible_by_million_exponent_power_of_two) {
+  const sourcemeta::core::Decimal dividend{"1e1000001"};
+  const sourcemeta::core::Decimal divisor{2};
+  EXPECT_TRUE(dividend.divisible_by(divisor));
+}
+
+TEST(divisible_by_million_exponent_multiple_of_eleven_is_false) {
+  const sourcemeta::core::Decimal dividend{"1e1000001"};
+  const sourcemeta::core::Decimal divisor{22};
+  EXPECT_FALSE(dividend.divisible_by(divisor));
+}
+
 TEST(divisible_by_very_large_number_not_divisible_false) {
   const sourcemeta::core::Decimal dividend{"1e308"};
   const sourcemeta::core::Decimal divisor{"0.123456789"};
@@ -1890,6 +1926,101 @@ TEST(is_qnan_false_for_snan) {
 TEST(is_nan_true_for_both) {
   EXPECT_TRUE(sourcemeta::core::Decimal::nan().is_nan());
   EXPECT_TRUE(sourcemeta::core::Decimal::snan().is_nan());
+}
+
+TEST(add_propagates_left_nan_payload) {
+  const auto result{sourcemeta::core::Decimal::nan(1) +
+                    -sourcemeta::core::Decimal::infinity()};
+  EXPECT_TRUE(result.is_qnan());
+  EXPECT_EQ(result.nan_payload(), 1);
+  EXPECT_FALSE(result.is_signed());
+}
+
+TEST(add_propagates_right_nan_payload) {
+  const auto result{-sourcemeta::core::Decimal::infinity() +
+                    sourcemeta::core::Decimal::nan(7)};
+  EXPECT_TRUE(result.is_qnan());
+  EXPECT_EQ(result.nan_payload(), 7);
+  EXPECT_FALSE(result.is_signed());
+}
+
+TEST(add_selects_the_first_nan_when_both_are_quiet) {
+  const auto result{sourcemeta::core::Decimal::nan(5) +
+                    sourcemeta::core::Decimal::nan(6)};
+  EXPECT_TRUE(result.is_qnan());
+  EXPECT_EQ(result.nan_payload(), 5);
+}
+
+TEST(add_selects_the_signaling_nan_over_a_leading_quiet_nan) {
+  const auto result{sourcemeta::core::Decimal::nan(16) +
+                    sourcemeta::core::Decimal::snan(191)};
+  EXPECT_TRUE(result.is_qnan());
+  EXPECT_FALSE(result.is_snan());
+  EXPECT_EQ(result.nan_payload(), 191);
+}
+
+TEST(add_propagates_the_left_nan_sign) {
+  const auto result{-sourcemeta::core::Decimal::nan(26) +
+                    sourcemeta::core::Decimal::nan(28)};
+  EXPECT_TRUE(result.is_qnan());
+  EXPECT_EQ(result.nan_payload(), 26);
+  EXPECT_TRUE(result.is_signed());
+}
+
+TEST(add_propagates_the_right_nan_sign) {
+  const auto result{sourcemeta::core::Decimal{1000} +
+                    -sourcemeta::core::Decimal::nan(30)};
+  EXPECT_TRUE(result.is_qnan());
+  EXPECT_EQ(result.nan_payload(), 30);
+  EXPECT_TRUE(result.is_signed());
+}
+
+TEST(add_quiets_a_signaling_nan_and_keeps_its_payload) {
+  const auto result{sourcemeta::core::Decimal::snan(11) +
+                    -sourcemeta::core::Decimal::infinity()};
+  EXPECT_TRUE(result.is_qnan());
+  EXPECT_FALSE(result.is_snan());
+  EXPECT_EQ(result.nan_payload(), 11);
+}
+
+TEST(subtract_does_not_flip_the_right_nan_sign) {
+  const auto result{-sourcemeta::core::Decimal::infinity() -
+                    -sourcemeta::core::Decimal::nan(71)};
+  EXPECT_TRUE(result.is_qnan());
+  EXPECT_EQ(result.nan_payload(), 71);
+  EXPECT_TRUE(result.is_signed());
+}
+
+TEST(multiply_propagates_the_nan_payload_and_sign) {
+  const auto result{-sourcemeta::core::Decimal::nan(9) *
+                    -sourcemeta::core::Decimal::infinity()};
+  EXPECT_TRUE(result.is_qnan());
+  EXPECT_EQ(result.nan_payload(), 9);
+  EXPECT_TRUE(result.is_signed());
+}
+
+TEST(divide_propagates_the_nan_payload_and_sign) {
+  const auto result{sourcemeta::core::Decimal{-1000} /
+                    -sourcemeta::core::Decimal::nan(3)};
+  EXPECT_TRUE(result.is_qnan());
+  EXPECT_EQ(result.nan_payload(), 3);
+  EXPECT_TRUE(result.is_signed());
+}
+
+TEST(remainder_propagates_the_nan_payload_and_sign) {
+  const auto result{sourcemeta::core::Decimal{1} %
+                    -sourcemeta::core::Decimal::nan(4)};
+  EXPECT_TRUE(result.is_qnan());
+  EXPECT_EQ(result.nan_payload(), 4);
+  EXPECT_TRUE(result.is_signed());
+}
+
+TEST(divide_integer_propagates_the_nan_payload_and_sign) {
+  const auto result{sourcemeta::core::Decimal::infinity().divide_integer(
+      -sourcemeta::core::Decimal::nan(2))};
+  EXPECT_TRUE(result.is_qnan());
+  EXPECT_EQ(result.nan_payload(), 2);
+  EXPECT_TRUE(result.is_signed());
 }
 
 TEST(nan_payload_zero_for_plain_nan) {
@@ -4119,6 +4250,21 @@ TEST(big_coefficient_copy_assignment_over_small) {
 TEST(engineering_string_of_zero_with_positive_exponent) {
   const sourcemeta::core::Decimal value{"0E+5"};
   EXPECT_EQ(value.to_string(), "0.0e+6");
+}
+
+TEST(divide_integer_by_one_preserves_a_hundred_thousand_digits) {
+  const std::string digits(100001, '9');
+  const sourcemeta::core::Decimal value{digits};
+  const auto quotient{value.divide_integer(sourcemeta::core::Decimal{1})};
+  EXPECT_FALSE(quotient.is_nan());
+  EXPECT_EQ(quotient, value);
+}
+
+TEST(divide_integer_by_one_preserves_a_two_million_exponent) {
+  const sourcemeta::core::Decimal value{"1e2000001"};
+  const auto quotient{value.divide_integer(sourcemeta::core::Decimal{1})};
+  EXPECT_FALSE(quotient.is_nan());
+  EXPECT_EQ(quotient, value);
 }
 
 TEST(divide_integer_with_big_quotient) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

