### PR TITLE
Make the exported macOS link interface readable outside CMake

### DIFF
--- a/src/core/crypto/CMakeLists.txt
+++ b/src/core/crypto/CMakeLists.txt
@@ -129,19 +129,34 @@ elseif(APPLE)
   target_include_directories(sourcemeta_core_crypto
     PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 
-  target_link_libraries(sourcemeta_core_crypto PRIVATE "-framework Security")
+  # Resolve the frameworks to absolute bundle paths rather than passing raw
+  # linker flags, as the exported interface is also read by build systems that
+  # only understand a path to a library
+  find_library(CRYPTOKIT_SECURITY_FRAMEWORK Security REQUIRED)
+  find_library(CRYPTOKIT_CORE_FOUNDATION_FRAMEWORK CoreFoundation REQUIRED)
+  find_library(CRYPTOKIT_CRYPTOKIT_FRAMEWORK CryptoKit REQUIRED)
+  find_library(CRYPTOKIT_FOUNDATION_FRAMEWORK Foundation REQUIRED)
   target_link_libraries(sourcemeta_core_crypto
-    PRIVATE "-framework CoreFoundation")
-  target_link_libraries(sourcemeta_core_crypto PRIVATE "-framework CryptoKit")
-  target_link_libraries(sourcemeta_core_crypto PRIVATE "-framework Foundation")
+    PRIVATE "${CRYPTOKIT_SECURITY_FRAMEWORK}")
+  target_link_libraries(sourcemeta_core_crypto
+    PRIVATE "${CRYPTOKIT_CORE_FOUNDATION_FRAMEWORK}")
+  target_link_libraries(sourcemeta_core_crypto
+    PRIVATE "${CRYPTOKIT_CRYPTOKIT_FRAMEWORK}")
+  target_link_libraries(sourcemeta_core_crypto
+    PRIVATE "${CRYPTOKIT_FOUNDATION_FRAMEWORK}")
 
   # Resolve the Swift runtime that the shim autolinks, both at link and at load.
   # PUBLIC rather than INTERFACE so that a shared build of this library, which
-  # has its own link step pulling in the Swift object, also gets the flags
+  # has its own link step pulling in the Swift object, also gets the flags.
+  # Every option is a single token, as the multi-token spellings need a SHELL:
+  # prefix that only CMake knows how to strip back out of the exported
+  # interface, and every one of them addresses the linker directly, as these
+  # paths serve libraries that no command line asks for by name and a build
+  # system that resolves the named ones itself would drop a plain search path
   target_link_options(sourcemeta_core_crypto PUBLIC
-    "SHELL:-L ${CRYPTOKIT_SDK}/usr/lib/swift"
-    "SHELL:-L ${CRYPTOKIT_RUNTIME_LIB}"
-    "SHELL:-Xlinker -rpath -Xlinker /usr/lib/swift")
+    "-Wl,-L${CRYPTOKIT_SDK}/usr/lib/swift"
+    "-Wl,-L${CRYPTOKIT_RUNTIME_LIB}"
+    "-Wl,-rpath,/usr/lib/swift")
 elseif(WIN32)
   target_sources(sourcemeta_core_crypto PRIVATE
     crypto_sha1_windows.cc crypto_sha256_windows.cc

--- a/src/core/http/CMakeLists.txt
+++ b/src/core/http/CMakeLists.txt
@@ -38,7 +38,12 @@ if(SOURCEMETA_CORE_HTTP_USE_SYSTEM_CURL)
     PRIVATE SOURCEMETA_CORE_HTTP_USE_SYSTEM_CURL)
   target_link_libraries(sourcemeta_core_http PRIVATE CURL::libcurl)
 elseif(APPLE)
-  target_link_libraries(sourcemeta_core_http PRIVATE "-framework Foundation")
+  # Resolve the framework to an absolute bundle path rather than passing a raw
+  # linker flag, as the exported interface is also read by build systems that
+  # only understand a path to a library
+  find_library(HTTP_FOUNDATION_FRAMEWORK Foundation REQUIRED)
+  target_link_libraries(sourcemeta_core_http
+    PRIVATE "${HTTP_FOUNDATION_FRAMEWORK}")
 elseif(WIN32 AND NOT CMAKE_SYSTEM_NAME STREQUAL "MSYS")
   target_link_libraries(sourcemeta_core_http PRIVATE winhttp)
   target_link_libraries(sourcemeta_core_http PRIVATE sourcemeta::core::unicode)


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

