### PR TITLE
Fail the test runner when no tests are selected

### DIFF
--- a/src/lang/test/test.cc
+++ b/src/lang/test/test.cc
@@ -158,6 +158,19 @@ auto test_run(int argc, char **argv) -> int {
   std::cout << "TAP version 14\n";
   std::cout << "1.." << selected.size() << "\n";
 
+  // A test binary exists to run tests, so selecting none exits with failure on
+  // purpose. An empty run means either broken registration or a filter that
+  // matches nothing, neither of which may pass as a green suite
+  if (selected.empty()) {
+    if (needle.empty()) {
+      print_diagnostic("no tests were registered");
+    } else {
+      print_diagnostic("no tests matched the filter: " + std::string{needle});
+    }
+
+    return EXIT_FAILURE;
+  }
+
   std::size_t number{0};
   std::size_t passed{0};
   std::size_t failed{0};

--- a/test/test/framework/CMakeLists.txt
+++ b/test/test/framework/CMakeLists.txt
@@ -26,6 +26,10 @@ add_executable(sourcemeta_core_test_dynamic test_dynamic.cc)
 target_link_libraries(sourcemeta_core_test_dynamic
   PRIVATE sourcemeta::core::test sourcemeta::core::test_main)
 
+add_executable(sourcemeta_core_test_empty test_empty.cc)
+target_link_libraries(sourcemeta_core_test_empty
+  PRIVATE sourcemeta::core::test sourcemeta::core::test_main)
+
 # The framework's own command line is exercised through the script runner that
 # this module ships, so the language is proven against the framework hosting it
 macro(add_framework_test name binary)
@@ -45,3 +49,4 @@ add_framework_test(filter_short sourcemeta_core_test_filter)
 add_framework_test(filter_none sourcemeta_core_test_filter)
 add_framework_test(fixture sourcemeta_core_test_fixture)
 add_framework_test(dynamic sourcemeta_core_test_dynamic)
+add_framework_test(empty sourcemeta_core_test_empty)

--- a/test/test/framework/test_empty.cc
+++ b/test/test/framework/test_empty.cc
@@ -1,0 +1,1 @@
+#include <sourcemeta/core/test.h>

--- a/test/test/framework/test_empty.clitest
+++ b/test/test/framework/test_empty.clitest
@@ -1,0 +1,7 @@
+RUN STDIN /dev/null IN . INTO result.txt EXPECTING 1
+WRITE expected.txt UNTIL EXPECTED
+1> TAP version 14
+1> 1..0
+1> # no tests were registered
+EXPECTED
+COMPARE result.txt AGAINST expected.txt

--- a/test/test/framework/test_filter_none.clitest
+++ b/test/test/framework/test_filter_none.clitest
@@ -1,7 +1,7 @@
-RUN --filter nonexistent STDIN /dev/null IN . INTO result.txt EXPECTING 0
+RUN --filter nonexistent STDIN /dev/null IN . INTO result.txt EXPECTING 1
 WRITE expected.txt UNTIL EXPECTED
 1> TAP version 14
 1> 1..0
-1> # 0 passed, 0 failed
+1> # no tests matched the filter: nonexistent
 EXPECTED
 COMPARE result.txt AGAINST expected.txt


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

