### PR TITLE
Don't set default options on header-only libraries

### DIFF
--- a/cmake/common/targets/library.cmake
+++ b/cmake/common/targets/library.cmake
@@ -61,7 +61,6 @@ function(sourcemeta_library)
   else()
     add_library(${TARGET_NAME} INTERFACE
       ${PUBLIC_HEADER} ${ABSOLUTE_PRIVATE_HEADERS})
-    sourcemeta_add_default_options(INTERFACE ${TARGET_NAME})
   endif()
 
   add_library(${ALIAS_NAME} ALIAS ${TARGET_NAME})

--- a/test/test/clitest/CMakeLists.txt
+++ b/test/test/clitest/CMakeLists.txt
@@ -11,7 +11,8 @@ endif()
 # framework itself is: through its command line, against a golden diagnostic.
 # Each case runs from the fixture directory so that the path a diagnostic names
 # is the bare script name rather than wherever the checkout happens to live
-add_executable(sourcemeta_core_clitest_stub stub.cc)
+sourcemeta_executable(NAMESPACE sourcemeta PROJECT core NAME clitest
+  VARIANT stub SOURCES stub.cc)
 target_link_libraries(sourcemeta_core_clitest_stub
   PRIVATE sourcemeta::core::options)
 target_link_libraries(sourcemeta_core_clitest_stub

--- a/test/test/framework/CMakeLists.txt
+++ b/test/test/framework/CMakeLists.txt
@@ -1,32 +1,40 @@
-add_executable(sourcemeta_core_test_success test_success.cc)
+sourcemeta_executable(NAMESPACE sourcemeta PROJECT core NAME test
+  VARIANT success SOURCES test_success.cc)
 target_link_libraries(sourcemeta_core_test_success
   PRIVATE sourcemeta::core::test sourcemeta::core::test_main)
 
-add_executable(sourcemeta_core_test_failure test_failure.cc)
+sourcemeta_executable(NAMESPACE sourcemeta PROJECT core NAME test
+  VARIANT failure SOURCES test_failure.cc)
 target_link_libraries(sourcemeta_core_test_failure
   PRIVATE sourcemeta::core::test sourcemeta::core::test_main)
 
-add_executable(sourcemeta_core_test_diff test_diff.cc)
+sourcemeta_executable(NAMESPACE sourcemeta PROJECT core NAME test
+  VARIANT diff SOURCES test_diff.cc)
 target_link_libraries(sourcemeta_core_test_diff
   PRIVATE sourcemeta::core::test sourcemeta::core::test_main)
 
-add_executable(sourcemeta_core_test_throw test_throw.cc)
+sourcemeta_executable(NAMESPACE sourcemeta PROJECT core NAME test
+  VARIANT throw SOURCES test_throw.cc)
 target_link_libraries(sourcemeta_core_test_throw
   PRIVATE sourcemeta::core::test sourcemeta::core::test_main)
 
-add_executable(sourcemeta_core_test_filter test_filter.cc)
+sourcemeta_executable(NAMESPACE sourcemeta PROJECT core NAME test
+  VARIANT filter SOURCES test_filter.cc)
 target_link_libraries(sourcemeta_core_test_filter
   PRIVATE sourcemeta::core::test sourcemeta::core::test_main)
 
-add_executable(sourcemeta_core_test_fixture test_fixture.cc)
+sourcemeta_executable(NAMESPACE sourcemeta PROJECT core NAME test
+  VARIANT fixture SOURCES test_fixture.cc)
 target_link_libraries(sourcemeta_core_test_fixture
   PRIVATE sourcemeta::core::test sourcemeta::core::test_main)
 
-add_executable(sourcemeta_core_test_dynamic test_dynamic.cc)
+sourcemeta_executable(NAMESPACE sourcemeta PROJECT core NAME test
+  VARIANT dynamic SOURCES test_dynamic.cc)
 target_link_libraries(sourcemeta_core_test_dynamic
   PRIVATE sourcemeta::core::test sourcemeta::core::test_main)
 
-add_executable(sourcemeta_core_test_empty test_empty.cc)
+sourcemeta_executable(NAMESPACE sourcemeta PROJECT core NAME test
+  VARIANT empty SOURCES test_empty.cc)
 target_link_libraries(sourcemeta_core_test_empty
   PRIVATE sourcemeta::core::test sourcemeta::core::test_main)
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

