### PR TITLE
Stop `libdeflate` from exporting its symbols

### DIFF
--- a/cmake/FindLibDeflate.cmake
+++ b/cmake/FindLibDeflate.cmake
@@ -105,6 +105,10 @@ if(NOT LibDeflate_FOUND)
   target_include_directories(libdeflate PRIVATE
     "${LIBDEFLATE_LIB_DIR}")
 
+  # Marking every entry point as visible would publish this library from the
+  # one it is merged into, where it can collide with a real installation of it
+  target_compile_definitions(libdeflate PRIVATE LIBDEFLATE_EXPORT_SYM=)
+
   # The processor feature detection this library performs on Linux reaches for
   # interfaces that the C library only declares outside the strict ISO mode
   # this project otherwise compiles C in

--- a/patches/libdeflate/0001-Let-the-build-decide-whether-symbols-are-marked-for-e.patch
+++ b/patches/libdeflate/0001-Let-the-build-decide-whether-symbols-are-marked-for-e.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Juan Cruz Viotti <jviotti@sourcemeta.com>
+Date: Sat, 5 Sep 2026 00:00:00 -0300
+Subject: [PATCH] Let the build decide whether symbols are marked for export
+
+This library marks every entry point with default visibility whenever
+the compiler is GCC or Clang, with no way to ask for anything else. A
+build that compiles this library into a larger one rather than shipping
+it on its own then publishes these symbols from whatever binary they end
+up in, where they collide with a real installation of this library.
+
+Honour a definition the build provides, leaving the existing behaviour
+in place for everyone else.
+---
+diff --git a/lib/lib_common.h b/lib/lib_common.h
+index faedfcb03..9246ca1e5 100644
+--- a/lib/lib_common.h
++++ b/lib/lib_common.h
+@@ -13,6 +13,12 @@
+ #  error "lib_common.h must always be included before libdeflate.h"
+ #endif
+ 
++/*
++ * A build that compiles this library into a larger one does not want its
++ * symbols marked for export, as they would then leave whatever binary it
++ * ends up in.  Such a build can say so by defining this itself.
++ */
++#ifndef LIBDEFLATE_EXPORT_SYM
+ #if defined(LIBDEFLATE_DLL) && (defined(_WIN32) || defined(__CYGWIN__))
+ #  define LIBDEFLATE_EXPORT_SYM  __declspec(dllexport)
+ #elif defined(__GNUC__)
+@@ -20,6 +26,7 @@
+ #else
+ #  define LIBDEFLATE_EXPORT_SYM
+ #endif
++#endif
+ 
+ /*
+  * On i386, gcc assumes that the stack is 16-byte aligned at function entry.

--- a/test/process/CMakeLists.txt
+++ b/test/process/CMakeLists.txt
@@ -21,13 +21,13 @@ endif()
 
 target_link_libraries(sourcemeta_core_process_unit PRIVATE sourcemeta::core::process)
 
-add_executable(sourcemeta_core_process_unit_spawn_main process_spawn_main.cc)
+sourcemeta_executable(NAMESPACE sourcemeta PROJECT core NAME process
+  VARIANT unit_spawn_main SOURCES process_spawn_main.cc)
 target_link_libraries(sourcemeta_core_process_unit_spawn_main
   PRIVATE sourcemeta::core::process)
 
-add_executable(sourcemeta_core_process_unit_capture_main
-  process_spawn_and_capture_main.cc)
-sourcemeta_add_default_options(PRIVATE sourcemeta_core_process_unit_capture_main)
+sourcemeta_executable(NAMESPACE sourcemeta PROJECT core NAME process
+  VARIANT unit_capture_main SOURCES process_spawn_and_capture_main.cc)
 target_link_libraries(sourcemeta_core_process_unit_capture_main
   PRIVATE sourcemeta::core::text)
 

--- a/vendor/libdeflate/lib/lib_common.h
+++ b/vendor/libdeflate/lib/lib_common.h
@@ -13,12 +13,19 @@
 #  error "lib_common.h must always be included before libdeflate.h"
 #endif
 
+/*
+ * A build that compiles this library into a larger one does not want its
+ * symbols marked for export, as they would then leave whatever binary it
+ * ends up in.  Such a build can say so by defining this itself.
+ */
+#ifndef LIBDEFLATE_EXPORT_SYM
 #if defined(LIBDEFLATE_DLL) && (defined(_WIN32) || defined(__CYGWIN__))
 #  define LIBDEFLATE_EXPORT_SYM  __declspec(dllexport)
 #elif defined(__GNUC__)
 #  define LIBDEFLATE_EXPORT_SYM  __attribute__((visibility("default")))
 #else
 #  define LIBDEFLATE_EXPORT_SYM
+#endif
 #endif
 
 /*


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

