### PR TITLE
Properly enable `clang-tidy` on benchmarks

### DIFF
--- a/benchmark/gzip.cc
+++ b/benchmark/gzip.cc
@@ -6,9 +6,6 @@
 #include <cstdint>    // std::uint8_t
 #include <filesystem> // std::filesystem
 
-// GoogleBenchmark reports the name of each of these functions as the label
-// of its result, and the tooling that tracks those results over time keys
-// its history on that label, so they do not follow the usual convention
 static void
 // NOLINTNEXTLINE(readability-identifier-naming)
 GZIP_Compress_ISO_Language_Set_3_Locations(benchmark::State &state) {

--- a/benchmark/gzip.cc
+++ b/benchmark/gzip.cc
@@ -6,7 +6,11 @@
 #include <cstdint>    // std::uint8_t
 #include <filesystem> // std::filesystem
 
+// GoogleBenchmark reports the name of each of these functions as the label
+// of its result, and the tooling that tracks those results over time keys
+// its history on that label, so they do not follow the usual convention
 static void
+// NOLINTNEXTLINE(readability-identifier-naming)
 GZIP_Compress_ISO_Language_Set_3_Locations(benchmark::State &state) {
   const sourcemeta::core::FileView view{
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
@@ -14,7 +18,7 @@ GZIP_Compress_ISO_Language_Set_3_Locations(benchmark::State &state) {
   const auto contents{
       sourcemeta::core::gunzip(view.as<std::uint8_t>(), view.size())};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::gzip(
         reinterpret_cast<const std::uint8_t *>(contents.data()),
         contents.size())};
@@ -23,6 +27,7 @@ GZIP_Compress_ISO_Language_Set_3_Locations(benchmark::State &state) {
 }
 
 static void
+// NOLINTNEXTLINE(readability-identifier-naming)
 GZIP_Decompress_ISO_Language_Set_3_Locations(benchmark::State &state) {
   const sourcemeta::core::FileView view{
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
@@ -30,13 +35,14 @@ GZIP_Decompress_ISO_Language_Set_3_Locations(benchmark::State &state) {
   const auto output_hint{
       sourcemeta::core::gunzip(view.as<std::uint8_t>(), view.size()).size()};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::gunzip(view.as<std::uint8_t>(), view.size(),
                                          output_hint)};
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void GZIP_Compress_ISO_Language_Set_3_Schema(benchmark::State &state) {
   const sourcemeta::core::FileView view{
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
@@ -44,7 +50,7 @@ static void GZIP_Compress_ISO_Language_Set_3_Schema(benchmark::State &state) {
   const auto contents{
       sourcemeta::core::gunzip(view.as<std::uint8_t>(), view.size())};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::gzip(
         reinterpret_cast<const std::uint8_t *>(contents.data()),
         contents.size())};
@@ -52,6 +58,7 @@ static void GZIP_Compress_ISO_Language_Set_3_Schema(benchmark::State &state) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void GZIP_Decompress_ISO_Language_Set_3_Schema(benchmark::State &state) {
   const sourcemeta::core::FileView view{
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
@@ -59,7 +66,7 @@ static void GZIP_Decompress_ISO_Language_Set_3_Schema(benchmark::State &state) {
   const auto output_hint{
       sourcemeta::core::gunzip(view.as<std::uint8_t>(), view.size()).size()};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::gunzip(view.as<std::uint8_t>(), view.size(),
                                          output_hint)};
     benchmark::DoNotOptimize(result);

--- a/benchmark/html.cc
+++ b/benchmark/html.cc
@@ -62,9 +62,6 @@ static void write_table(sourcemeta::core::HTMLWriter &document) {
   document.close();
 }
 
-// GoogleBenchmark reports the name of each of these functions as the label
-// of its result, and the tooling that tracks those results over time keys
-// its history on that label, so they do not follow the usual convention
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void HTML_Build_Table_100000(benchmark::State &state) {
   for (auto iteration : state) {

--- a/benchmark/html.cc
+++ b/benchmark/html.cc
@@ -2,7 +2,8 @@
 
 #include <sourcemeta/core/html.h>
 
-#include <string> // std::string, std::to_string
+#include <cstddef> // std::size_t
+#include <string>  // std::string, std::to_string
 
 static void write_table(sourcemeta::core::HTMLWriter &document) {
   document.table().attribute("class", "file-table");
@@ -64,7 +65,7 @@ static void write_table(sourcemeta::core::HTMLWriter &document) {
 static void HTML_Build_Table_100000(benchmark::State &state) {
   for (auto _ : state) {
     sourcemeta::core::HTMLWriter document;
-    document.reserve(100000 * 300);
+    document.reserve(std::size_t{100000} * 300);
     write_table(document);
     auto result{std::string(document.str())};
     benchmark::DoNotOptimize(result);
@@ -73,7 +74,7 @@ static void HTML_Build_Table_100000(benchmark::State &state) {
 
 static void HTML_Render_Table_100000(benchmark::State &state) {
   sourcemeta::core::HTMLWriter document;
-  document.reserve(100000 * 300);
+  document.reserve(std::size_t{100000} * 300);
   write_table(document);
   for (auto _ : state) {
     auto result{std::string(document.str())};

--- a/benchmark/html.cc
+++ b/benchmark/html.cc
@@ -62,8 +62,12 @@ static void write_table(sourcemeta::core::HTMLWriter &document) {
   document.close();
 }
 
+// GoogleBenchmark reports the name of each of these functions as the label
+// of its result, and the tooling that tracks those results over time keys
+// its history on that label, so they do not follow the usual convention
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void HTML_Build_Table_100000(benchmark::State &state) {
-  for (auto _ : state) {
+  for (auto iteration : state) {
     sourcemeta::core::HTMLWriter document;
     document.reserve(std::size_t{100000} * 300);
     write_table(document);
@@ -72,11 +76,12 @@ static void HTML_Build_Table_100000(benchmark::State &state) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void HTML_Render_Table_100000(benchmark::State &state) {
   sourcemeta::core::HTMLWriter document;
   document.reserve(std::size_t{100000} * 300);
   write_table(document);
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{std::string(document.str())};
     benchmark::DoNotOptimize(result);
   }

--- a/benchmark/jose.cc
+++ b/benchmark/jose.cc
@@ -30,9 +30,6 @@ constexpr std::string_view ES512_JWK{
     R"JSON({ "kty": "EC", "crv": "P-521", "x": "ASTBdxhoeBK4-OqrpidcXbsz_Gsd-TRgqkZGD9ROv7r_kBHW1_is2HDctAOVBWC3ywSUS5MZJIl17xJuYCyZA-Rg", "y": "AOQCwwmrhHkVTm9BgloMWDc7T3hw5yQM5Z-YhVumpCYyFIGuyrziD5iqsH8uQvsNXGqnMKhOJ26X8ADhvP20RIAW" })JSON"};
 } // namespace
 
-// GoogleBenchmark reports the name of each of these functions as the label
-// of its result, and the tooling that tracks those results over time keys
-// its history on that label, so they do not follow the usual convention
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void JOSE_VerifySignature_RS256(benchmark::State &state) {
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN)};

--- a/benchmark/jose.cc
+++ b/benchmark/jose.cc
@@ -30,6 +30,10 @@ constexpr std::string_view ES512_JWK{
     R"JSON({ "kty": "EC", "crv": "P-521", "x": "ASTBdxhoeBK4-OqrpidcXbsz_Gsd-TRgqkZGD9ROv7r_kBHW1_is2HDctAOVBWC3ywSUS5MZJIl17xJuYCyZA-Rg", "y": "AOQCwwmrhHkVTm9BgloMWDc7T3hw5yQM5Z-YhVumpCYyFIGuyrziD5iqsH8uQvsNXGqnMKhOJ26X8ADhvP20RIAW" })JSON"};
 } // namespace
 
+// GoogleBenchmark reports the name of each of these functions as the label
+// of its result, and the tooling that tracks those results over time keys
+// its history on that label, so they do not follow the usual convention
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JOSE_VerifySignature_RS256(benchmark::State &state) {
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN)};
   const auto key{
@@ -38,7 +42,7 @@ static void JOSE_VerifySignature_RS256(benchmark::State &state) {
   assert(key.has_value());
   const auto *public_key{key.value().public_key()};
   assert(public_key != nullptr);
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::rsassa_pkcs1_v15_verify(
         *public_key, sourcemeta::core::SignatureHashFunction::SHA256,
         token.value().signing_input(), token.value().signature())};
@@ -47,6 +51,7 @@ static void JOSE_VerifySignature_RS256(benchmark::State &state) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JOSE_VerifySignature_ES512(benchmark::State &state) {
   const auto token{sourcemeta::core::JWT::from(ES512_TOKEN)};
   const auto key{
@@ -55,7 +60,7 @@ static void JOSE_VerifySignature_ES512(benchmark::State &state) {
   assert(key.has_value());
   const auto *public_key{key.value().public_key()};
   assert(public_key != nullptr);
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::ecdsa_verify(
         *public_key, sourcemeta::core::SignatureHashFunction::SHA512,
         token.value().signing_input(), token.value().signature())};

--- a/benchmark/json.cc
+++ b/benchmark/json.cc
@@ -43,7 +43,7 @@ static void JSON_Array_Of_Objects_Unique(benchmark::State &state) {
 }
 
 static void JSON_Parse_1(benchmark::State &state) {
-  const auto document{R"JSON({
+  const auto *const document{R"JSON({
     "metadata": {
         "description": "Comprehensive JSON grammar stress test",
         "version": 1.0,
@@ -100,7 +100,7 @@ static void JSON_Parse_1(benchmark::State &state) {
 }
 
 static void JSON_Parse_Real(benchmark::State &state) {
-  const auto document{R"JSON([
+  const auto *const document{R"JSON([
     1.0,
     2.0,
     3.5,
@@ -214,7 +214,7 @@ static void JSON_Parse_Real(benchmark::State &state) {
 }
 
 static void JSON_Parse_Decimal(benchmark::State &state) {
-  const auto document{R"JSON([
+  const auto *const document{R"JSON([
     123456789012345678901234567890,
     987654321098765432109876543210,
     111111111111111111111111111111,

--- a/benchmark/json.cc
+++ b/benchmark/json.cc
@@ -11,9 +11,6 @@
 #include <filesystem>  // std::filesystem
 #include <string_view> // std::string_view
 
-// GoogleBenchmark reports the name of each of these functions as the label
-// of its result, and the tooling that tracks those results over time keys
-// its history on that label, so they do not follow the usual convention
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Array_Of_Objects_Unique(benchmark::State &state) {
   // From Unreal Engine `uproject` files

--- a/benchmark/json.cc
+++ b/benchmark/json.cc
@@ -11,6 +11,10 @@
 #include <filesystem>  // std::filesystem
 #include <string_view> // std::string_view
 
+// GoogleBenchmark reports the name of each of these functions as the label
+// of its result, and the tooling that tracks those results over time keys
+// its history on that label, so they do not follow the usual convention
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Array_Of_Objects_Unique(benchmark::State &state) {
   // From Unreal Engine `uproject` files
   const auto document{sourcemeta::core::parse_json(R"JSON([
@@ -35,13 +39,14 @@ static void JSON_Array_Of_Objects_Unique(benchmark::State &state) {
     { "SupportedTargetPlatforms": [ "Win64" ], "Enabled": true, "Name": "LiveLinkOverNDisplay" }
   ])JSON")};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{document.unique()};
     assert(result);
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_1(benchmark::State &state) {
   const auto *const document{R"JSON({
     "metadata": {
@@ -92,13 +97,14 @@ static void JSON_Parse_1(benchmark::State &state) {
     }
   })JSON"};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(document)};
     assert(result.is_object());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_Real(benchmark::State &state) {
   const auto *const document{R"JSON([
     1.0,
@@ -206,13 +212,14 @@ static void JSON_Parse_Real(benchmark::State &state) {
   assert(std::ranges::all_of(sourcemeta::core::parse_json(document).as_array(),
                              [](const auto &item) { return item.is_real(); }));
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(document)};
     assert(result.is_array());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_Decimal(benchmark::State &state) {
   const auto *const document{R"JSON([
     123456789012345678901234567890,
@@ -321,123 +328,134 @@ static void JSON_Parse_Decimal(benchmark::State &state) {
       std::ranges::all_of(sourcemeta::core::parse_json(document).as_array(),
                           [](const auto &item) { return item.is_decimal(); }));
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(document)};
     assert(result.is_array());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_Schema_ISO_Language(benchmark::State &state) {
   const auto schema{sourcemeta::core::read_file_to_string(
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
       "2020_12_iso_language_2023_set_3.json")};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(schema)};
     assert(result.is_object());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_Integer(benchmark::State &state) {
   const auto document{sourcemeta::core::read_file_to_string(
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
       "integer_array.json")};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(document)};
     assert(result.is_array());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_String_NonSSO_Plain(benchmark::State &state) {
   const auto document{sourcemeta::core::read_file_to_string(
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
       "string_array_plain.json")};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(document)};
     assert(result.is_array());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_String_SSO_Plain(benchmark::State &state) {
   const auto document{sourcemeta::core::read_file_to_string(
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
       "string_array_short.json")};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(document)};
     assert(result.is_array());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_String_Escape_Heavy(benchmark::State &state) {
   const auto document{sourcemeta::core::read_file_to_string(
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
       "string_array_escaped.json")};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(document)};
     assert(result.is_array());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_Object_Short_Keys(benchmark::State &state) {
   const auto document{sourcemeta::core::read_file_to_string(
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
       "object_short_keys.json")};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(document)};
     assert(result.is_object());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_Object_Scalar_Properties(benchmark::State &state) {
   const auto document{sourcemeta::core::read_file_to_string(
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
       "object_scalar_properties.json")};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(document)};
     assert(result.is_object());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_Object_Array_Properties(benchmark::State &state) {
   const auto document{sourcemeta::core::read_file_to_string(
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
       "object_array_properties.json")};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(document)};
     assert(result.is_object());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_Object_Object_Properties(benchmark::State &state) {
   const auto document{sourcemeta::core::read_file_to_string(
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
       "object_object_properties.json")};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(document)};
     assert(result.is_object());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Parse_Nested_Containers(benchmark::State &state) {
   const auto document{sourcemeta::core::read_file_to_string(
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
       "nested_containers.json")};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::parse_json(document)};
     assert(result.is_array());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Fast_Hash_Helm_Chart_Lock(benchmark::State &state) {
   // From `helm-chart-lock`
   const auto document{sourcemeta::core::parse_json(R"JSON({
@@ -467,12 +485,13 @@ static void JSON_Fast_Hash_Helm_Chart_Lock(benchmark::State &state) {
     ]
   })JSON")};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{document.fast_hash()};
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Equality_Helm_Chart_Lock(benchmark::State &state) {
   // From `helm-chart-lock`
 
@@ -530,26 +549,28 @@ static void JSON_Equality_Helm_Chart_Lock(benchmark::State &state) {
     ]
   })JSON")};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{document_1 == document_2};
     assert(result);
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_String_Equal(benchmark::State &state) {
   const auto length{static_cast<std::size_t>(state.range(0))};
   sourcemeta::core::JSON::String string_left(length, 'x');
   sourcemeta::core::JSON::String string_right(length, 'x');
   const sourcemeta::core::JSON left{std::move(string_left)};
   const sourcemeta::core::JSON right{std::move(string_right)};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     bool result = left == right;
     assert(result);
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_String_Equal_Small_By_Perfect_Hash(benchmark::State &state) {
   const auto length{static_cast<std::size_t>(state.range(0))};
   sourcemeta::core::JSON::String left(length, 'x');
@@ -560,7 +581,7 @@ static void JSON_String_Equal_Small_By_Perfect_Hash(benchmark::State &state) {
   const auto hash_right{hasher(right)};
   assert(hasher.is_perfect(hash_left));
   assert(hasher.is_perfect(hash_right));
-  for (auto _ : state) {
+  for (auto iteration : state) {
     bool result = hash_left == hash_right;
     assert(result);
     benchmark::DoNotOptimize(result);
@@ -568,13 +589,14 @@ static void JSON_String_Equal_Small_By_Perfect_Hash(benchmark::State &state) {
 }
 
 static void
+// NOLINTNEXTLINE(readability-identifier-naming)
 JSON_String_Equal_Small_By_Runtime_Perfect_Hash(benchmark::State &state) {
   const auto length{static_cast<std::size_t>(state.range(0))};
   sourcemeta::core::JSON::String left(length, 'x');
   sourcemeta::core::JSON::String right(length, 'x');
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
-  for (auto _ : state) {
+  for (auto iteration : state) {
     const auto hash_left{hasher(left)};
     const auto hash_right{hasher(right)};
     assert(hasher.is_perfect(hash_left));
@@ -585,25 +607,28 @@ JSON_String_Equal_Small_By_Runtime_Perfect_Hash(benchmark::State &state) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_String_Fast_Hash(benchmark::State &state) {
   const auto length{static_cast<std::size_t>(state.range(0))};
   sourcemeta::core::JSON::String value(length, 'x');
   const sourcemeta::core::JSON document{std::move(value)};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     benchmark::DoNotOptimize(document.fast_hash());
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_String_Key_Hash(benchmark::State &state) {
   const auto length{static_cast<std::size_t>(state.range(0))};
   sourcemeta::core::JSON::String value(length, 'x');
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
-  for (auto _ : state) {
+  for (auto iteration : state) {
     benchmark::DoNotOptimize(hasher(value));
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Object_Defines_Miss_Same_Length(benchmark::State &state) {
   auto document{sourcemeta::core::JSON::make_object()};
   document.assign("abcdefg", sourcemeta::core::JSON{1});
@@ -614,13 +639,14 @@ static void JSON_Object_Defines_Miss_Same_Length(benchmark::State &state) {
   const auto &object{document.as_object()};
   const sourcemeta::core::JSON::String key{"foobarbaz"};
   const auto key_hash{hasher(key)};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result = object.defines(key, key_hash);
     assert(!result);
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Object_Defines_Miss_Too_Small(benchmark::State &state) {
   auto document{sourcemeta::core::JSON::make_object()};
   document.assign("abcdefg", sourcemeta::core::JSON{1});
@@ -631,13 +657,14 @@ static void JSON_Object_Defines_Miss_Too_Small(benchmark::State &state) {
   const auto &object{document.as_object()};
   const sourcemeta::core::JSON::String key{"foo"};
   const auto key_hash{hasher(key)};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result = object.defines(key, key_hash);
     assert(!result);
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Object_Defines_Miss_Too_Large(benchmark::State &state) {
   auto document{sourcemeta::core::JSON::make_object()};
   document.assign("abcdefg", sourcemeta::core::JSON{1});
@@ -648,37 +675,41 @@ static void JSON_Object_Defines_Miss_Too_Large(benchmark::State &state) {
   const auto &object{document.as_object()};
   const sourcemeta::core::JSON::String key{"toolargestring"};
   const auto key_hash{hasher(key)};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result = object.defines(key, key_hash);
     assert(!result);
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_From_String_Copy(benchmark::State &state) {
   const sourcemeta::core::JSON::String value(48, 'x');
-  for (auto _ : state) {
+  for (auto iteration : state) {
     sourcemeta::core::JSON document{value};
     benchmark::DoNotOptimize(document);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_From_String_Temporary(benchmark::State &state) {
-  for (auto _ : state) {
+  for (auto iteration : state) {
     sourcemeta::core::JSON document{sourcemeta::core::JSON::String(48, 'x')};
     benchmark::DoNotOptimize(document);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Number_To_Double(benchmark::State &state) {
   const std::string_view input{"-273.150123"};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::to_double(input)};
     assert(result.has_value());
     benchmark::DoNotOptimize(result);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Object_At_Last_Key(benchmark::State &state) {
   const auto property_count{static_cast<std::size_t>(state.range(0))};
   auto document{sourcemeta::core::JSON::make_object()};
@@ -691,12 +722,13 @@ static void JSON_Object_At_Last_Key(benchmark::State &state) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const auto key_hash{hasher(last_key)};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto &value{document.at(last_key, key_hash)};
     benchmark::DoNotOptimize(value);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSON_Divisible_By_Decimal(benchmark::State &state) {
   const auto value_1{
       sourcemeta::core::parse_json("123456789012345678901234567890")};
@@ -709,7 +741,7 @@ static void JSON_Divisible_By_Decimal(benchmark::State &state) {
   const auto divisor_3{sourcemeta::core::parse_json("3")};
   const auto divisor_4{sourcemeta::core::parse_json("1e100")};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     benchmark::DoNotOptimize(value_1.divisible_by(divisor_1));
     benchmark::DoNotOptimize(value_2.divisible_by(divisor_2));
     benchmark::DoNotOptimize(value_3.divisible_by(divisor_3));

--- a/benchmark/jsonl.cc
+++ b/benchmark/jsonl.cc
@@ -8,9 +8,6 @@
 #include <fstream>    // std::ifstream
 #include <ios>        // std::ios
 
-// GoogleBenchmark reports the name of each of these functions as the label
-// of its result, and the tooling that tracks those results over time keys
-// its history on that label, so they do not follow the usual convention
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void JSONL_Parse_Large(benchmark::State &state) {
   const std::filesystem::path filepath{std::string{CURRENT_DIRECTORY} +

--- a/benchmark/jsonl.cc
+++ b/benchmark/jsonl.cc
@@ -8,11 +8,15 @@
 #include <fstream>    // std::ifstream
 #include <ios>        // std::ios
 
+// GoogleBenchmark reports the name of each of these functions as the label
+// of its result, and the tooling that tracks those results over time keys
+// its history on that label, so they do not follow the usual convention
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSONL_Parse_Large(benchmark::State &state) {
   const std::filesystem::path filepath{std::string{CURRENT_DIRECTORY} +
                                        "/files/large.jsonl"};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     std::ifstream stream{filepath};
     assert(stream.is_open());
     std::size_t count{0};
@@ -25,11 +29,12 @@ static void JSONL_Parse_Large(benchmark::State &state) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSONL_Parse_Large_GZIP(benchmark::State &state) {
   const std::filesystem::path filepath{std::string{CURRENT_DIRECTORY} +
                                        "/files/large.jsonl.gz"};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     std::ifstream stream{filepath, std::ios::binary};
     assert(stream.is_open());
     std::size_t count{0};

--- a/benchmark/jsonld.cc
+++ b/benchmark/jsonld.cc
@@ -349,9 +349,6 @@ static auto populate_annotation_list(
   }
 }
 
-// GoogleBenchmark reports the name of each of these functions as the label
-// of its result, and the tooling that tracks those results over time keys
-// its history on that label, so they do not follow the usual convention
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void JSONLD_Catalog_Annotation_List_Populate(benchmark::State &state) {
   for (auto iteration : state) {

--- a/benchmark/jsonld.cc
+++ b/benchmark/jsonld.cc
@@ -13,13 +13,13 @@
 // The catalog dimensions set how many entries the annotation list carries
 // and how many instance positions materialization visits, so they are the
 // knobs to turn when stress testing this functionality
-static constexpr std::size_t catalog_member_count{256};
-static constexpr std::size_t authors_per_member{3};
-static constexpr std::size_t keywords_per_member{3};
-static constexpr std::size_t annotations_per_member{19 +
-                                                    (authors_per_member * 2)};
-static constexpr std::size_t total_annotation_count{
-    2 + (catalog_member_count * annotations_per_member)};
+static constexpr std::size_t CATALOG_MEMBER_COUNT{256};
+static constexpr std::size_t AUTHORS_PER_MEMBER{3};
+static constexpr std::size_t KEYWORDS_PER_MEMBER{3};
+static constexpr std::size_t ANNOTATIONS_PER_MEMBER{19 +
+                                                    (AUTHORS_PER_MEMBER * 2)};
+static constexpr std::size_t TOTAL_ANNOTATION_COUNT{
+    2 + (CATALOG_MEMBER_COUNT * ANNOTATIONS_PER_MEMBER)};
 
 struct CatalogKeys {
   const sourcemeta::core::JSON::String members{"members"};
@@ -45,8 +45,8 @@ struct CatalogKeys {
 // The pointers these benchmarks build borrow their tokens rather than own
 // them, so the keys have to outlive every list that refers back to them
 static auto catalog_keys() -> const CatalogKeys & {
-  static const CatalogKeys instance;
-  return instance;
+  static const CatalogKeys INSTANCE;
+  return INSTANCE;
 }
 
 static auto currency_code(const std::size_t index) -> std::string {
@@ -72,7 +72,7 @@ static auto make_title(const std::size_t index) -> sourcemeta::core::JSON {
 
 static auto make_keywords() -> sourcemeta::core::JSON {
   auto keywords{sourcemeta::core::JSON::make_array()};
-  for (std::size_t offset = 0; offset < keywords_per_member; offset += 1) {
+  for (std::size_t offset = 0; offset < KEYWORDS_PER_MEMBER; offset += 1) {
     keywords.push_back(
         sourcemeta::core::JSON{"keyword-" + std::to_string(offset)});
   }
@@ -147,7 +147,7 @@ static auto make_member(const std::size_t index) -> sourcemeta::core::JSON {
   member.assign("datePublished", sourcemeta::core::JSON{"2020-05-15"});
 
   auto authors{sourcemeta::core::JSON::make_array()};
-  for (std::size_t offset = 0; offset < authors_per_member; offset += 1) {
+  for (std::size_t offset = 0; offset < AUTHORS_PER_MEMBER; offset += 1) {
     authors.push_back(make_person((index * 10) + offset));
   }
   member.assign("authors", std::move(authors));
@@ -164,7 +164,7 @@ static auto make_member(const std::size_t index) -> sourcemeta::core::JSON {
 
 static auto make_catalog() -> sourcemeta::core::JSON {
   auto members{sourcemeta::core::JSON::make_array()};
-  for (std::size_t index = 0; index < catalog_member_count; index += 1) {
+  for (std::size_t index = 0; index < CATALOG_MEMBER_COUNT; index += 1) {
     members.push_back(make_member(index));
   }
 
@@ -217,7 +217,7 @@ populate_member(sourcemeta::core::JSONLDWeakAnnotationList &annotations,
           .edges = {{.predicate = "https://schema.org/author"}},
           .value = sourcemeta::core::JSONLDCollection{
               .container = sourcemeta::core::JSONLDContainer::List}});
-  for (std::size_t offset = 0; offset < authors_per_member; offset += 1) {
+  for (std::size_t offset = 0; offset < AUTHORS_PER_MEMBER; offset += 1) {
     annotations.emplace_back(
         WeakPointer{std::cref(keys.members), index, std::cref(keys.authors),
                     offset},
@@ -330,7 +330,7 @@ populate_member(sourcemeta::core::JSONLDWeakAnnotationList &annotations,
 static auto populate_annotation_list(
     sourcemeta::core::JSONLDWeakAnnotationList &annotations) -> void {
   const auto &keys{catalog_keys()};
-  annotations.reserve(total_annotation_count);
+  annotations.reserve(TOTAL_ANNOTATION_COUNT);
   annotations.emplace_back(
       sourcemeta::core::WeakPointer{},
       sourcemeta::core::JSONLDDescriptor{
@@ -344,27 +344,32 @@ static auto populate_annotation_list(
           .edges = {{.predicate = "https://schema.org/dataset"}},
           .value = sourcemeta::core::JSONLDCollection{
               .container = sourcemeta::core::JSONLDContainer::Set}});
-  for (std::size_t index = 0; index < catalog_member_count; index += 1) {
+  for (std::size_t index = 0; index < CATALOG_MEMBER_COUNT; index += 1) {
     populate_member(annotations, index);
   }
 }
 
+// GoogleBenchmark reports the name of each of these functions as the label
+// of its result, and the tooling that tracks those results over time keys
+// its history on that label, so they do not follow the usual convention
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSONLD_Catalog_Annotation_List_Populate(benchmark::State &state) {
-  for (auto _ : state) {
+  for (auto iteration : state) {
     sourcemeta::core::JSONLDWeakAnnotationList annotations;
     populate_annotation_list(annotations);
-    assert(annotations.size() == total_annotation_count);
+    assert(annotations.size() == TOTAL_ANNOTATION_COUNT);
     benchmark::DoNotOptimize(annotations);
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSONLD_Catalog_Materialize(benchmark::State &state) {
   const auto instance{make_catalog()};
   sourcemeta::core::JSONLDWeakAnnotationList annotations;
   populate_annotation_list(annotations);
-  assert(annotations.size() == total_annotation_count);
+  assert(annotations.size() == TOTAL_ANNOTATION_COUNT);
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::jsonld_materialize(instance, annotations)};
     assert(result.is_array());
     assert(!result.empty());

--- a/benchmark/jsonld.cc
+++ b/benchmark/jsonld.cc
@@ -21,24 +21,33 @@ static constexpr std::size_t annotations_per_member{19 +
 static constexpr std::size_t total_annotation_count{
     2 + (catalog_member_count * annotations_per_member)};
 
-static const sourcemeta::core::JSON::String members_key{"members"};
-static const sourcemeta::core::JSON::String isbn_key{"isbn"};
-static const sourcemeta::core::JSON::String title_key{"title"};
-static const sourcemeta::core::JSON::String abstract_key{"abstract"};
-static const sourcemeta::core::JSON::String date_published_key{"datePublished"};
-static const sourcemeta::core::JSON::String authors_key{"authors"};
-static const sourcemeta::core::JSON::String name_key{"name"};
-static const sourcemeta::core::JSON::String keywords_key{"keywords"};
-static const sourcemeta::core::JSON::String identifiers_key{"identifiers"};
-static const sourcemeta::core::JSON::String price_key{"price"};
-static const sourcemeta::core::JSON::String currency_key{"currency"};
-static const sourcemeta::core::JSON::String value_key{"value"};
-static const sourcemeta::core::JSON::String publisher_key{"publisher"};
-static const sourcemeta::core::JSON::String url_key{"url"};
-static const sourcemeta::core::JSON::String series_key{"series"};
-static const sourcemeta::core::JSON::String metadata_key{"metadata"};
-static const sourcemeta::core::JSON::String provenance_key{"provenance"};
-static const sourcemeta::core::JSON::String generated_by_key{"generatedBy"};
+struct CatalogKeys {
+  const sourcemeta::core::JSON::String members{"members"};
+  const sourcemeta::core::JSON::String isbn{"isbn"};
+  const sourcemeta::core::JSON::String title{"title"};
+  const sourcemeta::core::JSON::String abstract{"abstract"};
+  const sourcemeta::core::JSON::String date_published{"datePublished"};
+  const sourcemeta::core::JSON::String authors{"authors"};
+  const sourcemeta::core::JSON::String name{"name"};
+  const sourcemeta::core::JSON::String keywords{"keywords"};
+  const sourcemeta::core::JSON::String identifiers{"identifiers"};
+  const sourcemeta::core::JSON::String price{"price"};
+  const sourcemeta::core::JSON::String currency{"currency"};
+  const sourcemeta::core::JSON::String value{"value"};
+  const sourcemeta::core::JSON::String publisher{"publisher"};
+  const sourcemeta::core::JSON::String url{"url"};
+  const sourcemeta::core::JSON::String series{"series"};
+  const sourcemeta::core::JSON::String metadata{"metadata"};
+  const sourcemeta::core::JSON::String provenance{"provenance"};
+  const sourcemeta::core::JSON::String generated_by{"generatedBy"};
+};
+
+// The pointers these benchmarks build borrow their tokens rather than own
+// them, so the keys have to outlive every list that refers back to them
+static auto catalog_keys() -> const CatalogKeys & {
+  static const CatalogKeys instance;
+  return instance;
+}
 
 static auto currency_code(const std::size_t index) -> std::string {
   return index % 3 == 0 ? "USD" : index % 3 == 1 ? "EUR" : "GBP";
@@ -139,7 +148,7 @@ static auto make_member(const std::size_t index) -> sourcemeta::core::JSON {
 
   auto authors{sourcemeta::core::JSON::make_array()};
   for (std::size_t offset = 0; offset < authors_per_member; offset += 1) {
-    authors.push_back(make_person(index * 10 + offset));
+    authors.push_back(make_person((index * 10) + offset));
   }
   member.assign("authors", std::move(authors));
 
@@ -168,155 +177,159 @@ static auto
 populate_member(sourcemeta::core::JSONLDWeakAnnotationList &annotations,
                 const std::size_t index) -> void {
   using sourcemeta::core::WeakPointer;
+  const auto &keys{catalog_keys()};
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index},
+      WeakPointer{std::cref(keys.members), index},
       sourcemeta::core::JSONLDDescriptor{
           .edges = {},
           .value = sourcemeta::core::JSONLDNode{
               .id = "urn:isbn:978-0-" + std::to_string(index),
               .types = {"https://schema.org/Book"}}});
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(isbn_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.isbn)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/isbn", false}},
+          .edges = {{.predicate = "https://schema.org/isbn"}},
           .value = sourcemeta::core::JSONLDLiteral{}});
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(title_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.title)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/name", false}},
+          .edges = {{.predicate = "https://schema.org/name"}},
           .value = sourcemeta::core::JSONLDCollection{
               .container = sourcemeta::core::JSONLDContainer::Language}});
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(abstract_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.abstract)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/abstract", false}},
+          .edges = {{.predicate = "https://schema.org/abstract"}},
           .value = sourcemeta::core::JSONLDLiteral{
               .language = "en",
               .direction = sourcemeta::core::JSONLDDirection::LTR}});
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(date_published_key)},
+      WeakPointer{std::cref(keys.members), index,
+                  std::cref(keys.date_published)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/datePublished", false}},
+          .edges = {{.predicate = "https://schema.org/datePublished"}},
           .value = sourcemeta::core::JSONLDLiteral{
               .datatype = "http://www.w3.org/2001/XMLSchema#date"}});
 
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(authors_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.authors)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/author", false}},
+          .edges = {{.predicate = "https://schema.org/author"}},
           .value = sourcemeta::core::JSONLDCollection{
               .container = sourcemeta::core::JSONLDContainer::List}});
   for (std::size_t offset = 0; offset < authors_per_member; offset += 1) {
     annotations.emplace_back(
-        WeakPointer{std::cref(members_key), index, std::cref(authors_key),
+        WeakPointer{std::cref(keys.members), index, std::cref(keys.authors),
                     offset},
         sourcemeta::core::JSONLDDescriptor{
             .edges = {},
             .value = sourcemeta::core::JSONLDNode{
                 .id = "https://example.com/people/person-" +
-                      std::to_string(index * 10 + offset),
+                      std::to_string((index * 10) + offset),
                 .types = {"https://schema.org/Person"}}});
-    annotations.emplace_back(WeakPointer{std::cref(members_key), index,
-                                         std::cref(authors_key), offset,
-                                         std::cref(name_key)},
-                             sourcemeta::core::JSONLDDescriptor{
-                                 .edges = {{"https://schema.org/name", false}},
-                                 .value = sourcemeta::core::JSONLDLiteral{}});
+    annotations.emplace_back(
+        WeakPointer{std::cref(keys.members), index, std::cref(keys.authors),
+                    offset, std::cref(keys.name)},
+        sourcemeta::core::JSONLDDescriptor{
+            .edges = {{.predicate = "https://schema.org/name"}},
+            .value = sourcemeta::core::JSONLDLiteral{}});
   }
 
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(keywords_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.keywords)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/keywords", false}},
+          .edges = {{.predicate = "https://schema.org/keywords"}},
           .value = sourcemeta::core::JSONLDCollection{
               .container = sourcemeta::core::JSONLDContainer::Set}});
 
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(identifiers_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.identifiers)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/identifier", false}},
+          .edges = {{.predicate = "https://schema.org/identifier"}},
           .value = sourcemeta::core::JSONLDCollection{
               .container = sourcemeta::core::JSONLDContainer::Index}});
 
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(price_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.price)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/offers", false}},
+          .edges = {{.predicate = "https://schema.org/offers"}},
           .value = sourcemeta::core::JSONLDNode{}});
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(price_key),
-                  std::cref(currency_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.price),
+                  std::cref(keys.currency)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/priceCurrency", false}},
+          .edges = {{.predicate = "https://schema.org/priceCurrency"}},
           .value = sourcemeta::core::JSONLDReference{
               .id = "https://www.iso.org/iso-4217/" + currency_code(index),
               .types = {"https://schema.org/Currency"}}});
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(price_key),
-                  std::cref(value_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.price),
+                  std::cref(keys.value)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/price", false}},
+          .edges = {{.predicate = "https://schema.org/price"}},
           .value = sourcemeta::core::JSONLDLiteral{
               .datatype = "http://www.w3.org/2001/XMLSchema#decimal"}});
 
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(publisher_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.publisher)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/publisher", false}},
+          .edges = {{.predicate = "https://schema.org/publisher"}},
           .value = sourcemeta::core::JSONLDNode{
               .id = "https://example.com/org/" + std::to_string(index),
               .types = {"https://schema.org/Organization"}}});
-  annotations.emplace_back(WeakPointer{std::cref(members_key), index,
-                                       std::cref(publisher_key),
-                                       std::cref(name_key)},
-                           sourcemeta::core::JSONLDDescriptor{
-                               .edges = {{"https://schema.org/name", false}},
-                               .value = sourcemeta::core::JSONLDLiteral{}});
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(publisher_key),
-                  std::cref(url_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.publisher),
+                  std::cref(keys.name)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/url", false}},
+          .edges = {{.predicate = "https://schema.org/name"}},
+          .value = sourcemeta::core::JSONLDLiteral{}});
+  annotations.emplace_back(
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.publisher),
+                  std::cref(keys.url)},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{.predicate = "https://schema.org/url"}},
           .value = sourcemeta::core::JSONLDLiteral{
               .datatype = "http://www.w3.org/2001/XMLSchema#anyURI"}});
 
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(series_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.series)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/hasPart", true}},
+          .edges = {{.predicate = "https://schema.org/hasPart",
+                     .reverse = true}},
           .value = sourcemeta::core::JSONLDNode{
               .id = "https://example.com/series/" + std::to_string(index),
               .types = {"https://schema.org/CreativeWorkSeries"}}});
-  annotations.emplace_back(WeakPointer{std::cref(members_key), index,
-                                       std::cref(series_key),
-                                       std::cref(name_key)},
-                           sourcemeta::core::JSONLDDescriptor{
-                               .edges = {{"https://schema.org/name", false}},
-                               .value = sourcemeta::core::JSONLDLiteral{}});
+  annotations.emplace_back(
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.series),
+                  std::cref(keys.name)},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{.predicate = "https://schema.org/name"}},
+          .value = sourcemeta::core::JSONLDLiteral{}});
 
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(metadata_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.metadata)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/additionalProperty", false}},
+          .edges = {{.predicate = "https://schema.org/additionalProperty"}},
           .value = sourcemeta::core::JSONLDLiteral{.json = true}});
 
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(provenance_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.provenance)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://www.w3.org/ns/prov#has_provenance", false}},
+          .edges = {{.predicate = "https://www.w3.org/ns/prov#has_provenance"}},
           .value = sourcemeta::core::JSONLDNode{
               .id = "https://example.com/provenance/" + std::to_string(index),
               .graph = true}});
   annotations.emplace_back(
-      WeakPointer{std::cref(members_key), index, std::cref(provenance_key),
-                  std::cref(generated_by_key)},
+      WeakPointer{std::cref(keys.members), index, std::cref(keys.provenance),
+                  std::cref(keys.generated_by)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://www.w3.org/ns/prov#wasGeneratedBy", false}},
+          .edges = {{.predicate = "https://www.w3.org/ns/prov#wasGeneratedBy"}},
           .value = sourcemeta::core::JSONLDLiteral{}});
 }
 
 static auto populate_annotation_list(
     sourcemeta::core::JSONLDWeakAnnotationList &annotations) -> void {
+  const auto &keys{catalog_keys()};
   annotations.reserve(total_annotation_count);
   annotations.emplace_back(
       sourcemeta::core::WeakPointer{},
@@ -326,9 +339,9 @@ static auto populate_annotation_list(
               .id = "https://example.com/catalog",
               .types = {"https://schema.org/DataCatalog"}}});
   annotations.emplace_back(
-      sourcemeta::core::WeakPointer{std::cref(members_key)},
+      sourcemeta::core::WeakPointer{std::cref(keys.members)},
       sourcemeta::core::JSONLDDescriptor{
-          .edges = {{"https://schema.org/dataset", false}},
+          .edges = {{.predicate = "https://schema.org/dataset"}},
           .value = sourcemeta::core::JSONLDCollection{
               .container = sourcemeta::core::JSONLDContainer::Set}});
   for (std::size_t index = 0; index < catalog_member_count; index += 1) {

--- a/benchmark/jsonpath.cc
+++ b/benchmark/jsonpath.cc
@@ -6,9 +6,6 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpath.h>
 
-// GoogleBenchmark reports the name of each of these functions as the label
-// of its result, and the tooling that tracks those results over time keys
-// its history on that label, so they do not follow the usual convention
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void JSONPath_Descendant_Filter_Nested(benchmark::State &state) {
   const auto document{sourcemeta::core::parse_json(R"JSON({

--- a/benchmark/jsonpath.cc
+++ b/benchmark/jsonpath.cc
@@ -6,6 +6,10 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpath.h>
 
+// GoogleBenchmark reports the name of each of these functions as the label
+// of its result, and the tooling that tracks those results over time keys
+// its history on that label, so they do not follow the usual convention
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void JSONPath_Descendant_Filter_Nested(benchmark::State &state) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "store": {
@@ -57,7 +61,7 @@ static void JSONPath_Descendant_Filter_Nested(benchmark::State &state) {
   const sourcemeta::core::JSONPath path{
       "$..books[?@.price < 10 && match(@.category, 'fic.*')]"};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     std::size_t count{0};
     path.evaluate(document,
                   [&count](const auto &, const auto &) { count += 1; });

--- a/benchmark/jsonpointer.cc
+++ b/benchmark/jsonpointer.cc
@@ -9,9 +9,6 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 
-// GoogleBenchmark reports the name of each of these functions as the label
-// of its result, and the tooling that tracks those results over time keys
-// its history on that label, so they do not follow the usual convention
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void Pointer_Object_Traverse(benchmark::State &state) {
   const auto document{sourcemeta::core::parse_json(R"JSON({

--- a/benchmark/jsonpointer.cc
+++ b/benchmark/jsonpointer.cc
@@ -9,6 +9,10 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 
+// GoogleBenchmark reports the name of each of these functions as the label
+// of its result, and the tooling that tracks those results over time keys
+// its history on that label, so they do not follow the usual convention
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void Pointer_Object_Traverse(benchmark::State &state) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "one": {
@@ -36,7 +40,7 @@ static void Pointer_Object_Traverse(benchmark::State &state) {
                                           "five", "six", "seven", "eight",
                                           "nine", "ten"};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result{sourcemeta::core::get(document, pointer)};
     assert(result.is_boolean());
     assert(result.to_boolean());
@@ -44,6 +48,7 @@ static void Pointer_Object_Traverse(benchmark::State &state) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void Pointer_Object_Try_Traverse(benchmark::State &state) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "one": {
@@ -71,7 +76,7 @@ static void Pointer_Object_Try_Traverse(benchmark::State &state) {
                                           "five", "six", "seven", "eight",
                                           "nine", "ten"};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     const auto *result{sourcemeta::core::try_get(document, pointer)};
     assert(result);
     assert(result->is_boolean());
@@ -80,6 +85,7 @@ static void Pointer_Object_Try_Traverse(benchmark::State &state) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void Pointer_Push_Back_Pointer_To_Weak_Pointer(benchmark::State &state) {
   const sourcemeta::core::Pointer pointer{"QG5",
                                           "hzh4HOy0CDatvDds",
@@ -143,7 +149,7 @@ static void Pointer_Push_Back_Pointer_To_Weak_Pointer(benchmark::State &state) {
                                           "Q6OQxzHNwZsSpM0Fib",
                                           "ltLJ5HS1fUXQIIE"};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     sourcemeta::core::WeakPointer destination;
     destination.push_back(pointer);
     assert(destination.size() == pointer.size());
@@ -151,12 +157,13 @@ static void Pointer_Push_Back_Pointer_To_Weak_Pointer(benchmark::State &state) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void Pointer_Walker_Schema_ISO_Language(benchmark::State &state) {
   const auto schema{sourcemeta::core::read_json(
       std::filesystem::path{CURRENT_DIRECTORY} / "files" /
       "2020_12_iso_language_2023_set_3.json")};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     sourcemeta::core::PointerWalker walker{schema};
     auto pointer_count =
         static_cast<std::size_t>(std::distance(walker.cbegin(), walker.cend()));
@@ -164,6 +171,7 @@ static void Pointer_Walker_Schema_ISO_Language(benchmark::State &state) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void Pointer_Maybe_Tracked_Deeply_Nested(benchmark::State &state) {
   const auto enable_tracker{static_cast<bool>(state.range(0))};
   const std::filesystem::path path{std::filesystem::path{CURRENT_DIRECTORY} /
@@ -173,7 +181,7 @@ static void Pointer_Maybe_Tracked_Deeply_Nested(benchmark::State &state) {
   buffer << file.rdbuf();
   const auto content{buffer.str()};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     if (enable_tracker) {
       sourcemeta::core::PointerPositionTracker tracker;
       sourcemeta::core::JSON result{nullptr};
@@ -190,6 +198,7 @@ static void Pointer_Maybe_Tracked_Deeply_Nested(benchmark::State &state) {
 }
 
 static void
+// NOLINTNEXTLINE(readability-identifier-naming)
 Pointer_Position_Tracker_Get_Deeply_Nested(benchmark::State &state) {
   const std::filesystem::path path{std::filesystem::path{CURRENT_DIRECTORY} /
                                    "files" / "deeply_nested.json"};
@@ -208,7 +217,7 @@ Pointer_Position_Tracker_Get_Deeply_Nested(benchmark::State &state) {
       "next", "next", "next", "next", "next", "next", "next", "next",
       "next", "next", "next", "next", "next", "next", "p0"};
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto position{tracker.get(pointer)};
     assert(position.has_value());
     benchmark::DoNotOptimize(position);

--- a/benchmark/jsonpointer.cc
+++ b/benchmark/jsonpointer.cc
@@ -72,7 +72,7 @@ static void Pointer_Object_Try_Traverse(benchmark::State &state) {
                                           "nine", "ten"};
 
   for (auto _ : state) {
-    auto result{sourcemeta::core::try_get(document, pointer)};
+    const auto *result{sourcemeta::core::try_get(document, pointer)};
     assert(result);
     assert(result->is_boolean());
     assert(result->to_boolean());
@@ -219,5 +219,5 @@ BENCHMARK(Pointer_Object_Traverse);
 BENCHMARK(Pointer_Object_Try_Traverse);
 BENCHMARK(Pointer_Push_Back_Pointer_To_Weak_Pointer);
 BENCHMARK(Pointer_Walker_Schema_ISO_Language);
-BENCHMARK(Pointer_Maybe_Tracked_Deeply_Nested)->Arg(false)->Arg(true);
+BENCHMARK(Pointer_Maybe_Tracked_Deeply_Nested)->Arg(0)->Arg(1);
 BENCHMARK(Pointer_Position_Tracker_Get_Deeply_Nested);

--- a/benchmark/regex.cc
+++ b/benchmark/regex.cc
@@ -9,7 +9,7 @@
   static void name(benchmark::State &state) {                                  \
     const auto regex{sourcemeta::core::to_regex(pattern)};                     \
     assert(regex.has_value());                                                 \
-    for (auto _ : state) {                                                     \
+    for (auto iteration : state) {                                             \
       auto result{sourcemeta::core::matches(regex.value(), input)};            \
       assert(result);                                                          \
       benchmark::DoNotOptimize(result);                                        \
@@ -17,6 +17,10 @@
   }                                                                            \
   BENCHMARK(name);
 
+// GoogleBenchmark reports the name of each of these functions as the label
+// of its result, and the tooling that tracks those results over time keys
+// its history on that label, so they do not follow the usual convention
+// NOLINTBEGIN(readability-identifier-naming)
 BENCHMARK_REGEX(Regex_Lower_S_Or_Upper_S_Asterisk, "[\\s\\S]*", "foo")
 BENCHMARK_REGEX(Regex_Caret_Lower_S_Or_Upper_S_Asterisk_Dollar, "^[\\s\\S]*$",
                 "foo")
@@ -34,3 +38,4 @@ BENCHMARK_REGEX(Regex_Caret_Slash_Period_Asterisk, "^/.*", "/foo/bar")
 BENCHMARK_REGEX(Regex_Caret_Period_Range_Dollar, "^.{1,256}$", "foobar")
 // As a stress test, it is supposed to have O(2^n) complexity
 BENCHMARK_REGEX(Regex_Nested_Backtrack, "^(x+x+)+y$", "xxxxxxxxxxxxxxxxy")
+// NOLINTEND(readability-identifier-naming)

--- a/benchmark/regex.cc
+++ b/benchmark/regex.cc
@@ -17,9 +17,6 @@
   }                                                                            \
   BENCHMARK(name);
 
-// GoogleBenchmark reports the name of each of these functions as the label
-// of its result, and the tooling that tracks those results over time keys
-// its history on that label, so they do not follow the usual convention
 // NOLINTBEGIN(readability-identifier-naming)
 BENCHMARK_REGEX(Regex_Lower_S_Or_Upper_S_Asterisk, "[\\s\\S]*", "foo")
 BENCHMARK_REGEX(Regex_Caret_Lower_S_Or_Upper_S_Asterisk_Dollar, "^[\\s\\S]*$",

--- a/benchmark/uritemplate.cc
+++ b/benchmark/uritemplate.cc
@@ -131,9 +131,6 @@ static auto operation_id_table()
   return INSTANCE;
 }
 
-// GoogleBenchmark reports the name of each of these functions as the label
-// of its result, and the tooling that tracks those results over time keys
-// its history on that label, so they do not follow the usual convention
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void URITemplateRouter_Create(benchmark::State &state) {
   const auto &operation_ids{operation_id_table()};

--- a/benchmark/uritemplate.cc
+++ b/benchmark/uritemplate.cc
@@ -10,110 +10,110 @@
 #include <string>      // std::string, std::to_string
 #include <string_view> // std::string_view
 
-static constexpr std::string_view ROUTES[] = {
-    "/api/v1",
-    "/api/v2",
-    "/api/v3",
-    "/api/v1/health",
-    "/api/v2/health",
-    "/api/v3/health",
-    "/api/v1/users",
-    "/api/v1/users/{user_id}",
-    "/api/v1/users/{user_id}/profile",
-    "/api/v1/users/{user_id}/settings",
-    "/api/v1/users/{user_id}/preferences",
-    "/api/v1/users/{user_id}/avatar",
-    "/api/v1/users/{user_id}/posts",
-    "/api/v1/users/{user_id}/posts/{post_id}",
-    "/api/v1/users/{user_id}/posts/{post_id}/comments",
-    "/api/v1/users/{user_id}/posts/{post_id}/comments/{comment_id}",
-    "/api/v1/users/{user_id}/posts/{post_id}/likes",
-    "/api/v1/users/{user_id}/followers",
-    "/api/v1/users/{user_id}/following",
-    "/api/v1/users/{user_id}/notifications",
-    "/api/v1/users/{user_id}/notifications/{notification_id}",
-    "/api/v1/organizations",
-    "/api/v1/organizations/{org_id}",
-    "/api/v1/organizations/{org_id}/members",
-    "/api/v1/organizations/{org_id}/members/{member_id}",
-    "/api/v1/organizations/{org_id}/teams",
-    "/api/v1/organizations/{org_id}/teams/{team_id}",
-    "/api/v1/organizations/{org_id}/teams/{team_id}/members",
-    "/api/v1/organizations/{org_id}/projects",
-    "/api/v1/organizations/{org_id}/projects/{project_id}",
-    "/api/v1/organizations/{org_id}/billing",
-    "/api/v1/organizations/{org_id}/invoices",
-    "/api/v1/organizations/{org_id}/invoices/{invoice_id}",
-    "/api/v1/projects",
-    "/api/v1/projects/{project_id}",
-    "/api/v1/projects/{project_id}/issues",
-    "/api/v1/projects/{project_id}/issues/{issue_id}",
-    "/api/v1/projects/{project_id}/issues/{issue_id}/comments",
-    "/api/v1/projects/{project_id}/issues/{issue_id}/comments/{comment_id}",
-    "/api/v1/projects/{project_id}/issues/{issue_id}/labels",
-    "/api/v1/projects/{project_id}/issues/{issue_id}/assignees",
-    "/api/v1/projects/{project_id}/milestones",
-    "/api/v1/projects/{project_id}/milestones/{milestone_id}",
-    "/api/v1/projects/{project_id}/releases",
-    "/api/v1/projects/{project_id}/releases/{release_id}",
-    "/api/v1/projects/{project_id}/releases/{release_id}/assets",
-    "/api/v1/projects/{project_id}/branches",
-    "/api/v1/projects/{project_id}/branches/{branch_name}",
-    "/api/v1/projects/{project_id}/commits",
-    "/api/v1/projects/{project_id}/commits/{commit_sha}",
-    "/api/v1/projects/{project_id}/pulls",
-    "/api/v1/projects/{project_id}/pulls/{pull_id}",
-    "/api/v1/projects/{project_id}/pulls/{pull_id}/reviews",
-    "/api/v1/projects/{project_id}/pulls/{pull_id}/reviews/{review_id}",
-    "/api/v1/projects/{project_id}/pulls/{pull_id}/commits",
-    "/api/v1/projects/{project_id}/pulls/{pull_id}/files",
-    "/api/v1/documents",
-    "/api/v1/documents/{document_id}",
-    "/api/v1/documents/{document_id}/versions",
-    "/api/v1/documents/{document_id}/versions/{version_id}",
-    "/api/v1/documents/{document_id}/permissions",
-    "/api/v1/documents/{document_id}/comments",
-    "/api/v1/documents/{document_id}/comments/{comment_id}",
-    "/api/v1/documents/{document_id}/shares",
-    "/api/v1/documents/{document_id}/exports/{format}",
-    "/api/v1/storage/buckets",
-    "/api/v1/storage/buckets/{bucket_id}",
-    "/api/v1/storage/buckets/{bucket_id}/objects",
-    "/api/v1/storage/buckets/{bucket_id}/objects/{object_key}",
-    "/api/v1/storage/buckets/{bucket_id}/objects/{object_key}/metadata",
-    "/api/v1/storage/buckets/{bucket_id}/objects/{object_key}/versions",
-    "/api/v1/storage/buckets/{bucket_id}/policies",
-    "/api/v1/analytics/events",
-    "/api/v1/analytics/events/{event_id}",
-    "/api/v1/analytics/reports",
-    "/api/v1/analytics/reports/{report_id}",
-    "/api/v1/analytics/dashboards",
-    "/api/v1/analytics/dashboards/{dashboard_id}",
-    "/api/v1/analytics/dashboards/{dashboard_id}/widgets",
-    "/api/v1/analytics/dashboards/{dashboard_id}/widgets/{widget_id}",
-    "/api/v1/webhooks",
-    "/api/v1/webhooks/{webhook_id}",
-    "/api/v1/webhooks/{webhook_id}/deliveries",
-    "/api/v1/webhooks/{webhook_id}/deliveries/{delivery_id}",
-    "/api/v1/search/users",
-    "/api/v1/search/projects",
-    "/api/v1/search/documents",
-    "/api/v1/search/issues",
-    "/api/v1/admin/users",
-    "/api/v1/admin/users/{user_id}",
-    "/api/v1/admin/organizations",
-    "/api/v1/admin/organizations/{org_id}",
-    "/api/v1/admin/logs",
-    "/api/v1/admin/logs/{log_id}",
-    "/api/v1/admin/settings",
-    "/api/v1/admin/settings/{setting_key}",
-    "/api/v1/organizations/{org_id}/teams/{team_id}/projects/{project_id}/"
-    "issues/{issue_id}/comments/{comment_id}/reactions/{reaction_id}",
-    "/api/v1/workspaces/{workspace_id}/folders/{folder_id}/documents/"
-    "{document_id}/sections/{section_id}/paragraphs/{paragraph_id}/comments/"
-    "{comment_id}"};
+static constexpr auto ROUTES{std::to_array<std::string_view>(
+    {"/api/v1",
+     "/api/v2",
+     "/api/v3",
+     "/api/v1/health",
+     "/api/v2/health",
+     "/api/v3/health",
+     "/api/v1/users",
+     "/api/v1/users/{user_id}",
+     "/api/v1/users/{user_id}/profile",
+     "/api/v1/users/{user_id}/settings",
+     "/api/v1/users/{user_id}/preferences",
+     "/api/v1/users/{user_id}/avatar",
+     "/api/v1/users/{user_id}/posts",
+     "/api/v1/users/{user_id}/posts/{post_id}",
+     "/api/v1/users/{user_id}/posts/{post_id}/comments",
+     "/api/v1/users/{user_id}/posts/{post_id}/comments/{comment_id}",
+     "/api/v1/users/{user_id}/posts/{post_id}/likes",
+     "/api/v1/users/{user_id}/followers",
+     "/api/v1/users/{user_id}/following",
+     "/api/v1/users/{user_id}/notifications",
+     "/api/v1/users/{user_id}/notifications/{notification_id}",
+     "/api/v1/organizations",
+     "/api/v1/organizations/{org_id}",
+     "/api/v1/organizations/{org_id}/members",
+     "/api/v1/organizations/{org_id}/members/{member_id}",
+     "/api/v1/organizations/{org_id}/teams",
+     "/api/v1/organizations/{org_id}/teams/{team_id}",
+     "/api/v1/organizations/{org_id}/teams/{team_id}/members",
+     "/api/v1/organizations/{org_id}/projects",
+     "/api/v1/organizations/{org_id}/projects/{project_id}",
+     "/api/v1/organizations/{org_id}/billing",
+     "/api/v1/organizations/{org_id}/invoices",
+     "/api/v1/organizations/{org_id}/invoices/{invoice_id}",
+     "/api/v1/projects",
+     "/api/v1/projects/{project_id}",
+     "/api/v1/projects/{project_id}/issues",
+     "/api/v1/projects/{project_id}/issues/{issue_id}",
+     "/api/v1/projects/{project_id}/issues/{issue_id}/comments",
+     "/api/v1/projects/{project_id}/issues/{issue_id}/comments/{comment_id}",
+     "/api/v1/projects/{project_id}/issues/{issue_id}/labels",
+     "/api/v1/projects/{project_id}/issues/{issue_id}/assignees",
+     "/api/v1/projects/{project_id}/milestones",
+     "/api/v1/projects/{project_id}/milestones/{milestone_id}",
+     "/api/v1/projects/{project_id}/releases",
+     "/api/v1/projects/{project_id}/releases/{release_id}",
+     "/api/v1/projects/{project_id}/releases/{release_id}/assets",
+     "/api/v1/projects/{project_id}/branches",
+     "/api/v1/projects/{project_id}/branches/{branch_name}",
+     "/api/v1/projects/{project_id}/commits",
+     "/api/v1/projects/{project_id}/commits/{commit_sha}",
+     "/api/v1/projects/{project_id}/pulls",
+     "/api/v1/projects/{project_id}/pulls/{pull_id}",
+     "/api/v1/projects/{project_id}/pulls/{pull_id}/reviews",
+     "/api/v1/projects/{project_id}/pulls/{pull_id}/reviews/{review_id}",
+     "/api/v1/projects/{project_id}/pulls/{pull_id}/commits",
+     "/api/v1/projects/{project_id}/pulls/{pull_id}/files",
+     "/api/v1/documents",
+     "/api/v1/documents/{document_id}",
+     "/api/v1/documents/{document_id}/versions",
+     "/api/v1/documents/{document_id}/versions/{version_id}",
+     "/api/v1/documents/{document_id}/permissions",
+     "/api/v1/documents/{document_id}/comments",
+     "/api/v1/documents/{document_id}/comments/{comment_id}",
+     "/api/v1/documents/{document_id}/shares",
+     "/api/v1/documents/{document_id}/exports/{format}",
+     "/api/v1/storage/buckets",
+     "/api/v1/storage/buckets/{bucket_id}",
+     "/api/v1/storage/buckets/{bucket_id}/objects",
+     "/api/v1/storage/buckets/{bucket_id}/objects/{object_key}",
+     "/api/v1/storage/buckets/{bucket_id}/objects/{object_key}/metadata",
+     "/api/v1/storage/buckets/{bucket_id}/objects/{object_key}/versions",
+     "/api/v1/storage/buckets/{bucket_id}/policies",
+     "/api/v1/analytics/events",
+     "/api/v1/analytics/events/{event_id}",
+     "/api/v1/analytics/reports",
+     "/api/v1/analytics/reports/{report_id}",
+     "/api/v1/analytics/dashboards",
+     "/api/v1/analytics/dashboards/{dashboard_id}",
+     "/api/v1/analytics/dashboards/{dashboard_id}/widgets",
+     "/api/v1/analytics/dashboards/{dashboard_id}/widgets/{widget_id}",
+     "/api/v1/webhooks",
+     "/api/v1/webhooks/{webhook_id}",
+     "/api/v1/webhooks/{webhook_id}/deliveries",
+     "/api/v1/webhooks/{webhook_id}/deliveries/{delivery_id}",
+     "/api/v1/search/users",
+     "/api/v1/search/projects",
+     "/api/v1/search/documents",
+     "/api/v1/search/issues",
+     "/api/v1/admin/users",
+     "/api/v1/admin/users/{user_id}",
+     "/api/v1/admin/organizations",
+     "/api/v1/admin/organizations/{org_id}",
+     "/api/v1/admin/logs",
+     "/api/v1/admin/logs/{log_id}",
+     "/api/v1/admin/settings",
+     "/api/v1/admin/settings/{setting_key}",
+     "/api/v1/organizations/{org_id}/teams/{team_id}/projects/{project_id}/"
+     "issues/{issue_id}/comments/{comment_id}/reactions/{reaction_id}",
+     "/api/v1/workspaces/{workspace_id}/folders/{folder_id}/documents/"
+     "{document_id}/sections/{section_id}/paragraphs/{paragraph_id}/comments/"
+     "{comment_id}"})};
 
-static constexpr std::size_t ROUTE_COUNT = sizeof(ROUTES) / sizeof(ROUTES[0]);
+static constexpr std::size_t ROUTE_COUNT{ROUTES.size()};
 
 static auto make_operation_ids() -> std::array<std::string, ROUTE_COUNT> {
   std::array<std::string, ROUTE_COUNT> ids;
@@ -123,13 +123,20 @@ static auto make_operation_ids() -> std::array<std::string, ROUTE_COUNT> {
   return ids;
 }
 
-static const auto OPERATION_IDS = make_operation_ids();
+// Building these eagerly would run before the program can catch anything that
+// goes wrong, and every benchmark below takes its own reference anyway
+static auto operation_id_table()
+    -> const std::array<std::string, ROUTE_COUNT> & {
+  static const auto instance{make_operation_ids()};
+  return instance;
+}
 
 static void URITemplateRouter_Create(benchmark::State &state) {
+  const auto &operation_ids{operation_id_table()};
   for (auto _ : state) {
     sourcemeta::core::URITemplateRouter router;
     for (std::size_t index = 0; index < ROUTE_COUNT; ++index) {
-      router.add(ROUTES[index], OPERATION_IDS[index],
+      router.add(ROUTES[index], operation_ids[index],
                  static_cast<sourcemeta::core::URITemplateRouter::Identifier>(
                      index + 1));
     }
@@ -139,9 +146,10 @@ static void URITemplateRouter_Create(benchmark::State &state) {
 }
 
 static void URITemplateRouter_Match(benchmark::State &state) {
+  const auto &operation_ids{operation_id_table()};
   sourcemeta::core::URITemplateRouter router;
   for (std::size_t index = 0; index < ROUTE_COUNT; ++index) {
-    router.add(ROUTES[index], OPERATION_IDS[index],
+    router.add(ROUTES[index], operation_ids[index],
                static_cast<sourcemeta::core::URITemplateRouter::Identifier>(
                    index + 1));
   }
@@ -157,13 +165,14 @@ static void URITemplateRouter_Match(benchmark::State &state) {
 }
 
 static void URITemplateRouterView_Restore(benchmark::State &state) {
+  const auto &operation_ids{operation_id_table()};
   const auto path{std::filesystem::temp_directory_path() /
                   "uritemplate_benchmark.bin"};
 
   {
     sourcemeta::core::URITemplateRouter router;
     for (std::size_t index = 0; index < ROUTE_COUNT; ++index) {
-      router.add(ROUTES[index], OPERATION_IDS[index],
+      router.add(ROUTES[index], operation_ids[index],
                  static_cast<sourcemeta::core::URITemplateRouter::Identifier>(
                      index + 1));
     }
@@ -180,13 +189,14 @@ static void URITemplateRouterView_Restore(benchmark::State &state) {
 }
 
 static void URITemplateRouterView_Match(benchmark::State &state) {
+  const auto &operation_ids{operation_id_table()};
   const auto path{std::filesystem::temp_directory_path() /
                   "uritemplate_benchmark.bin"};
 
   {
     sourcemeta::core::URITemplateRouter router;
     for (std::size_t index = 0; index < ROUTE_COUNT; ++index) {
-      router.add(ROUTES[index], OPERATION_IDS[index],
+      router.add(ROUTES[index], operation_ids[index],
                  static_cast<sourcemeta::core::URITemplateRouter::Identifier>(
                      index + 1));
     }
@@ -360,9 +370,10 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
 }
 
 static void URITemplateRouter_Match_BasePath(benchmark::State &state) {
+  const auto &operation_ids{operation_id_table()};
   sourcemeta::core::URITemplateRouter router{"/v1/catalog"};
   for (std::size_t index = 0; index < ROUTE_COUNT; ++index) {
-    router.add(ROUTES[index], OPERATION_IDS[index],
+    router.add(ROUTES[index], operation_ids[index],
                static_cast<sourcemeta::core::URITemplateRouter::Identifier>(
                    index + 1));
   }
@@ -378,13 +389,14 @@ static void URITemplateRouter_Match_BasePath(benchmark::State &state) {
 }
 
 static void URITemplateRouterView_Match_BasePath(benchmark::State &state) {
+  const auto &operation_ids{operation_id_table()};
   const auto path{std::filesystem::temp_directory_path() /
                   "uritemplate_benchmark_basepath.bin"};
 
   {
     sourcemeta::core::URITemplateRouter router{"/v1/catalog"};
     for (std::size_t index = 0; index < ROUTE_COUNT; ++index) {
-      router.add(ROUTES[index], OPERATION_IDS[index],
+      router.add(ROUTES[index], operation_ids[index],
                  static_cast<sourcemeta::core::URITemplateRouter::Identifier>(
                      index + 1));
     }

--- a/benchmark/uritemplate.cc
+++ b/benchmark/uritemplate.cc
@@ -127,13 +127,17 @@ static auto make_operation_ids() -> std::array<std::string, ROUTE_COUNT> {
 // goes wrong, and every benchmark below takes its own reference anyway
 static auto operation_id_table()
     -> const std::array<std::string, ROUTE_COUNT> & {
-  static const auto instance{make_operation_ids()};
-  return instance;
+  static const auto INSTANCE{make_operation_ids()};
+  return INSTANCE;
 }
 
+// GoogleBenchmark reports the name of each of these functions as the label
+// of its result, and the tooling that tracks those results over time keys
+// its history on that label, so they do not follow the usual convention
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void URITemplateRouter_Create(benchmark::State &state) {
   const auto &operation_ids{operation_id_table()};
-  for (auto _ : state) {
+  for (auto iteration : state) {
     sourcemeta::core::URITemplateRouter router;
     for (std::size_t index = 0; index < ROUTE_COUNT; ++index) {
       router.add(ROUTES[index], operation_ids[index],
@@ -145,6 +149,7 @@ static void URITemplateRouter_Create(benchmark::State &state) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void URITemplateRouter_Match(benchmark::State &state) {
   const auto &operation_ids{operation_id_table()};
   sourcemeta::core::URITemplateRouter router;
@@ -154,7 +159,7 @@ static void URITemplateRouter_Match(benchmark::State &state) {
                    index + 1));
   }
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result = router.match(
         "/api/v1/organizations/12345/teams/67890/projects/abc/issues/999/"
         "comments/42/reactions/1",
@@ -164,6 +169,7 @@ static void URITemplateRouter_Match(benchmark::State &state) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void URITemplateRouterView_Restore(benchmark::State &state) {
   const auto &operation_ids{operation_id_table()};
   const auto path{std::filesystem::temp_directory_path() /
@@ -180,7 +186,7 @@ static void URITemplateRouterView_Restore(benchmark::State &state) {
     sourcemeta::core::URITemplateRouterView::save(router, path);
   }
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     sourcemeta::core::URITemplateRouterView view{path};
     benchmark::DoNotOptimize(view);
   }
@@ -188,6 +194,7 @@ static void URITemplateRouterView_Restore(benchmark::State &state) {
   std::filesystem::remove(path);
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void URITemplateRouterView_Match(benchmark::State &state) {
   const auto &operation_ids{operation_id_table()};
   const auto path{std::filesystem::temp_directory_path() /
@@ -208,7 +215,7 @@ static void URITemplateRouterView_Match(benchmark::State &state) {
   // file
   {
     sourcemeta::core::URITemplateRouterView view{path};
-    for (auto _ : state) {
+    for (auto iteration : state) {
       auto result = view.match(
           "/api/v1/organizations/12345/teams/67890/projects/abc/issues/999/"
           "comments/42/reactions/1",
@@ -221,12 +228,13 @@ static void URITemplateRouterView_Match(benchmark::State &state) {
   std::filesystem::remove(path);
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void URITemplateRouterView_Arguments(benchmark::State &state) {
   const auto path{std::filesystem::temp_directory_path() /
                   "uritemplate_benchmark_arguments.bin"};
 
   // clang-format off
-  constexpr std::string_view long_value =
+  constexpr std::string_view LONG_VALUE =
       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
       "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
@@ -240,7 +248,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
           {"argument_00", std::string_view{"short_value_0"}},
           {"argument_01", std::int64_t{1}},
           {"argument_02", true},
-          {"argument_03", long_value},
+          {"argument_03", LONG_VALUE},
           {"argument_04", std::int64_t{-100}},
           {"argument_05", false},
           {"argument_06", std::string_view{"response/schema/path"}},
@@ -249,7 +257,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
           {"argument_09", std::string_view{"another_short"}},
           {"argument_10", std::int64_t{0}},
           {"argument_11", false},
-          {"argument_12", long_value},
+          {"argument_12", LONG_VALUE},
           {"argument_13", std::int64_t{42}},
           {"argument_14", true},
           {"argument_15", std::string_view{"path/to/resource"}},
@@ -258,7 +266,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
           {"argument_18", std::string_view{"value_18"}},
           {"argument_19", std::int64_t{12345}},
           {"argument_20", true},
-          {"argument_21", long_value},
+          {"argument_21", LONG_VALUE},
           {"argument_22", std::int64_t{67890}},
           {"argument_23", false},
           {"argument_24", std::string_view{"config/key"}},
@@ -267,7 +275,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
           {"argument_27", std::string_view{"value_27"}},
           {"argument_28", std::int64_t{100}},
           {"argument_29", false},
-          {"argument_30", long_value},
+          {"argument_30", LONG_VALUE},
           {"argument_31", std::int64_t{200}},
           {"argument_32", true},
           {"argument_33", std::string_view{"schemas/api/list"}},
@@ -276,7 +284,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
           {"argument_36", std::string_view{"value_36"}},
           {"argument_37", std::int64_t{400}},
           {"argument_38", true},
-          {"argument_39", long_value},
+          {"argument_39", LONG_VALUE},
           {"argument_40", std::int64_t{500}},
           {"argument_41", false},
           {"argument_42", std::string_view{"target/url/path"}},
@@ -285,7 +293,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
           {"argument_45", std::string_view{"value_45"}},
           {"argument_46", std::int64_t{700}},
           {"argument_47", false},
-          {"argument_48", long_value},
+          {"argument_48", LONG_VALUE},
           {"argument_49", std::int64_t{800}},
           {"argument_50", true},
           {"argument_51", std::string_view{"redirect/path"}},
@@ -294,7 +302,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
           {"argument_54", std::string_view{"value_54"}},
           {"argument_55", std::int64_t{1000}},
           {"argument_56", true},
-          {"argument_57", long_value},
+          {"argument_57", LONG_VALUE},
           {"argument_58", std::int64_t{1100}},
           {"argument_59", false},
           {"argument_60", std::string_view{"webhook/endpoint"}},
@@ -303,7 +311,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
           {"argument_63", std::string_view{"value_63"}},
           {"argument_64", std::int64_t{1300}},
           {"argument_65", false},
-          {"argument_66", long_value},
+          {"argument_66", LONG_VALUE},
           {"argument_67", std::int64_t{1400}},
           {"argument_68", true},
           {"argument_69", std::string_view{"proxy/upstream"}},
@@ -312,7 +320,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
           {"argument_72", std::string_view{"value_72"}},
           {"argument_73", std::int64_t{1600}},
           {"argument_74", true},
-          {"argument_75", long_value},
+          {"argument_75", LONG_VALUE},
           {"argument_76", std::int64_t{1700}},
           {"argument_77", false},
           {"argument_78", std::string_view{"static/directory"}},
@@ -321,7 +329,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
           {"argument_81", std::string_view{"value_81"}},
           {"argument_82", std::int64_t{1900}},
           {"argument_83", false},
-          {"argument_84", long_value},
+          {"argument_84", LONG_VALUE},
           {"argument_85", std::int64_t{2000}},
           {"argument_86", true},
           {"argument_87", std::string_view{"cache/control"}},
@@ -330,7 +338,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
           {"argument_90", std::string_view{"value_90"}},
           {"argument_91", std::int64_t{2200}},
           {"argument_92", true},
-          {"argument_93", long_value},
+          {"argument_93", LONG_VALUE},
           {"argument_94", std::int64_t{2300}},
           {"argument_95", false},
           {"argument_96", std::string_view{"auth/token/path"}},
@@ -353,7 +361,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
   {
     sourcemeta::core::URITemplateRouterView view{path};
 
-    for (auto _ : state) {
+    for (auto iteration : state) {
       auto result = view.match("/api/v1/many", [](auto, auto, auto) {});
       assert(result.first == 3);
       benchmark::DoNotOptimize(result);
@@ -369,6 +377,7 @@ static void URITemplateRouterView_Arguments(benchmark::State &state) {
   std::filesystem::remove(path);
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void URITemplateRouter_Match_BasePath(benchmark::State &state) {
   const auto &operation_ids{operation_id_table()};
   sourcemeta::core::URITemplateRouter router{"/v1/catalog"};
@@ -378,7 +387,7 @@ static void URITemplateRouter_Match_BasePath(benchmark::State &state) {
                    index + 1));
   }
 
-  for (auto _ : state) {
+  for (auto iteration : state) {
     auto result = router.match(
         "/v1/catalog/api/v1/organizations/12345/teams/67890/projects/abc/"
         "issues/999/comments/42/reactions/1",
@@ -388,6 +397,7 @@ static void URITemplateRouter_Match_BasePath(benchmark::State &state) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static void URITemplateRouterView_Match_BasePath(benchmark::State &state) {
   const auto &operation_ids{operation_id_table()};
   const auto path{std::filesystem::temp_directory_path() /
@@ -406,7 +416,7 @@ static void URITemplateRouterView_Match_BasePath(benchmark::State &state) {
 
   {
     sourcemeta::core::URITemplateRouterView view{path};
-    for (auto _ : state) {
+    for (auto iteration : state) {
       auto result = view.match(
           "/v1/catalog/api/v1/organizations/12345/teams/67890/projects/abc/"
           "issues/999/comments/42/reactions/1",

--- a/cmake/FindGoogleBenchmark.cmake
+++ b/cmake/FindGoogleBenchmark.cmake
@@ -1,5 +1,13 @@
 if(NOT Benchmark_FOUND)
   set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "enable testing of the benchmark library")
   add_subdirectory("${PROJECT_SOURCE_DIR}/vendor/googlebenchmark")
+
+  # Consumers run static analysis over their own benchmark sources, and the
+  # headers this library exposes are not theirs to answer for
+  get_target_property(BENCHMARK_INCLUDE_DIRECTORIES
+    benchmark INTERFACE_INCLUDE_DIRECTORIES)
+  set_target_properties(benchmark PROPERTIES
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${BENCHMARK_INCLUDE_DIRECTORIES}")
+
   set(Benchmark_FOUND ON)
 endif()

--- a/cmake/common/clang-tidy.cmake
+++ b/cmake/common/clang-tidy.cmake
@@ -86,7 +86,7 @@ function(sourcemeta_clang_tidy_attempt_install)
 endfunction()
 
 function(sourcemeta_clang_tidy_attempt_enable)
-  cmake_parse_arguments(SOURCEMETA_TARGET_CLANG_TIDY_ATTEMPT_ENABLE "" "TARGET" "" ${ARGN})
+  cmake_parse_arguments(SOURCEMETA_TARGET_CLANG_TIDY_ATTEMPT_ENABLE "" "TARGET" "DISABLE" ${ARGN})
   if(NOT SOURCEMETA_TARGET_CLANG_TIDY_ATTEMPT_ENABLE_TARGET)
     message(FATAL_ERROR "You must pass the target name using the TARGET option")
   endif()
@@ -123,11 +123,25 @@ function(sourcemeta_clang_tidy_attempt_enable)
   # it stays out of the local edit loop. This sits outside the cache guard above
   # so that toggling the option takes effect on an existing build tree. The
   # `--checks` argument is appended to the `Checks` option of the configuration
-  # file rather than replacing it, so the group composes with whatever the file
-  # enables
+  # file rather than replacing it, so both the group below and whatever a target
+  # opts out of compose with what the file enables
   set(TARGET_CLANG_TIDY "${SOURCEMETA_CXX_CLANG_TIDY}")
+
+  # This tool bundles a newer compiler than the ones this project builds with,
+  # and reports a counter macro that third-party headers have long relied on as
+  # a feature of a language revision that is yet to be released
+  list(APPEND TARGET_CLANG_TIDY "--extra-arg=-Wno-c2y-extensions")
+
+  set(TARGET_CLANG_TIDY_CHECKS)
   if(SOURCEMETA_CORE_CLANG_TIDY_ANALYZER)
-    list(APPEND TARGET_CLANG_TIDY "--checks=clang-analyzer-*")
+    list(APPEND TARGET_CLANG_TIDY_CHECKS "clang-analyzer-*")
+  endif()
+  foreach(CHECK IN LISTS SOURCEMETA_TARGET_CLANG_TIDY_ATTEMPT_ENABLE_DISABLE)
+    list(APPEND TARGET_CLANG_TIDY_CHECKS "-${CHECK}")
+  endforeach()
+  if(TARGET_CLANG_TIDY_CHECKS)
+    list(JOIN TARGET_CLANG_TIDY_CHECKS "," TARGET_CLANG_TIDY_CHECKS)
+    list(APPEND TARGET_CLANG_TIDY "--checks=${TARGET_CLANG_TIDY_CHECKS}")
   endif()
 
   set_target_properties("${SOURCEMETA_TARGET_CLANG_TIDY_ATTEMPT_ENABLE_TARGET}"

--- a/cmake/common/clang-tidy.cmake
+++ b/cmake/common/clang-tidy.cmake
@@ -86,7 +86,7 @@ function(sourcemeta_clang_tidy_attempt_install)
 endfunction()
 
 function(sourcemeta_clang_tidy_attempt_enable)
-  cmake_parse_arguments(SOURCEMETA_TARGET_CLANG_TIDY_ATTEMPT_ENABLE "" "TARGET" "DISABLE" ${ARGN})
+  cmake_parse_arguments(SOURCEMETA_TARGET_CLANG_TIDY_ATTEMPT_ENABLE "" "TARGET" "" ${ARGN})
   if(NOT SOURCEMETA_TARGET_CLANG_TIDY_ATTEMPT_ENABLE_TARGET)
     message(FATAL_ERROR "You must pass the target name using the TARGET option")
   endif()
@@ -123,8 +123,8 @@ function(sourcemeta_clang_tidy_attempt_enable)
   # it stays out of the local edit loop. This sits outside the cache guard above
   # so that toggling the option takes effect on an existing build tree. The
   # `--checks` argument is appended to the `Checks` option of the configuration
-  # file rather than replacing it, so both the group below and whatever a target
-  # opts out of compose with what the file enables
+  # file rather than replacing it, so the group composes with whatever the file
+  # enables
   set(TARGET_CLANG_TIDY "${SOURCEMETA_CXX_CLANG_TIDY}")
 
   # This tool bundles a newer compiler than the ones this project builds with,
@@ -132,16 +132,8 @@ function(sourcemeta_clang_tidy_attempt_enable)
   # a feature of a language revision that is yet to be released
   list(APPEND TARGET_CLANG_TIDY "--extra-arg=-Wno-c2y-extensions")
 
-  set(TARGET_CLANG_TIDY_CHECKS)
   if(SOURCEMETA_CORE_CLANG_TIDY_ANALYZER)
-    list(APPEND TARGET_CLANG_TIDY_CHECKS "clang-analyzer-*")
-  endif()
-  foreach(CHECK IN LISTS SOURCEMETA_TARGET_CLANG_TIDY_ATTEMPT_ENABLE_DISABLE)
-    list(APPEND TARGET_CLANG_TIDY_CHECKS "-${CHECK}")
-  endforeach()
-  if(TARGET_CLANG_TIDY_CHECKS)
-    list(JOIN TARGET_CLANG_TIDY_CHECKS "," TARGET_CLANG_TIDY_CHECKS)
-    list(APPEND TARGET_CLANG_TIDY "--checks=${TARGET_CLANG_TIDY_CHECKS}")
+    list(APPEND TARGET_CLANG_TIDY "--checks=clang-analyzer-*")
   endif()
 
   set_target_properties("${SOURCEMETA_TARGET_CLANG_TIDY_ATTEMPT_ENABLE_TARGET}"

--- a/cmake/common/targets/executable.cmake
+++ b/cmake/common/targets/executable.cmake
@@ -1,6 +1,6 @@
 function(sourcemeta_executable)
   cmake_parse_arguments(SOURCEMETA_EXECUTABLE ""
-    "NAMESPACE;PROJECT;NAME;VARIANT;OUTPUT" "SOURCES" ${ARGN})
+    "NAMESPACE;PROJECT;NAME;VARIANT;OUTPUT" "SOURCES;CLANG_TIDY_DISABLE" ${ARGN})
 
   if(NOT SOURCEMETA_EXECUTABLE_PROJECT)
     message(FATAL_ERROR "You must pass the project name using the PROJECT option")
@@ -81,6 +81,7 @@ function(sourcemeta_executable)
 
   # We don't want consumers to be bothered with this
   if(PROJECT_IS_TOP_LEVEL)
-    sourcemeta_clang_tidy_attempt_enable(TARGET "${TARGET_NAME}")
+    sourcemeta_clang_tidy_attempt_enable(TARGET "${TARGET_NAME}"
+      DISABLE ${SOURCEMETA_EXECUTABLE_CLANG_TIDY_DISABLE})
   endif()
 endfunction()

--- a/cmake/common/targets/executable.cmake
+++ b/cmake/common/targets/executable.cmake
@@ -1,6 +1,6 @@
 function(sourcemeta_executable)
   cmake_parse_arguments(SOURCEMETA_EXECUTABLE ""
-    "NAMESPACE;PROJECT;NAME;VARIANT;OUTPUT" "SOURCES;CLANG_TIDY_DISABLE" ${ARGN})
+    "NAMESPACE;PROJECT;NAME;VARIANT;OUTPUT" "SOURCES" ${ARGN})
 
   if(NOT SOURCEMETA_EXECUTABLE_PROJECT)
     message(FATAL_ERROR "You must pass the project name using the PROJECT option")
@@ -81,7 +81,6 @@ function(sourcemeta_executable)
 
   # We don't want consumers to be bothered with this
   if(PROJECT_IS_TOP_LEVEL)
-    sourcemeta_clang_tidy_attempt_enable(TARGET "${TARGET_NAME}"
-      DISABLE ${SOURCEMETA_EXECUTABLE_CLANG_TIDY_DISABLE})
+    sourcemeta_clang_tidy_attempt_enable(TARGET "${TARGET_NAME}")
   endif()
 endfunction()

--- a/cmake/common/targets/googlebenchmark.cmake
+++ b/cmake/common/targets/googlebenchmark.cmake
@@ -7,10 +7,6 @@ function(sourcemeta_googlebenchmark)
     PROJECT "${SOURCEMETA_GOOGLEBENCHMARK_PROJECT}"
     NAME benchmark
     SOURCES "${SOURCEMETA_GOOGLEBENCHMARK_SOURCES}"
-    # The names of these functions are the labels GoogleBenchmark reports, which
-    # tools that track results over time key their history on, and the loop
-    # variable that the framework's iteration idiom asks for carries no meaning
-    CLANG_TIDY_DISABLE readability-identifier-naming readability-identifier-length
     OUTPUT TARGET_NAME)
 
   target_link_libraries("${TARGET_NAME}" PRIVATE benchmark::benchmark)

--- a/cmake/common/targets/googlebenchmark.cmake
+++ b/cmake/common/targets/googlebenchmark.cmake
@@ -2,33 +2,17 @@ function(sourcemeta_googlebenchmark)
   cmake_parse_arguments(SOURCEMETA_GOOGLEBENCHMARK ""
     "NAMESPACE;PROJECT" "SOURCES" ${ARGN})
 
-  if(NOT SOURCEMETA_GOOGLEBENCHMARK_PROJECT)
-    message(FATAL_ERROR "You must pass the project name using the PROJECT option")
-  endif()
-  if(NOT SOURCEMETA_GOOGLEBENCHMARK_SOURCES)
-    message(FATAL_ERROR "You must pass the sources list using the SOURCES option")
-  endif()
+  sourcemeta_executable(
+    NAMESPACE "${SOURCEMETA_GOOGLEBENCHMARK_NAMESPACE}"
+    PROJECT "${SOURCEMETA_GOOGLEBENCHMARK_PROJECT}"
+    NAME benchmark
+    SOURCES "${SOURCEMETA_GOOGLEBENCHMARK_SOURCES}"
+    # The names of these functions are the labels GoogleBenchmark reports, which
+    # tools that track results over time key their history on, and the loop
+    # variable that the framework's iteration idiom asks for carries no meaning
+    CLANG_TIDY_DISABLE readability-identifier-naming readability-identifier-length
+    OUTPUT TARGET_NAME)
 
-  if(SOURCEMETA_GOOGLEBENCHMARK_NAMESPACE)
-    set(TARGET_NAME "${SOURCEMETA_GOOGLEBENCHMARK_NAMESPACE}_${SOURCEMETA_GOOGLEBENCHMARK_PROJECT}_benchmark")
-    set(FOLDER_NAME "${SOURCEMETA_GOOGLEBENCHMARK_NAMESPACE}/${SOURCEMETA_GOOGLEBENCHMARK_PROJECT}")
-  else()
-    set(TARGET_NAME "${SOURCEMETA_GOOGLEBENCHMARK_PROJECT}_benchmark")
-    set(FOLDER_NAME "${SOURCEMETA_GOOGLEBENCHMARK_PROJECT}")
-  endif()
-
-  add_executable("${TARGET_NAME}" ${SOURCEMETA_GOOGLEBENCHMARK_SOURCES})
-  sourcemeta_add_default_options(PRIVATE ${TARGET_NAME})
-
-  # Measuring this project on an allocator that its programs do not ship with
-  # would report timings that no user of them can observe
-  if(SOURCEMETA_CORE_ALLOCATOR_TARGET)
-    target_link_libraries("${TARGET_NAME}" PRIVATE ${SOURCEMETA_CORE_ALLOCATOR_TARGET})
-  endif()
-  if(SOURCEMETA_COMPILER_MSVC)
-    target_link_options("${TARGET_NAME}" PRIVATE /guard:cf /CETCOMPAT)
-  endif()
-  set_target_properties("${TARGET_NAME}" PROPERTIES FOLDER "${FOLDER_NAME}")
   target_link_libraries("${TARGET_NAME}" PRIVATE benchmark::benchmark)
   target_link_libraries("${TARGET_NAME}" PRIVATE benchmark::benchmark_main)
 endfunction()

--- a/src/lang/test/CMakeLists.txt
+++ b/src/lang/test/CMakeLists.txt
@@ -33,6 +33,11 @@ target_link_libraries(sourcemeta_core_test_main
 set_target_properties(sourcemeta_core_test_main
   PROPERTIES EXPORT_NAME core::test_main)
 
+# We don't want consumers to be bothered with this
+if(PROJECT_IS_TOP_LEVEL)
+  sourcemeta_clang_tidy_attempt_enable(TARGET sourcemeta_core_test_main)
+endif()
+
 if(SOURCEMETA_CORE_INSTALL)
   include(GNUInstallDirs)
   install(TARGETS sourcemeta_core_test_main

--- a/test/stacktrace/CMakeLists.txt
+++ b/test/stacktrace/CMakeLists.txt
@@ -9,7 +9,10 @@ macro(add_stacktrace_test_unix scenario debug_flag)
     if(SOURCEMETA_CORE_ALLOCATOR_TARGET)
       target_link_libraries(${target} PRIVATE ${SOURCEMETA_CORE_ALLOCATOR_TARGET})
     endif()
-    sourcemeta_clang_tidy_attempt_enable(TARGET ${target})
+    # We don't want consumers to be bothered with this
+    if(PROJECT_IS_TOP_LEVEL)
+      sourcemeta_clang_tidy_attempt_enable(TARGET ${target})
+    endif()
     if("${debug_flag}" STREQUAL "none")
       target_compile_options(${target} PRIVATE -g0 -fvisibility=default)
     else()
@@ -34,7 +37,10 @@ macro(add_stacktrace_test_windows scenario)
     if(SOURCEMETA_CORE_ALLOCATOR_TARGET)
       target_link_libraries(${target} PRIVATE ${SOURCEMETA_CORE_ALLOCATOR_TARGET})
     endif()
-    sourcemeta_clang_tidy_attempt_enable(TARGET ${target})
+    # We don't want consumers to be bothered with this
+    if(PROJECT_IS_TOP_LEVEL)
+      sourcemeta_clang_tidy_attempt_enable(TARGET ${target})
+    endif()
     target_compile_options(${target} PRIVATE /Zi)
     target_link_options(${target} PRIVATE /DEBUG)
     add_test(NAME core.stacktrace.${scenario}.e2e
@@ -57,7 +63,10 @@ macro(add_stacktrace_test_windows_no_debug scenario)
     if(SOURCEMETA_CORE_ALLOCATOR_TARGET)
       target_link_libraries(${target} PRIVATE ${SOURCEMETA_CORE_ALLOCATOR_TARGET})
     endif()
-    sourcemeta_clang_tidy_attempt_enable(TARGET ${target})
+    # We don't want consumers to be bothered with this
+    if(PROJECT_IS_TOP_LEVEL)
+      sourcemeta_clang_tidy_attempt_enable(TARGET ${target})
+    endif()
     add_test(NAME core.stacktrace.${scenario}.no_debug.e2e
       COMMAND powershell -ExecutionPolicy Bypass -File
         "${CMAKE_CURRENT_SOURCE_DIR}/stacktrace_${scenario}_no_debug_test.ps1"

--- a/test/stacktrace/CMakeLists.txt
+++ b/test/stacktrace/CMakeLists.txt
@@ -9,6 +9,7 @@ macro(add_stacktrace_test_unix scenario debug_flag)
     if(SOURCEMETA_CORE_ALLOCATOR_TARGET)
       target_link_libraries(${target} PRIVATE ${SOURCEMETA_CORE_ALLOCATOR_TARGET})
     endif()
+    sourcemeta_clang_tidy_attempt_enable(TARGET ${target})
     if("${debug_flag}" STREQUAL "none")
       target_compile_options(${target} PRIVATE -g0 -fvisibility=default)
     else()
@@ -33,6 +34,7 @@ macro(add_stacktrace_test_windows scenario)
     if(SOURCEMETA_CORE_ALLOCATOR_TARGET)
       target_link_libraries(${target} PRIVATE ${SOURCEMETA_CORE_ALLOCATOR_TARGET})
     endif()
+    sourcemeta_clang_tidy_attempt_enable(TARGET ${target})
     target_compile_options(${target} PRIVATE /Zi)
     target_link_options(${target} PRIVATE /DEBUG)
     add_test(NAME core.stacktrace.${scenario}.e2e
@@ -55,6 +57,7 @@ macro(add_stacktrace_test_windows_no_debug scenario)
     if(SOURCEMETA_CORE_ALLOCATOR_TARGET)
       target_link_libraries(${target} PRIVATE ${SOURCEMETA_CORE_ALLOCATOR_TARGET})
     endif()
+    sourcemeta_clang_tidy_attempt_enable(TARGET ${target})
     add_test(NAME core.stacktrace.${scenario}.no_debug.e2e
       COMMAND powershell -ExecutionPolicy Bypass -File
         "${CMAKE_CURRENT_SOURCE_DIR}/stacktrace_${scenario}_no_debug_test.ps1"


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

