### PR TITLE
Guard both long division routines against a zero-word divisor

### DIFF
--- a/src/core/crypto/crypto_bignum.h
+++ b/src/core/crypto/crypto_bignum.h
@@ -213,6 +213,12 @@ inline auto bignum_reduce(Bignum &value, const Bignum &modulus) noexcept
 
   const auto divisor_words{modulus.size};
 
+  // A zero modulus defines no residue to reduce into, and the division below
+  // reads the top two divisor words
+  if (divisor_words == 0) {
+    return;
+  }
+
   // A single-word divisor folds the value down word by word
   if (divisor_words == 1) {
     const auto divisor{modulus.words[0]};

--- a/src/lang/numeric/big_coefficient.h
+++ b/src/lang/numeric/big_coefficient.h
@@ -376,6 +376,15 @@ public:
       return {std::move(quotient), std::move(remainder)};
     }
 
+    // A divisor without words defines no quotient, and the long division below
+    // reads the top two divisor words
+    if (divisor.length == 0) {
+      BigCoefficient quotient{1};
+      quotient.words[0] = 0;
+      quotient.length = 1;
+      return {std::move(quotient), this->clone()};
+    }
+
     if (divisor.length == 1) {
       BigCoefficient quotient{this->length};
       quotient.length = this->length;

--- a/src/lang/numeric/big_coefficient.h
+++ b/src/lang/numeric/big_coefficient.h
@@ -376,9 +376,9 @@ public:
       return {std::move(quotient), std::move(remainder)};
     }
 
-    // A divisor without words defines no quotient, and the long division below
-    // reads the top two divisor words
-    if (divisor.length == 0) {
+    // A zero divisor defines no quotient, and the divisions below would either
+    // divide by that zero word or read past the divisor
+    if (divisor.is_zero()) {
       BigCoefficient quotient{1};
       quotient.words[0] = 0;
       quotient.length = 1;


### PR DESCRIPTION
See: https://github.com/sourcemeta/blaze/issues/1017
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

