### PR TITLE
Add RFC 7464 JSON text sequences to the `jsonl` module

### DIFF
--- a/src/core/jsonl/grammar.h
+++ b/src/core/jsonl/grammar.h
@@ -5,6 +5,10 @@ namespace sourcemeta::core::internal {
 template <typename CharT>
 static constexpr CharT TOKEN_JSONL_LINE_FEED{'\u000A'};
 
+// RFC 7464 Section 2.1: "RS = %x1E; "record separator" (RS), see RFC 20"
+template <typename CharT>
+static constexpr CharT TOKEN_JSONL_RECORD_SEPARATOR{'\u001E'};
+
 // Whitespace is any sequence of one or more of the following code points:
 // character tabulation (U+0009), line feed (U+000A), carriage return (U+000D),
 // and space (U+0020).

--- a/src/core/jsonl/include/sourcemeta/core/jsonl.h
+++ b/src/core/jsonl/include/sourcemeta/core/jsonl.h
@@ -16,11 +16,12 @@
 #include <memory>  // std::unique_ptr
 
 /// @defgroup jsonl JSONL
-/// @brief A JSON Lines (https://jsonlines.org) implementation with iterator
-/// support. Every non-empty line in a JSONL stream is a complete, valid JSON
-/// value of any type, and lines are separated by newline characters (U+000A),
-/// optionally preceded by a carriage return (U+000D). Multi-line JSON values
-/// are not supported, as per the JSONL specification.
+/// @brief A JSON Lines (https://jsonlines.org) and RFC 7464 JSON text sequence
+/// implementation with iterator support. Every non-empty line in a JSONL stream
+/// is a complete, valid JSON value of any type, and lines are separated by
+/// newline characters (U+000A), optionally preceded by a carriage return
+/// (U+000D). Multi-line JSON values are not supported, as per the JSONL
+/// specification.
 ///
 /// JSON Lines and NDJSON (https://github.com/ndjson/ndjson-spec) describe the
 /// same format with minor differences, and this implementation accepts a
@@ -33,6 +34,21 @@
 ///   recommendation, while NDJSON 3.1 requires it when serializing
 /// - Whitespace is tolerated anywhere around a value, including carriage
 ///   returns that NDJSON 3.1 only allows right before a newline
+///
+/// The same iterator reads RFC 7464 JSON text sequences, the
+/// `application/json-seq` media type, when given the corresponding framing.
+/// There, every value is introduced by a record separator (U+001E) rather than
+/// terminated by a newline, so a value may span multiple lines. RFC 7464
+/// Section 2.4 requires dropping a top-level number, boolean or null that no
+/// whitespace follows, as it may have been truncated, and this implementation
+/// honors that. It deviates from the specification as follows:
+///
+/// - Section 2.3 states that a parser "should skip to the next RS" when an
+///   element is not a valid JSON text. This implementation throws instead, so
+///   that malformed input is never dropped without notice
+/// - Section 2.1 permits ignoring the empty elements that consecutive record
+///   separators denote. This implementation also ignores elements that carry
+///   nothing but whitespace, matching how it treats blank lines
 ///
 /// This functionality is included as follows:
 ///
@@ -57,8 +73,9 @@ public:
   /// Parse a JSONL document from a C++ standard input stream using a standard
   /// read-only C++ forward iterator interface. An optional mode parameter
   /// controls whether the input is treated as raw text or gzip-compressed
-  /// data. For example, you can parse a JSONL document and prettify each of
-  /// its rows as follows:
+  /// data, and an optional framing parameter controls how values are
+  /// delimited. For example, you can parse a JSONL document and prettify each
+  /// of its rows as follows:
   ///
   /// ```cpp
   /// #include <sourcemeta/core/jsonl.h>
@@ -76,9 +93,28 @@ public:
   /// }
   /// ```
   ///
+  /// An RFC 7464 JSON text sequence is read the same way, by selecting the
+  /// record separator framing:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/jsonl.h>
+  /// #include <cassert>
+  /// #include <sstream>
+  ///
+  /// std::istringstream stream{"\x1E{ \"foo\": 1 }\n\x1E{ \"bar\": 2 }\n"};
+  /// const auto framing{sourcemeta::core::JSONLFraming::RecordSeparator};
+  ///
+  /// for (const auto &document :
+  ///      sourcemeta::core::JSONL{stream,
+  ///                              sourcemeta::core::JSONL::Mode::Raw,
+  ///                              framing}) {
+  ///   assert(document.is_object());
+  /// }
+  /// ```
+  ///
   /// If parsing fails, sourcemeta::core::JSONParseError will be thrown.
   JSONL(std::basic_istream<JSON::Char, JSON::CharTraits> &input,
-        Mode mode = Mode::Raw);
+        Mode mode = Mode::Raw, JSONLFraming framing = JSONLFraming::LineFeed);
   ~JSONL();
 
   JSONL(const JSONL &) = delete;
@@ -101,6 +137,7 @@ private:
 #pragma warning(disable : 4251)
 #endif
   std::basic_istream<JSON::Char, JSON::CharTraits> *stream_;
+  JSONLFraming framing_;
   struct Internal;
   std::unique_ptr<Internal> internal_;
 #if defined(_MSC_VER)

--- a/src/core/jsonl/include/sourcemeta/core/jsonl_iterator.h
+++ b/src/core/jsonl/include/sourcemeta/core/jsonl_iterator.h
@@ -16,12 +16,24 @@
 namespace sourcemeta::core {
 
 /// @ingroup jsonl
+/// The framing that delimits the JSON values of a stream
+enum class JSONLFraming : std::uint8_t {
+  /// Every value is terminated by a line feed, as in JSON Lines and NDJSON
+  LineFeed,
+  /// Every value is introduced by a record separator (U+001E) and terminated
+  /// by a line feed, as in RFC 7464 JSON text sequences
+  RecordSeparator
+};
+
+/// @ingroup jsonl
 /// A forward iterator to parse JSON documents out of a JSON Lines stream. Blank
 /// and whitespace-only lines are skipped rather than treated as errors.
 class SOURCEMETA_CORE_JSONL_EXPORT ConstJSONLIterator {
 public:
-  /// Construct an iterator over the JSON documents in a stream.
-  ConstJSONLIterator(std::basic_istream<JSON::Char, JSON::CharTraits> *stream);
+  /// Construct an iterator over the JSON documents in a stream, optionally
+  /// selecting the framing that delimits them.
+  ConstJSONLIterator(std::basic_istream<JSON::Char, JSON::CharTraits> *stream,
+                     JSONLFraming framing = JSONLFraming::LineFeed);
   ~ConstJSONLIterator();
   using iterator_category = std::forward_iterator_tag;
   using difference_type = std::ptrdiff_t;
@@ -40,7 +52,11 @@ public:
 private:
   std::uint64_t line_{0};
   std::uint64_t column_{0};
+  JSONLFraming framing_{JSONLFraming::LineFeed};
+  bool at_sequence_start_{true};
   auto parse_next() -> JSON;
+  auto parse_next_line() -> JSON;
+  auto parse_next_record() -> JSON;
   std::basic_istream<JSON::Char, JSON::CharTraits> *data_{};
 
 // Exporting symbols that depends on the standard C++ library is considered

--- a/src/core/jsonl/iterator.cc
+++ b/src/core/jsonl/iterator.cc
@@ -5,9 +5,13 @@
 
 #include "grammar.h"
 
-#include <cassert> // assert
-#include <istream> // std::basic_istream
-#include <string>  // std::basic_string
+#include <cassert>     // assert
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::uint64_t
+#include <istream>     // std::basic_istream
+#include <string>      // std::basic_string
+#include <string_view> // std::basic_string_view
+#include <utility>     // std::unreachable
 
 namespace sourcemeta::core {
 
@@ -15,11 +19,139 @@ struct ConstJSONLIterator::Internal {
   sourcemeta::core::JSON current;
 };
 
+namespace {
+
+// RFC 7159 Section 2: "ws = *( %x20 / %x09 / %x0A / %x0D )"
+auto is_json_whitespace(const JSON::Char character) -> bool {
+  return character == internal::TOKEN_JSONL_WHITESPACE_SPACE<JSON::Char> ||
+         character == internal::TOKEN_JSONL_WHITESPACE_TABULATION<JSON::Char> ||
+         character == internal::TOKEN_JSONL_LINE_FEED<JSON::Char> ||
+         character ==
+             internal::TOKEN_JSONL_WHITESPACE_CARRIAGE_RETURN<JSON::Char>;
+}
+
+// Consume a span that may only carry JSON whitespace, advancing the position
+// counters over it and reporting the first byte that is not whitespace,
+// returning whether the span carried any whitespace at all
+auto consume_whitespace(
+    const std::basic_string_view<JSON::Char, JSON::CharTraits> span,
+    std::uint64_t &line, std::uint64_t &column) -> bool {
+  for (const auto character : span) {
+    if (!is_json_whitespace(character)) {
+      column += 1;
+      throw JSONParseError(line, column);
+    }
+
+    if (character == internal::TOKEN_JSONL_LINE_FEED<JSON::Char>) {
+      line += 1;
+      column = 0;
+    } else {
+      column += 1;
+    }
+  }
+
+  return !span.empty();
+}
+
+// RFC 7464 Section 2.4: "While objects, arrays, and strings are self-delimited
+// in JSON texts, numbers and the values 'true', 'false', and 'null' are not"
+auto is_self_delimiting(const JSON &document) -> bool {
+  return document.is_object() || document.is_array() || document.is_string();
+}
+
+} // namespace
+
 /*
  * Parsing
  */
 
 auto ConstJSONLIterator::parse_next() -> JSON {
+  switch (this->framing_) {
+    case JSONLFraming::LineFeed:
+      return this->parse_next_line();
+    case JSONLFraming::RecordSeparator:
+      return this->parse_next_record();
+  }
+
+  std::unreachable();
+}
+
+auto ConstJSONLIterator::parse_next_record() -> JSON {
+  std::basic_string<JSON::Char, JSON::CharTraits> record;
+  while ((this->data_ != nullptr) &&
+         std::getline(*this->data_, record,
+                      internal::TOKEN_JSONL_RECORD_SEPARATOR<JSON::Char>)) {
+    if (this->at_sequence_start_) {
+      this->at_sequence_start_ = false;
+      this->line_ += 1;
+
+      // RFC 7464 Section 2.1: "input-JSON-sequence = *(1*RS possible-JSON)",
+      // so every element is introduced by a record separator and whatever
+      // precedes the first one is not part of the sequence
+      consume_whitespace(record, this->line_, this->column_);
+      continue;
+    }
+
+    // The record separator that introduced this element, which the previous
+    // read consumed
+    this->column_ += 1;
+
+    bool has_content{false};
+    for (const auto character : record) {
+      if (!is_json_whitespace(character)) {
+        has_content = true;
+        break;
+      }
+    }
+
+    // RFC 7464 Section 2.1: "Multiple consecutive RS octets do not denote
+    // empty sequence elements between them and can be ignored"
+    if (!has_content) {
+      consume_whitespace(record, this->line_, this->column_);
+      continue;
+    }
+
+    const auto record_line{this->line_};
+    const auto record_column{this->column_};
+    auto result{parse_json(record, this->line_, this->column_)};
+
+    // The parser reports where it stopped as a column within a line, so the
+    // offset of the remainder is found by skipping the line feeds it consumed
+    std::size_t offset{0};
+    if (this->line_ == record_line) {
+      offset = static_cast<std::size_t>(this->column_ - record_column);
+    } else {
+      for (auto consumed{this->line_ - record_line}; consumed > 0;
+           consumed -= 1) {
+        const auto position{
+            record.find(internal::TOKEN_JSONL_LINE_FEED<JSON::Char>, offset)};
+        assert(position != decltype(record)::npos);
+        offset = position + 1;
+      }
+
+      offset += static_cast<std::size_t>(this->column_);
+    }
+
+    const auto delimited{consume_whitespace(
+        std::basic_string_view<JSON::Char, JSON::CharTraits>{record}.substr(
+            offset),
+        this->line_, this->column_)};
+
+    // RFC 7464 Section 2.4: "Parsers MUST drop JSON-text sequence elements
+    // consisting of non-self-delimited top-level values that may have been
+    // truncated (that are not delimited by whitespace)"
+    if (!delimited && !is_self_delimiting(result)) {
+      continue;
+    }
+
+    return result;
+  }
+
+  this->data_ = nullptr;
+  return JSON{nullptr};
+}
+
+auto ConstJSONLIterator::parse_next_line() -> JSON {
   // Each line in a JSONL stream is a complete JSON value.
   // See https://jsonlines.org
   std::basic_string<JSON::Char, JSON::CharTraits> row;
@@ -37,11 +169,7 @@ auto ConstJSONLIterator::parse_next() -> JSON {
     // NDJSON 3.2 states that "The parser MAY silently ignore empty lines"
     bool has_content{false};
     for (const auto character : row) {
-      if (character != internal::TOKEN_JSONL_WHITESPACE_SPACE<JSON::Char> &&
-          character !=
-              internal::TOKEN_JSONL_WHITESPACE_TABULATION<JSON::Char> &&
-          character !=
-              internal::TOKEN_JSONL_WHITESPACE_CARRIAGE_RETURN<JSON::Char>) {
+      if (!is_json_whitespace(character)) {
         has_content = true;
         break;
       }
@@ -54,17 +182,10 @@ auto ConstJSONLIterator::parse_next() -> JSON {
     auto result{parse_json(row, this->line_, this->column_)};
 
     // Verify that the remainder of the line is only whitespace
-    for (auto index{static_cast<std::size_t>(this->column_)};
-         index < row.size(); ++index) {
-      if (row[index] != internal::TOKEN_JSONL_WHITESPACE_SPACE<JSON::Char> &&
-          row[index] !=
-              internal::TOKEN_JSONL_WHITESPACE_TABULATION<JSON::Char> &&
-          row[index] !=
-              internal::TOKEN_JSONL_WHITESPACE_CARRIAGE_RETURN<JSON::Char>) {
-        this->column_ = static_cast<std::uint64_t>(index) + 1;
-        throw JSONParseError(this->line_, this->column_);
-      }
-    }
+    consume_whitespace(
+        std::basic_string_view<JSON::Char, JSON::CharTraits>{row}.substr(
+            static_cast<std::size_t>(this->column_)),
+        this->line_, this->column_);
 
     return result;
   }
@@ -84,8 +205,10 @@ auto ConstJSONLIterator::operator++() -> ConstJSONLIterator & {
  */
 
 ConstJSONLIterator::ConstJSONLIterator(
-    std::basic_istream<JSON::Char, JSON::CharTraits> *stream)
-    : data_{stream}, internal_{new Internal({this->parse_next()})} {}
+    std::basic_istream<JSON::Char, JSON::CharTraits> *stream,
+    const JSONLFraming framing)
+    : framing_{framing}, data_{stream},
+      internal_{new Internal({this->parse_next()})} {}
 
 ConstJSONLIterator::~ConstJSONLIterator() = default;
 

--- a/src/core/jsonl/jsonl.cc
+++ b/src/core/jsonl/jsonl.cc
@@ -13,8 +13,9 @@ struct JSONL::Internal {
 };
 
 JSONL::JSONL(std::basic_istream<JSON::Char, JSON::CharTraits> &input,
-             const Mode mode)
-    : stream_{&input}, internal_{std::make_unique<Internal>()} {
+             const Mode mode, const JSONLFraming framing)
+    : stream_{&input}, framing_{framing},
+      internal_{std::make_unique<Internal>()} {
   if (mode == Mode::GZIP) {
     this->internal_->streambuf = std::make_unique<GZIPStreamBuffer>(input);
     this->internal_->decompressed_stream =
@@ -26,9 +27,13 @@ JSONL::JSONL(std::basic_istream<JSON::Char, JSON::CharTraits> &input,
 
 JSONL::~JSONL() = default;
 
-auto JSONL::begin() -> JSONL::const_iterator { return {this->stream_}; }
+auto JSONL::begin() -> JSONL::const_iterator {
+  return {this->stream_, this->framing_};
+}
 auto JSONL::end() -> JSONL::const_iterator { return {nullptr}; }
-auto JSONL::cbegin() -> JSONL::const_iterator { return {this->stream_}; }
+auto JSONL::cbegin() -> JSONL::const_iterator {
+  return {this->stream_, this->framing_};
+}
 auto JSONL::cend() -> JSONL::const_iterator { return {nullptr}; }
 
 } // namespace sourcemeta::core

--- a/test/jsonl/CMakeLists.txt
+++ b/test/jsonl/CMakeLists.txt
@@ -3,7 +3,10 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME jsonl
     jsonl_parse_test.cc
     jsonl_parse_error_test.cc
     jsonl_gzip_parse_test.cc
-    jsonl_gzip_parse_error_test.cc)
+    jsonl_gzip_parse_error_test.cc
+    jsonl_record_separator_parse_test.cc
+    jsonl_record_separator_parse_error_test.cc
+    jsonl_gzip_record_separator_parse_test.cc)
 
 target_link_libraries(sourcemeta_core_jsonl_unit
   PRIVATE sourcemeta::core::jsonl)

--- a/test/jsonl/jsonl_gzip_record_separator_parse_test.cc
+++ b/test/jsonl/jsonl_gzip_record_separator_parse_test.cc
@@ -1,0 +1,120 @@
+#include <sourcemeta/core/gzip.h>
+#include <sourcemeta/core/jsonl.h>
+#include <sourcemeta/core/test.h>
+
+#include <cstdint> // std::uint8_t
+#include <sstream> // std::istringstream
+#include <string>  // std::string
+#include <vector>  // std::vector
+
+// A hexadecimal escape consumes every hexadecimal digit that follows it, so
+// the record separator always closes the string literal it appears in
+static constexpr auto FRAMING{sourcemeta::core::JSONLFraming::RecordSeparator};
+static constexpr auto MODE{sourcemeta::core::JSONL::Mode::GZIP};
+
+// The decompressed data is read through a buffer of this many bytes, so a
+// record that exceeds it spans more than one refill
+static constexpr std::size_t VALUE_SIZE{10000};
+
+TEST(integers) {
+  const std::string input{"\x1E"
+                          "1\n"
+                          "\x1E"
+                          "2\n"
+                          "\x1E"
+                          "3\n"
+                          "\x1E"
+                          "4\n"};
+  const auto compressed{sourcemeta::core::gzip(
+      reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
+  std::istringstream stream{compressed};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 4);
+  EXPECT_TRUE(result.at(0).is_integer());
+  EXPECT_TRUE(result.at(1).is_integer());
+  EXPECT_TRUE(result.at(2).is_integer());
+  EXPECT_TRUE(result.at(3).is_integer());
+  EXPECT_EQ(result.at(0).to_integer(), 1);
+  EXPECT_EQ(result.at(1).to_integer(), 2);
+  EXPECT_EQ(result.at(2).to_integer(), 3);
+  EXPECT_EQ(result.at(3).to_integer(), 4);
+}
+
+TEST(objects) {
+  const std::string input{"\x1E"
+                          "{ \"foo\": 1 }\n"
+                          "\x1E"
+                          "{ \"bar\": 2 }\n"};
+  const auto compressed{sourcemeta::core::gzip(
+      reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
+  std::istringstream stream{compressed};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_TRUE(result.at(0).is_object());
+  EXPECT_TRUE(result.at(1).is_object());
+  EXPECT_EQ(result.at(0).size(), 1);
+  EXPECT_EQ(result.at(1).size(), 1);
+  EXPECT_TRUE(result.at(0).defines("foo"));
+  EXPECT_TRUE(result.at(1).defines("bar"));
+  EXPECT_EQ(result.at(0).at("foo").to_integer(), 1);
+  EXPECT_EQ(result.at(1).at("bar").to_integer(), 2);
+}
+
+TEST(truncated_number_dropped) {
+  const std::string input{"\x1E"
+                          "123"
+                          "\x1E"
+                          "456\n"};
+  const auto compressed{sourcemeta::core::gzip(
+      reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
+  std::istringstream stream{compressed};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_TRUE(result.at(0).is_integer());
+  EXPECT_EQ(result.at(0).to_integer(), 456);
+}
+
+TEST(records_across_buffer_refills) {
+  const std::string first(VALUE_SIZE, 'a');
+  const std::string second(VALUE_SIZE, 'b');
+  const std::string third(VALUE_SIZE, 'c');
+  const std::string input{"\x1E"
+                          "{ \"value\": \"" +
+                          first + "\" }\n" +
+                          "\x1E"
+                          "{ \"value\": \"" +
+                          second + "\" }\n" +
+                          "\x1E"
+                          "{ \"value\": \"" +
+                          third + "\" }\n"};
+  const auto compressed{sourcemeta::core::gzip(
+      reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
+  std::istringstream stream{compressed};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 3);
+  EXPECT_TRUE(result.at(0).is_object());
+  EXPECT_TRUE(result.at(1).is_object());
+  EXPECT_TRUE(result.at(2).is_object());
+  EXPECT_TRUE(result.at(0).defines("value"));
+  EXPECT_TRUE(result.at(1).defines("value"));
+  EXPECT_TRUE(result.at(2).defines("value"));
+  EXPECT_EQ(result.at(0).at("value").to_string(), first);
+  EXPECT_EQ(result.at(1).at("value").to_string(), second);
+  EXPECT_EQ(result.at(2).at("value").to_string(), third);
+}

--- a/test/jsonl/jsonl_record_separator_parse_error_test.cc
+++ b/test/jsonl/jsonl_record_separator_parse_error_test.cc
@@ -1,0 +1,78 @@
+#include <sourcemeta/core/jsonl.h>
+#include <sourcemeta/core/test.h>
+
+#include <exception> // std::exception
+#include <sstream>   // std::istringstream
+#include <string>    // std::string
+
+// A hexadecimal escape consumes every hexadecimal digit that follows it, so
+// the record separator always closes the string literal it appears in
+static constexpr auto FRAMING{sourcemeta::core::JSONLFraming::RecordSeparator};
+static constexpr auto MODE{sourcemeta::core::JSONL::Mode::Raw};
+
+#define EXPECT_PARSE_ERROR(stream, expected_line, expected_column)             \
+  try {                                                                        \
+    sourcemeta::core::JSONL parser{stream, MODE, FRAMING};                     \
+    sourcemeta::core::ConstJSONLIterator iterator{parser.cbegin()};            \
+    while (iterator != parser.cend())                                          \
+      ++iterator;                                                              \
+    FAIL();                                                                    \
+  } catch (const sourcemeta::core::JSONParseError &error) {                    \
+    EXPECT_EQ(error.line(), expected_line);                                    \
+    EXPECT_EQ(error.column(), expected_column);                                \
+  } catch (const std::exception &) {                                           \
+    FAIL();                                                                    \
+  }
+
+TEST(content_before_first_separator) {
+  const std::string data{"garbage"
+                         "\x1E"
+                         "1\n"};
+  std::istringstream input{data};
+  EXPECT_PARSE_ERROR(input, 1, 1);
+}
+
+TEST(value_before_first_separator) {
+  const std::string data{"1\n"
+                         "\x1E"
+                         "2\n"};
+  std::istringstream input{data};
+  EXPECT_PARSE_ERROR(input, 1, 1);
+}
+
+TEST(invalid_first_record) {
+  const std::string data{"\x1E"
+                         "trrue\n"};
+  std::istringstream input{data};
+  EXPECT_PARSE_ERROR(input, 1, 4);
+}
+
+TEST(invalid_second_record) {
+  const std::string data{"\x1E"
+                         "1\n"
+                         "\x1E"
+                         "trrue\n"};
+  std::istringstream input{data};
+  EXPECT_PARSE_ERROR(input, 2, 4);
+}
+
+TEST(trailing_content_in_record) {
+  const std::string data{"\x1E"
+                         "1 2\n"};
+  std::istringstream input{data};
+  EXPECT_PARSE_ERROR(input, 1, 4);
+}
+
+TEST(trailing_content_in_multi_line_record) {
+  const std::string data{"\x1E"
+                         "{\n  \"foo\": 1\n} x\n"};
+  std::istringstream input{data};
+  EXPECT_PARSE_ERROR(input, 3, 3);
+}
+
+TEST(invalid_multi_line_record) {
+  const std::string data{"\x1E"
+                         "{\n  \"foo\": }\n"};
+  std::istringstream input{data};
+  EXPECT_PARSE_ERROR(input, 2, 10);
+}

--- a/test/jsonl/jsonl_record_separator_parse_test.cc
+++ b/test/jsonl/jsonl_record_separator_parse_test.cc
@@ -1,0 +1,337 @@
+#include <sourcemeta/core/jsonl.h>
+#include <sourcemeta/core/test.h>
+
+#include <sstream> // std::istringstream
+#include <string>  // std::string
+#include <vector>  // std::vector
+
+// A hexadecimal escape consumes every hexadecimal digit that follows it, so
+// the record separator always closes the string literal it appears in
+static constexpr auto FRAMING{sourcemeta::core::JSONLFraming::RecordSeparator};
+static constexpr auto MODE{sourcemeta::core::JSONL::Mode::Raw};
+
+TEST(empty) {
+  const std::string input;
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(blank) {
+  const std::string input{"    "};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(integers) {
+  const std::string input{"\x1E"
+                          "1\n"
+                          "\x1E"
+                          "2\n"
+                          "\x1E"
+                          "3\n"
+                          "\x1E"
+                          "4\n"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 4);
+  EXPECT_TRUE(result.at(0).is_integer());
+  EXPECT_TRUE(result.at(1).is_integer());
+  EXPECT_TRUE(result.at(2).is_integer());
+  EXPECT_TRUE(result.at(3).is_integer());
+  EXPECT_EQ(result.at(0).to_integer(), 1);
+  EXPECT_EQ(result.at(1).to_integer(), 2);
+  EXPECT_EQ(result.at(2).to_integer(), 3);
+  EXPECT_EQ(result.at(3).to_integer(), 4);
+}
+
+TEST(objects) {
+  const std::string input{"\x1E"
+                          "{ \"foo\": 1 }\n"
+                          "\x1E"
+                          "{ \"bar\": 2 }\n"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_TRUE(result.at(0).is_object());
+  EXPECT_TRUE(result.at(1).is_object());
+  EXPECT_EQ(result.at(0).size(), 1);
+  EXPECT_EQ(result.at(1).size(), 1);
+  EXPECT_TRUE(result.at(0).defines("foo"));
+  EXPECT_TRUE(result.at(1).defines("bar"));
+  EXPECT_EQ(result.at(0).at("foo").to_integer(), 1);
+  EXPECT_EQ(result.at(1).at("bar").to_integer(), 2);
+}
+
+TEST(object_without_trailing_line_feed) {
+  const std::string input{"\x1E"
+                          "{ \"foo\": 1 }"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_TRUE(result.at(0).is_object());
+  EXPECT_EQ(result.at(0).size(), 1);
+  EXPECT_TRUE(result.at(0).defines("foo"));
+  EXPECT_EQ(result.at(0).at("foo").to_integer(), 1);
+}
+
+TEST(array_without_trailing_line_feed) {
+  const std::string input{"\x1E"
+                          "[ 1, 2 ]"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_TRUE(result.at(0).is_array());
+  EXPECT_EQ(result.at(0).size(), 2);
+  EXPECT_EQ(result.at(0).at(0).to_integer(), 1);
+  EXPECT_EQ(result.at(0).at(1).to_integer(), 2);
+}
+
+TEST(string_without_trailing_line_feed) {
+  const std::string input{"\x1E"
+                          "\"foo\""};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_TRUE(result.at(0).is_string());
+  EXPECT_EQ(result.at(0).to_string(), "foo");
+}
+
+TEST(truncated_number_dropped) {
+  const std::string input{"\x1E"
+                          "123"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(truncated_boolean_dropped) {
+  const std::string input{"\x1E"
+                          "true"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(truncated_null_dropped) {
+  const std::string input{"\x1E"
+                          "null"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(truncated_number_between_separators) {
+  const std::string input{"\x1E"
+                          "123"
+                          "\x1E"
+                          "456\n"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_TRUE(result.at(0).is_integer());
+  EXPECT_EQ(result.at(0).to_integer(), 456);
+}
+
+TEST(number_delimited_by_space) {
+  const std::string input{"\x1E"
+                          "123 "
+                          "\x1E"
+                          "456\n"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_TRUE(result.at(0).is_integer());
+  EXPECT_TRUE(result.at(1).is_integer());
+  EXPECT_EQ(result.at(0).to_integer(), 123);
+  EXPECT_EQ(result.at(1).to_integer(), 456);
+}
+
+TEST(consecutive_separators) {
+  const std::string input{"\x1E"
+                          "\x1E"
+                          "\x1E"
+                          "1\n"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_TRUE(result.at(0).is_integer());
+  EXPECT_EQ(result.at(0).to_integer(), 1);
+}
+
+TEST(whitespace_only_record) {
+  const std::string input{"\x1E"
+                          " \n"
+                          "\x1E"
+                          "1\n"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_TRUE(result.at(0).is_integer());
+  EXPECT_EQ(result.at(0).to_integer(), 1);
+}
+
+TEST(whitespace_before_first_separator) {
+  const std::string input{"  \n"
+                          "\x1E"
+                          "1\n"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_TRUE(result.at(0).is_integer());
+  EXPECT_EQ(result.at(0).to_integer(), 1);
+}
+
+TEST(multi_line_value) {
+  const std::string input{"\x1E"
+                          "{\n  \"foo\": 1\n}\n"
+                          "\x1E"
+                          "2\n"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_TRUE(result.at(0).is_object());
+  EXPECT_EQ(result.at(0).size(), 1);
+  EXPECT_TRUE(result.at(0).defines("foo"));
+  EXPECT_EQ(result.at(0).at("foo").to_integer(), 1);
+  EXPECT_TRUE(result.at(1).is_integer());
+  EXPECT_EQ(result.at(1).to_integer(), 2);
+}
+
+TEST(carriage_return_line_endings) {
+  const std::string input{"\x1E"
+                          "1\r\n"
+                          "\x1E"
+                          "2\r\n"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_TRUE(result.at(0).is_integer());
+  EXPECT_TRUE(result.at(1).is_integer());
+  EXPECT_EQ(result.at(0).to_integer(), 1);
+  EXPECT_EQ(result.at(1).to_integer(), 2);
+}
+
+TEST(mixed_types) {
+  const std::string input{"\x1E"
+                          "{ \"foo\": 1 }\n"
+                          "\x1E"
+                          "[ 1, 2 ]\n"
+                          "\x1E"
+                          "\"bar\"\n"
+                          "\x1E"
+                          "3\n"
+                          "\x1E"
+                          "true\n"
+                          "\x1E"
+                          "null\n"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{stream, MODE, FRAMING}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 6);
+  EXPECT_TRUE(result.at(0).is_object());
+  EXPECT_TRUE(result.at(1).is_array());
+  EXPECT_TRUE(result.at(2).is_string());
+  EXPECT_TRUE(result.at(3).is_integer());
+  EXPECT_TRUE(result.at(4).is_boolean());
+  EXPECT_TRUE(result.at(5).is_null());
+  EXPECT_EQ(result.at(0).size(), 1);
+  EXPECT_TRUE(result.at(0).defines("foo"));
+  EXPECT_EQ(result.at(0).at("foo").to_integer(), 1);
+  EXPECT_EQ(result.at(1).size(), 2);
+  EXPECT_EQ(result.at(1).at(0).to_integer(), 1);
+  EXPECT_EQ(result.at(1).at(1).to_integer(), 2);
+  EXPECT_EQ(result.at(2).to_string(), "bar");
+  EXPECT_EQ(result.at(3).to_integer(), 3);
+  EXPECT_TRUE(result.at(4).to_boolean());
+}
+
+TEST(explicit_line_feed_framing) {
+  const std::string input{"1\n2\n3\n"};
+  std::istringstream stream{input};
+  std::vector<sourcemeta::core::JSON> result;
+  for (const auto &document : sourcemeta::core::JSONL{
+           stream, MODE, sourcemeta::core::JSONLFraming::LineFeed}) {
+    result.push_back(document);
+  }
+
+  EXPECT_EQ(result.size(), 3);
+  EXPECT_TRUE(result.at(0).is_integer());
+  EXPECT_TRUE(result.at(1).is_integer());
+  EXPECT_TRUE(result.at(2).is_integer());
+  EXPECT_EQ(result.at(0).to_integer(), 1);
+  EXPECT_EQ(result.at(1).to_integer(), 2);
+  EXPECT_EQ(result.at(2).to_integer(), 3);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

