### PR TITLE
Add RFC 9110 media type parsing and range matching to the `http` module

### DIFF
--- a/src/core/http/CMakeLists.txt
+++ b/src/core/http/CMakeLists.txt
@@ -15,6 +15,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME http
           negotiate_encoding.cc from_date.cc format_link.cc format_vary.cc
           field_list.cc
           accept_includes_all.cc content_type_matches.cc parse_bearer.cc
+          parse_media_type.cc match_media_range.cc
           cache_control_max_age.cc serialize_cookie.cc aws_sigv4.cc
           serialize_challenge.cc parse_challenges.cc
           serialize_cache_control.cc

--- a/src/core/http/helpers.h
+++ b/src/core/http/helpers.h
@@ -20,6 +20,20 @@ inline auto http_subview(const std::string_view value, const std::size_t offset,
   return std::string_view{value.data() + offset, length};
 }
 
+// RFC 9110 §8.3.1: "media-type = type "/" subtype parameters", where both
+// "type = token" and "subtype = token", which rules out the comments and
+// folding whitespace that the MIME grammar of RFC 2045 §5.1 admits
+inline auto http_is_media_type(const std::string_view value) noexcept -> bool {
+  const auto slash{value.find('/')};
+  if (slash == std::string_view::npos) {
+    return false;
+  }
+
+  return http_is_token(http_subview(value, 0, slash)) &&
+         http_is_token(
+             http_subview(value, slash + 1, value.size() - slash - 1));
+}
+
 inline auto http_media_specificity(const std::string_view range,
                                    const std::string_view candidate) noexcept
     -> std::uint8_t {

--- a/src/core/http/include/sourcemeta/core/http.h
+++ b/src/core/http/include/sourcemeta/core/http.h
@@ -31,6 +31,15 @@
 /// @brief An implementation of HTTP-protocol parsing, formatting, and
 /// validation primitives per RFC 9110.
 ///
+/// Media types live in this module rather than in a MIME one because HTTP
+/// defines its own grammar for them. RFC 9110 §8.3.1 builds a media type from
+/// the HTTP token of §5.6.2, while the MIME grammar of RFC 2045 §5.1 admits
+/// curly braces, and a MIME header field further admits the comments and
+/// folding whitespace that HTTP has no equivalent of. RFC 9112 Appendix B.1
+/// states that "HTTP is not a MIME-compliant protocol". Only the registration
+/// vocabulary of RFC 6838, the structured syntax suffix among it, is common to
+/// both.
+///
 /// This functionality is included as follows:
 ///
 /// ```cpp
@@ -103,6 +112,67 @@ SOURCEMETA_CORE_HTTP_EXPORT
 auto http_content_type_matches(const std::string_view content_type_header,
                                const std::string_view media_type) noexcept
     -> bool;
+
+/// @ingroup http
+/// The parts of a media type per RFC 9110 §8.3.1, as views borrowed from the
+/// input.
+struct HTTPMediaType {
+  /// The type, such as `application`
+  std::string_view type{};
+  /// The subtype, such as `geo+json`
+  std::string_view subtype{};
+  /// The structured syntax suffix per RFC 6838 §4.2, carrying the leading `+`
+  /// that the IANA registry names it by, such as `+json`. Empty when the
+  /// subtype has none
+  std::string_view suffix{};
+  /// The parameters that follow the type, starting at the first `;`
+  std::string_view parameters{};
+};
+
+/// @ingroup http
+/// Parse a media type into its parts per RFC 9110 §8.3.1, splitting off any
+/// structured syntax suffix per RFC 6838 §4.2. Returns no value when the input
+/// is not well-formed. A media range such as `text/*` parses the same way. For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// const auto result{
+///     sourcemeta::core::http_parse_media_type("application/geo+json")};
+/// assert(result.has_value());
+/// assert(result.value().type == "application");
+/// assert(result.value().subtype == "geo+json");
+/// assert(result.value().suffix == "+json");
+/// ```
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_parse_media_type(const std::string_view media_type) noexcept
+    -> std::optional<HTTPMediaType>;
+
+/// @ingroup http
+/// Pick the most specific media range that a media type matches per RFC 9110
+/// §12.5.1, where `type/subtype` beats `type/*` beats `*/*` and a range that
+/// pins a parameter the media type also carries is more specific still.
+/// Returns an empty value when none match. The returned view borrows from
+/// `ranges`. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <array>
+/// #include <cassert>
+/// #include <string_view>
+///
+/// const std::array<std::string_view, 3> ranges{
+///     {"*/*", "text/*", "text/plain"}};
+/// const auto best{
+///     sourcemeta::core::http_match_media_range("text/plain", ranges)};
+/// assert(best == "text/plain");
+/// ```
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_match_media_range(const std::string_view media_type,
+                            std::span<const std::string_view> ranges) noexcept
+    -> std::string_view;
 
 /// @ingroup http
 /// Pick the best language-tag candidate against an `Accept-Language` header

--- a/src/core/http/include/sourcemeta/core/http.h
+++ b/src/core/http/include/sourcemeta/core/http.h
@@ -132,7 +132,8 @@ struct HTTPMediaType {
 /// @ingroup http
 /// Parse a media type into its parts per RFC 9110 §8.3.1, splitting off any
 /// structured syntax suffix per RFC 6838 §4.2. Returns no value when the input
-/// is not well-formed. A media range such as `text/*` parses the same way. For
+/// is not well-formed, including when its parameters do not follow RFC 9110
+/// §5.6.6. A media range such as `text/*` parses the same way. For
 /// example:
 ///
 /// ```cpp
@@ -147,15 +148,18 @@ struct HTTPMediaType {
 /// assert(result.value().suffix == "+json");
 /// ```
 SOURCEMETA_CORE_HTTP_EXPORT
-auto http_parse_media_type(const std::string_view media_type) noexcept
+auto http_parse_media_type(const std::string_view media_type)
     -> std::optional<HTTPMediaType>;
 
 /// @ingroup http
 /// Pick the most specific media range that a media type matches per RFC 9110
 /// §12.5.1, where an exact type beats a subtype wildcard, which in turn beats
 /// a full wildcard, and a range that pins a parameter the media type also
-/// carries is more specific still. Returns an empty value when none match. The
-/// returned view borrows from `ranges`. For example:
+/// carries is more specific still. A weight on a range is not a media type
+/// parameter and takes no part in matching. Selection looks only at the type
+/// and the parameters it is given, so neither side has to be well-formed
+/// beyond its type. Returns an empty value when none match. The returned view
+/// borrows from `ranges`. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/http.h>

--- a/src/core/http/include/sourcemeta/core/http.h
+++ b/src/core/http/include/sourcemeta/core/http.h
@@ -152,10 +152,10 @@ auto http_parse_media_type(const std::string_view media_type) noexcept
 
 /// @ingroup http
 /// Pick the most specific media range that a media type matches per RFC 9110
-/// §12.5.1, where `type/subtype` beats `type/*` beats `*/*` and a range that
-/// pins a parameter the media type also carries is more specific still.
-/// Returns an empty value when none match. The returned view borrows from
-/// `ranges`. For example:
+/// §12.5.1, where an exact type beats a subtype wildcard, which in turn beats
+/// a full wildcard, and a range that pins a parameter the media type also
+/// carries is more specific still. Returns an empty value when none match. The
+/// returned view borrows from `ranges`. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/http.h>
@@ -163,8 +163,7 @@ auto http_parse_media_type(const std::string_view media_type) noexcept
 /// #include <cassert>
 /// #include <string_view>
 ///
-/// const std::array<std::string_view, 3> ranges{
-///     {"*/*", "text/*", "text/plain"}};
+/// const std::array<std::string_view, 2> ranges{{"text/*", "text/plain"}};
 /// const auto best{
 ///     sourcemeta::core::http_match_media_range("text/plain", ranges)};
 /// assert(best == "text/plain");

--- a/src/core/http/match_media_range.cc
+++ b/src/core/http/match_media_range.cc
@@ -1,0 +1,40 @@
+#include <sourcemeta/core/http.h>
+
+#include "helpers.h"
+
+#include <cstdint>     // std::uint8_t
+#include <span>        // std::span
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+auto http_match_media_range(const std::string_view media_type,
+                            std::span<const std::string_view> ranges) noexcept
+    -> std::string_view {
+  const auto [candidate_value, candidate_parameters] =
+      http_split_entry(media_type);
+  const auto candidate{http_trim_leading_ows(candidate_value)};
+  if (!http_is_media_type(candidate)) {
+    return {};
+  }
+
+  std::string_view result;
+  std::uint8_t best_specificity{0};
+  for (const auto entry : ranges) {
+    const auto [range_value, range_parameters] = http_split_entry(entry);
+    const auto range{http_trim_leading_ows(range_value)};
+    const auto specificity{http_media_range_specificity(
+        range, range_parameters, candidate, candidate_parameters)};
+    // RFC 9110 §12.5.1: "If more than one media range applies to a given type,
+    // the most specific reference has precedence", so an equally specific
+    // later range does not displace an earlier one
+    if (specificity > best_specificity) {
+      best_specificity = specificity;
+      result = entry;
+    }
+  }
+
+  return result;
+}
+
+} // namespace sourcemeta::core

--- a/src/core/http/match_media_range.cc
+++ b/src/core/http/match_media_range.cc
@@ -21,8 +21,14 @@ auto http_match_media_range(const std::string_view media_type,
   std::string_view result;
   std::uint8_t best_specificity{0};
   for (const auto entry : ranges) {
-    const auto [range_value, range_parameters] = http_split_entry(entry);
+    const auto [range_value, range_suffix] = http_split_entry(entry);
     const auto range{http_trim_leading_ows(range_value)};
+    // RFC 9110 §12.5.1: "Accept = #( media-range [ weight ] )", so the weight
+    // is not part of the range, and "Recipients SHOULD process any parameter
+    // named "q" as weight, regardless of parameter ordering". That section
+    // further notes that "the media type registry disallows parameters named
+    // "q"", so a "q" can never be a media type parameter to match against
+    const auto range_parameters{http_split_media_range(range_suffix).first};
     const auto specificity{http_media_range_specificity(
         range, range_parameters, candidate, candidate_parameters)};
     // RFC 9110 §12.5.1: "If more than one media range applies to a given type,

--- a/src/core/http/parse_media_type.cc
+++ b/src/core/http/parse_media_type.cc
@@ -1,0 +1,35 @@
+#include <sourcemeta/core/http.h>
+
+#include "helpers.h"
+
+#include <optional>    // std::optional, std::nullopt
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+auto http_parse_media_type(const std::string_view media_type) noexcept
+    -> std::optional<HTTPMediaType> {
+  const auto [value, parameters] = http_split_entry(media_type);
+  const auto bare{http_trim_leading_ows(value)};
+  if (!http_is_media_type(bare)) {
+    return std::nullopt;
+  }
+
+  const auto slash{bare.find('/')};
+  const auto subtype{http_subview(bare, slash + 1, bare.size() - slash - 1)};
+
+  // RFC 6838 §4.2: "Characters after last plus always specify a structured
+  // syntax suffix", so a trailing plus with nothing after it names none
+  const auto plus{subtype.rfind('+')};
+  const auto suffix{
+      (plus == std::string_view::npos || plus + 1 == subtype.size())
+          ? std::string_view{}
+          : http_subview(subtype, plus, subtype.size() - plus)};
+
+  return HTTPMediaType{.type = http_subview(bare, 0, slash),
+                       .subtype = subtype,
+                       .suffix = suffix,
+                       .parameters = parameters};
+}
+
+} // namespace sourcemeta::core

--- a/src/core/http/parse_media_type.cc
+++ b/src/core/http/parse_media_type.cc
@@ -2,16 +2,87 @@
 
 #include "helpers.h"
 
+#include <cstddef>     // std::size_t
 #include <optional>    // std::optional, std::nullopt
+#include <string>      // std::string
 #include <string_view> // std::string_view
 
 namespace sourcemeta::core {
 
-auto http_parse_media_type(const std::string_view media_type) noexcept
+namespace {
+
+// RFC 9110 §5.6.6: "parameters = *( OWS ";" OWS [ parameter ] )", where
+// "parameter = parameter-name "=" parameter-value", the name is a token, and
+// the value is "( token / quoted-string )". That section also notes that
+// parameters "do not allow whitespace (not even "bad" whitespace) around the
+// "=" character"
+auto http_is_parameters(const std::string_view parameters) -> bool {
+  // A field value carries no leading or trailing whitespace of its own per
+  // RFC 9110 §5.5, so the tail is trimmed before the grammar applies
+  const auto span{http_trim_trailing_ows(parameters)};
+  std::string storage;
+  std::string_view value;
+  std::size_t position{0};
+  while (position < span.size()) {
+    while (position < span.size() && http_is_ows(span[position])) {
+      position += 1;
+    }
+
+    if (position >= span.size() || span[position] != ';') {
+      return false;
+    }
+
+    position += 1;
+    while (position < span.size() && http_is_ows(span[position])) {
+      position += 1;
+    }
+
+    // The parameter of each repetition is optional, so a separator that stands
+    // alone is well-formed
+    if (position >= span.size() || span[position] == ';') {
+      continue;
+    }
+
+    const auto name{position};
+    while (position < span.size() && http_is_tchar(span[position])) {
+      position += 1;
+    }
+
+    if (position == name || position >= span.size() || span[position] != '=') {
+      return false;
+    }
+
+    position += 1;
+    if (position < span.size() && span[position] == '"') {
+      const auto end{http_scan_quoted_string(span, position, storage, value)};
+      if (!end.has_value()) {
+        return false;
+      }
+
+      position = end.value();
+      continue;
+    }
+
+    const auto start{position};
+    while (position < span.size() && http_is_tchar(span[position])) {
+      position += 1;
+    }
+
+    if (position == start) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+} // namespace
+
+auto http_parse_media_type(const std::string_view media_type)
     -> std::optional<HTTPMediaType> {
   const auto [value, parameters] = http_split_entry(media_type);
   const auto bare{http_trim_leading_ows(value)};
-  if (!http_is_media_type(bare)) {
+  if (!http_is_media_type(bare) || !http_is_parameters(parameters)) {
     return std::nullopt;
   }
 

--- a/test/http/CMakeLists.txt
+++ b/test/http/CMakeLists.txt
@@ -15,7 +15,8 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME http
           http_serialize_cookie_test.cc http_parse_cookies_test.cc
           http_cookie_values_test.cc
           http_cookie_valid_test.cc http_aws_sigv4_test.cc
-          http_syntax_test.cc
+          http_syntax_test.cc http_parse_media_type_test.cc
+          http_match_media_range_test.cc
           http_system_request_test.cc)
 
 target_link_libraries(sourcemeta_core_http_unit

--- a/test/http/http_match_media_range_test.cc
+++ b/test/http/http_match_media_range_test.cc
@@ -1,0 +1,121 @@
+#include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
+
+#include <array>       // std::array
+#include <string_view> // std::string_view
+
+TEST(exact_beats_every_wildcard) {
+  const std::array<std::string_view, 3> ranges{{"*/*", "text/*", "text/plain"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range("text/plain", ranges),
+            "text/plain");
+}
+
+TEST(subtype_wildcard_beats_full_wildcard) {
+  const std::array<std::string_view, 2> ranges{{"*/*", "text/*"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range("text/plain", ranges),
+            "text/*");
+}
+
+TEST(full_wildcard_alone) {
+  const std::array<std::string_view, 1> ranges{{"*/*"}};
+  EXPECT_EQ(
+      sourcemeta::core::http_match_media_range("application/json", ranges),
+      "*/*");
+}
+
+TEST(order_does_not_affect_specificity) {
+  const std::array<std::string_view, 3> ranges{{"text/plain", "text/*", "*/*"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range("text/plain", ranges),
+            "text/plain");
+}
+
+TEST(no_match) {
+  const std::array<std::string_view, 2> ranges{{"text/*", "image/png"}};
+  EXPECT_EQ(
+      sourcemeta::core::http_match_media_range("application/json", ranges), "");
+}
+
+TEST(no_ranges) {
+  const std::array<std::string_view, 0> ranges{};
+  EXPECT_EQ(
+      sourcemeta::core::http_match_media_range("application/json", ranges), "");
+}
+
+TEST(type_and_subtype_are_case_insensitive) {
+  const std::array<std::string_view, 1> ranges{{"TEXT/PLAIN"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range("text/plain", ranges),
+            "TEXT/PLAIN");
+}
+
+TEST(wildcard_type_is_case_insensitive) {
+  const std::array<std::string_view, 1> ranges{{"TEXT/*"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range("text/plain", ranges),
+            "TEXT/*");
+}
+
+TEST(candidate_parameters_do_not_prevent_a_bare_range) {
+  const std::array<std::string_view, 1> ranges{{"text/plain"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range(
+                "text/plain; charset=UTF-8", ranges),
+            "text/plain");
+}
+
+TEST(range_parameter_is_more_specific) {
+  const std::array<std::string_view, 2> ranges{
+      {"text/plain", "text/plain; charset=UTF-8"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range(
+                "text/plain; charset=UTF-8", ranges),
+            "text/plain; charset=UTF-8");
+}
+
+TEST(range_parameter_the_candidate_lacks_does_not_match) {
+  const std::array<std::string_view, 1> ranges{{"text/plain; charset=UTF-8"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range("text/plain", ranges), "");
+}
+
+TEST(quoted_and_unquoted_parameter_values_are_equivalent) {
+  const std::array<std::string_view, 1> ranges{
+      {"text/plain; charset=\"utf-8\""}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range(
+                "text/plain; charset=utf-8", ranges),
+            "text/plain; charset=\"utf-8\"");
+}
+
+TEST(first_of_equally_specific_ranges_wins) {
+  const std::array<std::string_view, 2> ranges{{"text/*", "text/*"}};
+  EXPECT_EQ(
+      sourcemeta::core::http_match_media_range("text/plain", ranges).data(),
+      ranges.at(0).data());
+}
+
+TEST(structured_syntax_suffix_matches_a_type_wildcard) {
+  const std::array<std::string_view, 2> ranges{{"*/*", "application/*"}};
+  EXPECT_EQ(
+      sourcemeta::core::http_match_media_range("application/geo+json", ranges),
+      "application/*");
+}
+
+TEST(invalid_media_type) {
+  const std::array<std::string_view, 1> ranges{{"*/*"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range("application", ranges),
+            "");
+}
+
+TEST(invalid_media_type_with_a_comment) {
+  const std::array<std::string_view, 1> ranges{{"*/*"}};
+  EXPECT_EQ(
+      sourcemeta::core::http_match_media_range("text/plain(comment)", ranges),
+      "");
+}
+
+TEST(invalid_range_is_ignored) {
+  const std::array<std::string_view, 2> ranges{{"garbage", "text/plain"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range("text/plain", ranges),
+            "text/plain");
+}
+
+TEST(the_range_is_returned_as_given) {
+  const std::array<std::string_view, 1> ranges{{"  text/plain  "}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range("text/plain", ranges),
+            "  text/plain  ");
+}

--- a/test/http/http_match_media_range_test.cc
+++ b/test/http/http_match_media_range_test.cc
@@ -119,3 +119,38 @@ TEST(the_range_is_returned_as_given) {
   EXPECT_EQ(sourcemeta::core::http_match_media_range("text/plain", ranges),
             "  text/plain  ");
 }
+
+TEST(a_weight_on_a_range_is_not_a_media_type_parameter) {
+  const std::array<std::string_view, 1> ranges{{"text/plain;q=0.8"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range("text/plain", ranges),
+            "text/plain;q=0.8");
+}
+
+TEST(a_weight_after_a_media_type_parameter) {
+  const std::array<std::string_view, 1> ranges{
+      {"text/plain;charset=utf-8;q=0.8"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range(
+                "text/plain; charset=utf-8", ranges),
+            "text/plain;charset=utf-8;q=0.8");
+}
+
+TEST(parameters_after_a_weight_are_not_media_type_parameters) {
+  const std::array<std::string_view, 1> ranges{
+      {"text/plain;q=0.8;charset=utf-8"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range("text/plain", ranges),
+            "text/plain;q=0.8;charset=utf-8");
+}
+
+TEST(a_weight_does_not_affect_specificity) {
+  const std::array<std::string_view, 2> ranges{
+      {"text/*;q=1", "text/plain;q=0.1"}};
+  EXPECT_EQ(sourcemeta::core::http_match_media_range("text/plain", ranges),
+            "text/plain;q=0.1");
+}
+
+TEST(malformed_parameters_do_not_prevent_matching) {
+  const std::array<std::string_view, 1> ranges{{"text/plain"}};
+  EXPECT_EQ(
+      sourcemeta::core::http_match_media_range("text/plain; charset", ranges),
+      "text/plain");
+}

--- a/test/http/http_parse_media_type_test.cc
+++ b/test/http/http_parse_media_type_test.cc
@@ -1,0 +1,193 @@
+#include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
+
+TEST(simple) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("application/json")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "application");
+  EXPECT_EQ(result.value().subtype, "json");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "");
+}
+
+TEST(structured_syntax_suffix) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("application/geo+json")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "application");
+  EXPECT_EQ(result.value().subtype, "geo+json");
+  EXPECT_EQ(result.value().suffix, "+json");
+  EXPECT_EQ(result.value().parameters, "");
+}
+
+TEST(structured_syntax_suffix_sequence) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("application/geo+json-seq")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "application");
+  EXPECT_EQ(result.value().subtype, "geo+json-seq");
+  EXPECT_EQ(result.value().suffix, "+json-seq");
+  EXPECT_EQ(result.value().parameters, "");
+}
+
+TEST(structured_syntax_suffix_last_plus_wins) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("application/vnd.foo+bar+json")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "application");
+  EXPECT_EQ(result.value().subtype, "vnd.foo+bar+json");
+  EXPECT_EQ(result.value().suffix, "+json");
+  EXPECT_EQ(result.value().parameters, "");
+}
+
+TEST(structured_syntax_suffix_leading_plus) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("application/+json")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "application");
+  EXPECT_EQ(result.value().subtype, "+json");
+  EXPECT_EQ(result.value().suffix, "+json");
+  EXPECT_EQ(result.value().parameters, "");
+}
+
+TEST(structured_syntax_suffix_trailing_plus) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("application/json+")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "application");
+  EXPECT_EQ(result.value().subtype, "json+");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "");
+}
+
+TEST(single_parameter) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("text/html; charset=UTF-8")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "text");
+  EXPECT_EQ(result.value().subtype, "html");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "; charset=UTF-8");
+}
+
+TEST(single_parameter_without_space) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("text/html;charset=UTF-8")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "text");
+  EXPECT_EQ(result.value().subtype, "html");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, ";charset=UTF-8");
+}
+
+TEST(multiple_parameters) {
+  const auto result{sourcemeta::core::http_parse_media_type(
+      "multipart/form-data; boundary=abc; charset=UTF-8")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "multipart");
+  EXPECT_EQ(result.value().subtype, "form-data");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "; boundary=abc; charset=UTF-8");
+}
+
+TEST(parameter_with_quoted_semicolon) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("text/html; x=\"a;b\"")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "text");
+  EXPECT_EQ(result.value().subtype, "html");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "; x=\"a;b\"");
+}
+
+TEST(whitespace_before_parameters) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("text/html ; charset=UTF-8")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "text");
+  EXPECT_EQ(result.value().subtype, "html");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "; charset=UTF-8");
+}
+
+TEST(leading_whitespace) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("   application/json")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "application");
+  EXPECT_EQ(result.value().subtype, "json");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "");
+}
+
+TEST(trailing_whitespace) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("application/json   ")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "application");
+  EXPECT_EQ(result.value().subtype, "json");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "");
+}
+
+TEST(case_is_preserved) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("Application/JSON")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "Application");
+  EXPECT_EQ(result.value().subtype, "JSON");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "");
+}
+
+TEST(range_all) {
+  const auto result{sourcemeta::core::http_parse_media_type("*/*")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "*");
+  EXPECT_EQ(result.value().subtype, "*");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "");
+}
+
+TEST(range_subtype) {
+  const auto result{sourcemeta::core::http_parse_media_type("text/*")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "text");
+  EXPECT_EQ(result.value().subtype, "*");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "");
+}
+
+TEST(invalid_empty) {
+  EXPECT_FALSE(sourcemeta::core::http_parse_media_type("").has_value());
+}
+
+TEST(invalid_no_slash) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_parse_media_type("application").has_value());
+}
+
+TEST(invalid_empty_type) {
+  EXPECT_FALSE(sourcemeta::core::http_parse_media_type("/json").has_value());
+}
+
+TEST(invalid_empty_subtype) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_parse_media_type("application/").has_value());
+}
+
+TEST(invalid_second_slash) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_parse_media_type("application/a/b").has_value());
+}
+
+TEST(invalid_space_within) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_parse_media_type("application/j son").has_value());
+}
+
+TEST(invalid_mime_comment) {
+  EXPECT_FALSE(sourcemeta::core::http_parse_media_type("text/plain(comment)")
+                   .has_value());
+}

--- a/test/http/http_parse_media_type_test.cc
+++ b/test/http/http_parse_media_type_test.cc
@@ -1,6 +1,8 @@
 #include <sourcemeta/core/http.h>
 #include <sourcemeta/core/test.h>
 
+#include <string> // std::string
+
 TEST(simple) {
   const auto result{
       sourcemeta::core::http_parse_media_type("application/json")};
@@ -189,5 +191,107 @@ TEST(invalid_space_within) {
 
 TEST(invalid_mime_comment) {
   EXPECT_FALSE(sourcemeta::core::http_parse_media_type("text/plain(comment)")
+                   .has_value());
+}
+
+TEST(empty_parameter_slot) {
+  const auto result{sourcemeta::core::http_parse_media_type("text/plain;")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "text");
+  EXPECT_EQ(result.value().subtype, "plain");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, ";");
+}
+
+TEST(consecutive_parameter_separators) {
+  const auto result{sourcemeta::core::http_parse_media_type("text/plain;;")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "text");
+  EXPECT_EQ(result.value().subtype, "plain");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, ";;");
+}
+
+TEST(empty_parameter_slot_after_a_parameter) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("text/plain; charset=utf-8;")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "text");
+  EXPECT_EQ(result.value().subtype, "plain");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "; charset=utf-8;");
+}
+
+TEST(quoted_parameter_value) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("text/plain; charset=\"utf-8\"")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "text");
+  EXPECT_EQ(result.value().subtype, "plain");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "; charset=\"utf-8\"");
+}
+
+TEST(quoted_parameter_value_with_a_quoted_pair) {
+  const std::string input{R"(text/plain; x="a\"b")"};
+  const std::string parameters{R"(; x="a\"b")"};
+  const auto result{sourcemeta::core::http_parse_media_type(input)};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "text");
+  EXPECT_EQ(result.value().subtype, "plain");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, parameters);
+}
+
+TEST(parameter_with_trailing_whitespace) {
+  const auto result{
+      sourcemeta::core::http_parse_media_type("text/plain; charset=utf-8   ")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().type, "text");
+  EXPECT_EQ(result.value().subtype, "plain");
+  EXPECT_EQ(result.value().suffix, "");
+  EXPECT_EQ(result.value().parameters, "; charset=utf-8   ");
+}
+
+TEST(invalid_parameter_without_a_value) {
+  EXPECT_FALSE(sourcemeta::core::http_parse_media_type("text/plain; charset")
+                   .has_value());
+}
+
+TEST(invalid_parameter_with_an_empty_value) {
+  EXPECT_FALSE(sourcemeta::core::http_parse_media_type("text/plain; charset=")
+                   .has_value());
+}
+
+TEST(invalid_parameter_with_an_unterminated_quote) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_parse_media_type("text/plain; charset=\"utf-8")
+          .has_value());
+}
+
+TEST(invalid_parameter_with_a_control_character_in_its_value) {
+  EXPECT_FALSE(sourcemeta::core::http_parse_media_type("text/plain; x=\"a\nb\"")
+                   .has_value());
+}
+
+TEST(invalid_whitespace_before_the_parameter_equals) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_parse_media_type("text/plain; charset =utf-8")
+          .has_value());
+}
+
+TEST(invalid_whitespace_after_the_parameter_equals) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_parse_media_type("text/plain; charset= utf-8")
+          .has_value());
+}
+
+TEST(invalid_parameter_name) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_parse_media_type("text/plain; (x)=1").has_value());
+}
+
+TEST(invalid_parameter_without_a_separator) {
+  EXPECT_FALSE(sourcemeta::core::http_parse_media_type("text/plain; a=1 b=2")
                    .has_value());
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

