### PR TITLE
Add a WHATWG `form-urlencoded` body codec to the `uri` module

### DIFF
--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -23,7 +23,7 @@
 #include <string>      // std::string
 #include <string_view> // std::string_view
 #include <type_traits> // std::is_same_v, std::remove_cvref_t
-#include <utility>     // std::pair, std::forward, std::move
+#include <utility>     // std::pair, std::forward
 #include <vector>      // std::vector
 
 /// @defgroup uri URI
@@ -1113,9 +1113,11 @@ public:
 
   /// Decode an "application/x-www-form-urlencoded" body into its name and
   /// value pairs (WHATWG URL Section 5.1), appending them to a container in
-  /// the order they appear and keeping repeats. Each "+" becomes a space and
-  /// each percent escape becomes its octet, while a "%" that is not followed
-  /// by two hexadecimal digits is kept as it appears. For example:
+  /// the order they appear and keeping repeats. Decoding produces bytes the
+  /// input does not carry, so the pairs own their characters rather than
+  /// borrow them. Each "+" becomes a space and each percent escape becomes its
+  /// octet, while a "%" that is not followed by two hexadecimal digits is kept
+  /// as it appears. For example:
   ///
   /// ```cpp
   /// #include <sourcemeta/core/uri.h>
@@ -1131,6 +1133,11 @@ public:
   /// assert(parameters.at(1).second == "x y");
   /// ```
   template <typename Container>
+    requires requires(Container container, Container::value_type entry) {
+      container.emplace_back();
+      entry.first.push_back('\0');
+      entry.second.push_back('\0');
+    }
   static auto parse_form(const std::string_view input, Container &output)
       -> void {
     std::size_t position{0};
@@ -1152,16 +1159,13 @@ public:
       // 0x3D (=), and let value be the bytes, if any, after the first 0x3D
       // (=) up to the end of bytes"
       const auto equals{sequence.find('=')};
-      std::string name;
-      std::string value;
+      auto &entry{output.emplace_back()};
       if (equals == std::string_view::npos) {
-        URI::decode_form_component(sequence, name);
+        URI::decode_form_component(sequence, entry.first);
       } else {
-        URI::decode_form_component(sequence.substr(0, equals), name);
-        URI::decode_form_component(sequence.substr(equals + 1), value);
+        URI::decode_form_component(sequence.substr(0, equals), entry.first);
+        URI::decode_form_component(sequence.substr(equals + 1), entry.second);
       }
-
-      output.emplace_back(std::move(name), std::move(value));
     }
   }
 
@@ -1326,8 +1330,9 @@ private:
   // (SP)" and then percent-decode, which Section 1.3 defines to append a "%"
   // that is not followed by two hexadecimal digits as it appears rather than
   // to fail
+  template <typename Output>
   static auto decode_form_component(const std::string_view input,
-                                    std::string &output) -> void {
+                                    Output &output) -> void {
     output.reserve(output.size() + input.size());
     for (std::size_t position = 0; position < input.size();) {
       const auto character{input[position]};

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -23,7 +23,7 @@
 #include <string>      // std::string
 #include <string_view> // std::string_view
 #include <type_traits> // std::is_same_v, std::remove_cvref_t
-#include <utility>     // std::pair, std::forward
+#include <utility>     // std::pair, std::forward, std::move
 #include <vector>      // std::vector
 
 /// @defgroup uri URI
@@ -1032,6 +1032,139 @@ public:
     return true;
   }
 
+  /// Percent-encode an "application/x-www-form-urlencoded" component (WHATWG
+  /// URL Section 5.2), appending the encoded bytes to the output. Only the
+  /// ASCII alphanumerics and "*", "-", "." and "_" pass through, a space
+  /// becomes "+", and everything else is percent-encoded. Besides a
+  /// `std::string` the sink can be a wiping string for a secret such as a
+  /// client credential. The output must not alias the input. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  /// #include <string>
+  ///
+  /// std::string output;
+  /// sourcemeta::core::URI::escape_form("a b/c", output);
+  /// assert(output == "a+b%2Fc");
+  /// ```
+  template <typename Output>
+  static auto escape_form(const std::string_view input, Output &output)
+      -> void {
+    output.reserve(output.size() + (input.size() * 3));
+    for (const auto character : input) {
+      const auto byte{static_cast<unsigned char>(character)};
+      // WHATWG URL Section 5.2 percent-encodes with the space as plus flag set
+      if (byte == ' ') {
+        output.push_back('+');
+        continue;
+      }
+
+      // WHATWG URL Section 1.3: "The application/x-www-form-urlencoded
+      // percent-encode set contains all code points, except the ASCII
+      // alphanumeric, U+002A (*), U+002D (-), U+002E (.), and U+005F (_)"
+      if (is_alphanum(character) || byte == '*' || byte == '-' || byte == '.' ||
+          byte == '_') {
+        output.push_back(character);
+        continue;
+      }
+
+      // RFC 3986 Section 2.1: percent-encode with uppercase hexadecimal
+      const auto high{static_cast<unsigned char>((byte >> 4U) & 0x0FU)};
+      const auto low{static_cast<unsigned char>(byte & 0x0FU)};
+      output.push_back('%');
+      output.push_back(
+          static_cast<char>(high < 10 ? '0' + high : 'A' + high - 10));
+      output.push_back(
+          static_cast<char>(low < 10 ? '0' + low : 'A' + low - 10));
+    }
+  }
+
+  /// Append a percent-encoded name and value pair to an
+  /// "application/x-www-form-urlencoded" body under construction (WHATWG URL
+  /// Section 5.2), joining it to any preceding pair. The sink holds the body
+  /// being built and must not alias the name or value. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  /// #include <string>
+  ///
+  /// std::string body;
+  /// sourcemeta::core::URI::append_form_parameter(body, "grant_type",
+  ///                                              "client_credentials");
+  /// sourcemeta::core::URI::append_form_parameter(body, "scope",
+  ///                                              "read write");
+  /// assert(body == "grant_type=client_credentials&scope=read+write");
+  /// ```
+  template <typename Output>
+  static auto append_form_parameter(Output &sink, const std::string_view name,
+                                    const std::string_view value) -> void {
+    // WHATWG URL Section 5.2: "If output is not the empty string, then append
+    // U+0026 (&) to output"
+    if (!sink.empty()) {
+      sink.push_back('&');
+    }
+
+    URI::escape_form(name, sink);
+    sink.push_back('=');
+    URI::escape_form(value, sink);
+  }
+
+  /// Decode an "application/x-www-form-urlencoded" body into its name and
+  /// value pairs (WHATWG URL Section 5.1), appending them to a container in
+  /// the order they appear and keeping repeats. Each "+" becomes a space and
+  /// each percent escape becomes its octet, while a "%" that is not followed
+  /// by two hexadecimal digits is kept as it appears. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  /// #include <string>
+  /// #include <utility>
+  /// #include <vector>
+  ///
+  /// std::vector<std::pair<std::string, std::string>> parameters;
+  /// sourcemeta::core::URI::parse_form("a=1&b=x+y", parameters);
+  /// assert(parameters.size() == 2);
+  /// assert(parameters.at(1).first == "b");
+  /// assert(parameters.at(1).second == "x y");
+  /// ```
+  template <typename Container>
+  static auto parse_form(const std::string_view input, Container &output)
+      -> void {
+    std::size_t position{0};
+    while (position <= input.size()) {
+      const auto separator{input.find('&', position)};
+      const auto end{separator == std::string_view::npos ? input.size()
+                                                         : separator};
+      const auto sequence{input.substr(position, end - position)};
+      position = end + 1;
+
+      // WHATWG URL Section 5.1: "If bytes is the empty byte sequence, then
+      // continue"
+      if (sequence.empty()) {
+        continue;
+      }
+
+      // WHATWG URL Section 5.1: "If bytes contains a 0x3D (=), then let name
+      // be the bytes from the start of bytes up to but excluding its first
+      // 0x3D (=), and let value be the bytes, if any, after the first 0x3D
+      // (=) up to the end of bytes"
+      const auto equals{sequence.find('=')};
+      std::string name;
+      std::string value;
+      if (equals == std::string_view::npos) {
+        URI::decode_form_component(sequence, name);
+      } else {
+        URI::decode_form_component(sequence.substr(0, equals), name);
+        URI::decode_form_component(sequence.substr(equals + 1), value);
+      }
+
+      output.emplace_back(std::move(name), std::move(value));
+    }
+  }
+
   /// Remove the "." and ".." segments from a URI path per RFC 3986 Section
   /// 5.2.4, preserving leading ".." segments in a relative path. For example:
   ///
@@ -1188,6 +1321,37 @@ public:
 
 private:
   auto parse(std::string_view input) -> void;
+
+  // WHATWG URL Section 5.1: "Replace any 0x2B (+) in name and value with 0x20
+  // (SP)" and then percent-decode, which Section 1.3 defines to append a "%"
+  // that is not followed by two hexadecimal digits as it appears rather than
+  // to fail
+  static auto decode_form_component(const std::string_view input,
+                                    std::string &output) -> void {
+    output.reserve(output.size() + input.size());
+    for (std::size_t position = 0; position < input.size();) {
+      const auto character{input[position]};
+      if (character == '+') {
+        output.push_back(' ');
+        position += 1;
+        continue;
+      }
+
+      if (character == '%' && position + 2 < input.size()) {
+        const auto high{hex_digit_value(input[position + 1])};
+        const auto low{high < 0 ? static_cast<std::int8_t>(-1)
+                                : hex_digit_value(input[position + 2])};
+        if (low >= 0) {
+          output.push_back(static_cast<char>((high << 4) | low));
+          position += 3;
+          continue;
+        }
+      }
+
+      output.push_back(character);
+      position += 1;
+    }
+  }
 
 // Exporting symbols that depends on the standard C++ library is considered
 // safe.

--- a/test/uri/CMakeLists.txt
+++ b/test/uri/CMakeLists.txt
@@ -38,6 +38,9 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME uri
     uri_escape_test.cc
     uri_unescape_test.cc
     uri_unescape_form_test.cc
+    uri_escape_form_test.cc
+    uri_append_form_parameter_test.cc
+    uri_parse_form_test.cc
     uri_append_query_parameter_test.cc
     uri_normalize_path_test.cc
     uri_resolve_from_test.cc

--- a/test/uri/uri_append_form_parameter_test.cc
+++ b/test/uri/uri_append_form_parameter_test.cc
@@ -1,0 +1,51 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uri.h>
+
+#include <string> // std::string
+
+TEST(single_pair) {
+  std::string body;
+  sourcemeta::core::URI::append_form_parameter(body, "grant_type",
+                                               "client_credentials");
+  EXPECT_EQ(body, "grant_type=client_credentials");
+}
+
+TEST(joins_later_pairs_with_ampersand) {
+  std::string body;
+  sourcemeta::core::URI::append_form_parameter(body, "grant_type",
+                                               "client_credentials");
+  sourcemeta::core::URI::append_form_parameter(body, "scope", "read write");
+  EXPECT_EQ(body, "grant_type=client_credentials&scope=read+write");
+}
+
+TEST(empty_value) {
+  std::string body;
+  sourcemeta::core::URI::append_form_parameter(body, "scope", "");
+  EXPECT_EQ(body, "scope=");
+}
+
+TEST(empty_name) {
+  std::string body;
+  sourcemeta::core::URI::append_form_parameter(body, "", "value");
+  EXPECT_EQ(body, "=value");
+}
+
+TEST(the_name_is_encoded_too) {
+  std::string body;
+  sourcemeta::core::URI::append_form_parameter(body, "a b", "c d");
+  EXPECT_EQ(body, "a+b=c+d");
+}
+
+TEST(delimiters_in_a_value_are_encoded) {
+  std::string body;
+  sourcemeta::core::URI::append_form_parameter(body, "a", "x=1&y=2");
+  sourcemeta::core::URI::append_form_parameter(body, "b", "2");
+  EXPECT_EQ(body, "a=x%3D1%26y%3D2&b=2");
+}
+
+TEST(rfc6749_appendix_b_example) {
+  std::string body;
+  sourcemeta::core::URI::append_form_parameter(body, "value",
+                                               " %&+\xC2\xA3\xE2\x82\xAC");
+  EXPECT_EQ(body, "value=+%25%26%2B%C2%A3%E2%82%AC");
+}

--- a/test/uri/uri_escape_form_test.cc
+++ b/test/uri/uri_escape_form_test.cc
@@ -1,0 +1,88 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uri.h>
+
+#include <string> // std::string
+
+TEST(alphanumerics_pass_through) {
+  std::string output;
+  sourcemeta::core::URI::escape_form("abcXYZ019", output);
+  EXPECT_EQ(output, "abcXYZ019");
+}
+
+TEST(the_unencoded_punctuation_passes_through) {
+  std::string output;
+  sourcemeta::core::URI::escape_form("*-._", output);
+  EXPECT_EQ(output, "*-._");
+}
+
+TEST(space_becomes_plus) {
+  std::string output;
+  sourcemeta::core::URI::escape_form("a b c", output);
+  EXPECT_EQ(output, "a+b+c");
+}
+
+TEST(tilde_is_encoded) {
+  std::string output;
+  sourcemeta::core::URI::escape_form("~", output);
+  EXPECT_EQ(output, "%7E");
+}
+
+TEST(asterisk_is_not_encoded) {
+  std::string output;
+  sourcemeta::core::URI::escape_form("*", output);
+  EXPECT_EQ(output, "*");
+}
+
+TEST(plus_is_encoded) {
+  std::string output;
+  sourcemeta::core::URI::escape_form("+", output);
+  EXPECT_EQ(output, "%2B");
+}
+
+TEST(percent_is_encoded) {
+  std::string output;
+  sourcemeta::core::URI::escape_form("%", output);
+  EXPECT_EQ(output, "%25");
+}
+
+TEST(delimiters_are_encoded) {
+  std::string output;
+  sourcemeta::core::URI::escape_form("&=", output);
+  EXPECT_EQ(output, "%26%3D");
+}
+
+TEST(reserved_characters_are_encoded) {
+  std::string output;
+  sourcemeta::core::URI::escape_form("/?:@!$'()", output);
+  EXPECT_EQ(output, "%2F%3F%3A%40%21%24%27%28%29");
+}
+
+TEST(non_ascii_is_encoded_in_uppercase_hexadecimal) {
+  std::string output;
+  sourcemeta::core::URI::escape_form("\xC2\xA3", output);
+  EXPECT_EQ(output, "%C2%A3");
+}
+
+TEST(control_characters_are_encoded) {
+  std::string output;
+  sourcemeta::core::URI::escape_form("\n\t", output);
+  EXPECT_EQ(output, "%0A%09");
+}
+
+TEST(empty_input) {
+  std::string output;
+  sourcemeta::core::URI::escape_form("", output);
+  EXPECT_EQ(output, "");
+}
+
+TEST(appends_to_existing_output) {
+  std::string output{"prefix="};
+  sourcemeta::core::URI::escape_form("a b", output);
+  EXPECT_EQ(output, "prefix=a+b");
+}
+
+TEST(rfc6749_appendix_b_example) {
+  std::string output;
+  sourcemeta::core::URI::escape_form(" %&+\xC2\xA3\xE2\x82\xAC", output);
+  EXPECT_EQ(output, "+%25%26%2B%C2%A3%E2%82%AC");
+}

--- a/test/uri/uri_parse_form_test.cc
+++ b/test/uri/uri_parse_form_test.cc
@@ -1,0 +1,187 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uri.h>
+
+#include <string>  // std::string
+#include <utility> // std::pair
+#include <vector>  // std::vector
+
+using Parameters = std::vector<std::pair<std::string, std::string>>;
+
+TEST(two_pairs) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a=1&b=2", parameters);
+  EXPECT_EQ(parameters.size(), 2);
+  EXPECT_EQ(parameters.at(0).first, "a");
+  EXPECT_EQ(parameters.at(0).second, "1");
+  EXPECT_EQ(parameters.at(1).first, "b");
+  EXPECT_EQ(parameters.at(1).second, "2");
+}
+
+TEST(plus_becomes_space) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a+b=c+d", parameters);
+  EXPECT_EQ(parameters.size(), 1);
+  EXPECT_EQ(parameters.at(0).first, "a b");
+  EXPECT_EQ(parameters.at(0).second, "c d");
+}
+
+TEST(percent_escapes_are_decoded) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a%2Fb=c%26d", parameters);
+  EXPECT_EQ(parameters.size(), 1);
+  EXPECT_EQ(parameters.at(0).first, "a/b");
+  EXPECT_EQ(parameters.at(0).second, "c&d");
+}
+
+TEST(lowercase_hexadecimal_escapes_are_decoded) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a=%c2%a3", parameters);
+  EXPECT_EQ(parameters.size(), 1);
+  EXPECT_EQ(parameters.at(0).first, "a");
+  EXPECT_EQ(parameters.at(0).second, "\xC2\xA3");
+}
+
+TEST(a_sequence_without_an_equals_has_an_empty_value) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a&b=2", parameters);
+  EXPECT_EQ(parameters.size(), 2);
+  EXPECT_EQ(parameters.at(0).first, "a");
+  EXPECT_EQ(parameters.at(0).second, "");
+  EXPECT_EQ(parameters.at(1).first, "b");
+  EXPECT_EQ(parameters.at(1).second, "2");
+}
+
+TEST(a_leading_equals_gives_an_empty_name) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("=1", parameters);
+  EXPECT_EQ(parameters.size(), 1);
+  EXPECT_EQ(parameters.at(0).first, "");
+  EXPECT_EQ(parameters.at(0).second, "1");
+}
+
+TEST(a_trailing_equals_gives_an_empty_value) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a=", parameters);
+  EXPECT_EQ(parameters.size(), 1);
+  EXPECT_EQ(parameters.at(0).first, "a");
+  EXPECT_EQ(parameters.at(0).second, "");
+}
+
+TEST(only_the_first_equals_splits) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a=b=c", parameters);
+  EXPECT_EQ(parameters.size(), 1);
+  EXPECT_EQ(parameters.at(0).first, "a");
+  EXPECT_EQ(parameters.at(0).second, "b=c");
+}
+
+TEST(empty_sequences_are_skipped) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a=1&&b=2", parameters);
+  EXPECT_EQ(parameters.size(), 2);
+  EXPECT_EQ(parameters.at(0).first, "a");
+  EXPECT_EQ(parameters.at(0).second, "1");
+  EXPECT_EQ(parameters.at(1).first, "b");
+  EXPECT_EQ(parameters.at(1).second, "2");
+}
+
+TEST(only_ampersands_yield_no_pairs) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("&&&", parameters);
+  EXPECT_TRUE(parameters.empty());
+}
+
+TEST(a_lone_equals_is_a_pair) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a=1&=&b=2", parameters);
+  EXPECT_EQ(parameters.size(), 3);
+  EXPECT_EQ(parameters.at(0).first, "a");
+  EXPECT_EQ(parameters.at(0).second, "1");
+  EXPECT_EQ(parameters.at(1).first, "");
+  EXPECT_EQ(parameters.at(1).second, "");
+  EXPECT_EQ(parameters.at(2).first, "b");
+  EXPECT_EQ(parameters.at(2).second, "2");
+}
+
+TEST(repeats_are_kept_in_order) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a=1&a=2&a=3", parameters);
+  EXPECT_EQ(parameters.size(), 3);
+  EXPECT_EQ(parameters.at(0).first, "a");
+  EXPECT_EQ(parameters.at(0).second, "1");
+  EXPECT_EQ(parameters.at(1).first, "a");
+  EXPECT_EQ(parameters.at(1).second, "2");
+  EXPECT_EQ(parameters.at(2).first, "a");
+  EXPECT_EQ(parameters.at(2).second, "3");
+}
+
+TEST(a_trailing_ampersand_yields_no_extra_pair) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a=1&", parameters);
+  EXPECT_EQ(parameters.size(), 1);
+  EXPECT_EQ(parameters.at(0).first, "a");
+  EXPECT_EQ(parameters.at(0).second, "1");
+}
+
+TEST(empty_input_yields_no_pairs) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("", parameters);
+  EXPECT_TRUE(parameters.empty());
+}
+
+TEST(an_incomplete_escape_is_kept_as_it_appears) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a=%zz", parameters);
+  EXPECT_EQ(parameters.size(), 1);
+  EXPECT_EQ(parameters.at(0).first, "a");
+  EXPECT_EQ(parameters.at(0).second, "%zz");
+}
+
+TEST(a_trailing_percent_is_kept_as_it_appears) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a=%", parameters);
+  EXPECT_EQ(parameters.size(), 1);
+  EXPECT_EQ(parameters.at(0).first, "a");
+  EXPECT_EQ(parameters.at(0).second, "%");
+}
+
+TEST(a_truncated_escape_is_kept_as_it_appears) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("a=%4", parameters);
+  EXPECT_EQ(parameters.size(), 1);
+  EXPECT_EQ(parameters.at(0).first, "a");
+  EXPECT_EQ(parameters.at(0).second, "%4");
+}
+
+TEST(appends_to_an_existing_container) {
+  Parameters parameters;
+  parameters.emplace_back("existing", "value");
+  sourcemeta::core::URI::parse_form("a=1", parameters);
+  EXPECT_EQ(parameters.size(), 2);
+  EXPECT_EQ(parameters.at(0).first, "existing");
+  EXPECT_EQ(parameters.at(0).second, "value");
+  EXPECT_EQ(parameters.at(1).first, "a");
+  EXPECT_EQ(parameters.at(1).second, "1");
+}
+
+TEST(rfc6749_appendix_b_example) {
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form("value=+%25%26%2B%C2%A3%E2%82%AC",
+                                    parameters);
+  EXPECT_EQ(parameters.size(), 1);
+  EXPECT_EQ(parameters.at(0).first, "value");
+  EXPECT_EQ(parameters.at(0).second, " %&+\xC2\xA3\xE2\x82\xAC");
+}
+
+TEST(round_trip_through_the_serializer) {
+  std::string body;
+  sourcemeta::core::URI::append_form_parameter(body, "a b", "c&d=e");
+  sourcemeta::core::URI::append_form_parameter(body, "~", "*");
+  Parameters parameters;
+  sourcemeta::core::URI::parse_form(body, parameters);
+  EXPECT_EQ(parameters.size(), 2);
+  EXPECT_EQ(parameters.at(0).first, "a b");
+  EXPECT_EQ(parameters.at(0).second, "c&d=e");
+  EXPECT_EQ(parameters.at(1).first, "~");
+  EXPECT_EQ(parameters.at(1).second, "*");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

