### PR TITLE
Stop building the vendored GoogleBenchmark with warnings as errors

### DIFF
--- a/cmake/FindGoogleBenchmark.cmake
+++ b/cmake/FindGoogleBenchmark.cmake
@@ -1,5 +1,10 @@
 if(NOT Benchmark_FOUND)
   set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "enable testing of the benchmark library")
+
+  # This library compiles its own sources with warnings as errors, and those
+  # warnings are not ours to answer for on every compiler that we support
+  set(BENCHMARK_ENABLE_WERROR OFF CACHE BOOL "enable warnings as errors when building the benchmark library")
+
   add_subdirectory("${PROJECT_SOURCE_DIR}/vendor/googlebenchmark")
 
   # Consumers run static analysis over their own benchmark sources, and the


### PR DESCRIPTION
See: https://github.com/sourcemeta/blaze/issues/1017
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

