### PR TITLE
Cover the missing-lookup branches of PointerPositionTracker::get

### DIFF
--- a/test/jsonpointer/jsonpointer_position_test.cc
+++ b/test/jsonpointer/jsonpointer_position_test.cc
@@ -67,6 +67,28 @@ TEST(track_index_token_against_array_element) {
             sourcemeta::core::PointerPositionTracker::Position({1, 7, 1, 8}));
 }
 
+TEST(get_missing_property) {
+  const auto *const input{R"JSON({ "foo": 1 })JSON"};
+
+  sourcemeta::core::PointerPositionTracker tracker;
+  sourcemeta::core::JSON result{nullptr};
+  sourcemeta::core::parse_json(input, result, std::ref(tracker));
+
+  const sourcemeta::core::Pointer pointer{"bar"};
+  EXPECT_FALSE(tracker.get(pointer).has_value());
+}
+
+TEST(get_missing_index_against_array) {
+  const auto *const input{R"JSON([ 10, 20 ])JSON"};
+
+  sourcemeta::core::PointerPositionTracker tracker;
+  sourcemeta::core::JSON result{nullptr};
+  sourcemeta::core::parse_json(input, result, std::ref(tracker));
+
+  const auto pointer{sourcemeta::core::to_pointer("/5")};
+  EXPECT_FALSE(tracker.get(pointer).has_value());
+}
+
 TEST(to_json_1) {
   const auto *const input{R"JSON([
   {


### PR DESCRIPTION
Neither branch of `PointerPositionTracker::get` that returns `std::nullopt` had a test: the plain property-miss path, and the case where an index lookup misses and falls through to the RFC 6901 digit-string-as-property fallback, which also misses. Both are reachable any time a caller queries a pointer that does not exist in the tracked document, which is a normal outcome for callers using this to report positions for arbitrary user-supplied JSON Pointers (for example when producing diagnostics for a pointer that came from elsewhere and may not resolve).

Added two tests to jsonpointer_position_test.cc covering these two branches directly, following the existing file's structure.

Verified with `cmake --build ./build --target sourcemeta_core_jsonpointer_unit` followed by running the resulting binary: all 816 tests pass, including the two new ones. Also ran `cmake --build ./build --target clang_format`, which made no changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

