### PR TITLE
Cover the router trie structure exposed by root()

### DIFF
--- a/test/uritemplate/uritemplate_router_test.cc
+++ b/test/uritemplate/uritemplate_router_test.cc
@@ -3169,41 +3169,37 @@ TEST(root_reflects_literal_variable_expansion_and_optional_expansion_nodes) {
   EXPECT_EQ(assets.identifier, 0);
   EXPECT_TRUE(assets.literals.empty());
   EXPECT_TRUE(assets.variable);
-  if (assets.variable) {
-    EXPECT_EQ(assets.variable->type,
-              sourcemeta::core::URITemplateRouter::NodeType::OptionalExpansion);
-    EXPECT_EQ(assets.variable->value, "rest");
-    EXPECT_EQ(assets.variable->identifier, 4);
-  }
+  EXPECT_EQ(assets.variable->type,
+            sourcemeta::core::URITemplateRouter::NodeType::OptionalExpansion);
+  EXPECT_EQ(assets.variable->value, "rest");
+  EXPECT_EQ(assets.variable->identifier, 4);
 
   const auto &files = *root.literals.at(1);
+  EXPECT_EQ(files.type, sourcemeta::core::URITemplateRouter::NodeType::Literal);
   EXPECT_EQ(files.value, "files");
   EXPECT_EQ(files.identifier, 0);
   EXPECT_TRUE(files.variable);
-  if (files.variable) {
-    EXPECT_EQ(files.variable->type,
-              sourcemeta::core::URITemplateRouter::NodeType::Expansion);
-    EXPECT_EQ(files.variable->value, "path");
-    EXPECT_EQ(files.variable->identifier, 3);
-  }
+  EXPECT_EQ(files.variable->type,
+            sourcemeta::core::URITemplateRouter::NodeType::Expansion);
+  EXPECT_EQ(files.variable->value, "path");
+  EXPECT_EQ(files.variable->identifier, 3);
 
   const auto &users = *root.literals.at(2);
+  EXPECT_EQ(users.type, sourcemeta::core::URITemplateRouter::NodeType::Literal);
   EXPECT_EQ(users.value, "users");
   EXPECT_EQ(users.identifier, 1);
   EXPECT_TRUE(users.variable);
-  if (users.variable) {
-    EXPECT_EQ(users.variable->type,
-              sourcemeta::core::URITemplateRouter::NodeType::Variable);
-    EXPECT_EQ(users.variable->value, "id");
-    EXPECT_EQ(users.variable->identifier, 2);
-  }
+  EXPECT_EQ(users.variable->type,
+            sourcemeta::core::URITemplateRouter::NodeType::Variable);
+  EXPECT_EQ(users.variable->value, "id");
+  EXPECT_EQ(users.variable->identifier, 2);
 }
 
 TEST(root_literals_are_sorted_and_nest_across_multiple_segments) {
   sourcemeta::core::URITemplateRouter router;
-  router.add("/apple", "op_nest_1", 1);
-  router.add("/zebra/a/b", "op_nest_2", 2);
   router.add("/zebra/a/c", "op_nest_3", 3);
+  router.add("/zebra/a/b", "op_nest_2", 2);
+  router.add("/apple", "op_nest_1", 1);
 
   const auto &root = router.root();
   EXPECT_EQ(root.literals.size(), 2);

--- a/test/uritemplate/uritemplate_router_test.cc
+++ b/test/uritemplate/uritemplate_router_test.cc
@@ -3148,3 +3148,79 @@ TEST(add_rejects_a_variable_then_literal_segment) {
     FAIL();
   }
 }
+
+TEST(root_reflects_literal_variable_expansion_and_optional_expansion_nodes) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/users", "op_root_1", 1);
+  router.add("/users/{id}", "op_root_2", 2);
+  router.add("/files/{+path}", "op_root_3", 3);
+  router.add("/assets/{/rest*}", "op_root_4", 4);
+
+  const auto &root = router.root();
+  EXPECT_EQ(root.type, sourcemeta::core::URITemplateRouter::NodeType::Root);
+  EXPECT_EQ(root.identifier, 0);
+  EXPECT_FALSE(root.variable);
+  EXPECT_EQ(root.literals.size(), 3);
+
+  const auto &assets = *root.literals.at(0);
+  EXPECT_EQ(assets.type,
+            sourcemeta::core::URITemplateRouter::NodeType::Literal);
+  EXPECT_EQ(assets.value, "assets");
+  EXPECT_EQ(assets.identifier, 0);
+  EXPECT_TRUE(assets.literals.empty());
+  EXPECT_TRUE(assets.variable);
+  if (assets.variable) {
+    EXPECT_EQ(assets.variable->type,
+              sourcemeta::core::URITemplateRouter::NodeType::OptionalExpansion);
+    EXPECT_EQ(assets.variable->value, "rest");
+    EXPECT_EQ(assets.variable->identifier, 4);
+  }
+
+  const auto &files = *root.literals.at(1);
+  EXPECT_EQ(files.value, "files");
+  EXPECT_EQ(files.identifier, 0);
+  EXPECT_TRUE(files.variable);
+  if (files.variable) {
+    EXPECT_EQ(files.variable->type,
+              sourcemeta::core::URITemplateRouter::NodeType::Expansion);
+    EXPECT_EQ(files.variable->value, "path");
+    EXPECT_EQ(files.variable->identifier, 3);
+  }
+
+  const auto &users = *root.literals.at(2);
+  EXPECT_EQ(users.value, "users");
+  EXPECT_EQ(users.identifier, 1);
+  EXPECT_TRUE(users.variable);
+  if (users.variable) {
+    EXPECT_EQ(users.variable->type,
+              sourcemeta::core::URITemplateRouter::NodeType::Variable);
+    EXPECT_EQ(users.variable->value, "id");
+    EXPECT_EQ(users.variable->identifier, 2);
+  }
+}
+
+TEST(root_literals_are_sorted_and_nest_across_multiple_segments) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/apple", "op_nest_1", 1);
+  router.add("/zebra/a/b", "op_nest_2", 2);
+  router.add("/zebra/a/c", "op_nest_3", 3);
+
+  const auto &root = router.root();
+  EXPECT_EQ(root.literals.size(), 2);
+  EXPECT_EQ(root.literals.at(0)->value, "apple");
+  EXPECT_EQ(root.literals.at(1)->value, "zebra");
+
+  const auto &zebra = *root.literals.at(1);
+  EXPECT_EQ(zebra.identifier, 0);
+  EXPECT_FALSE(zebra.variable);
+  EXPECT_EQ(zebra.literals.size(), 1);
+
+  const auto &segment_a = *zebra.literals.at(0);
+  EXPECT_EQ(segment_a.value, "a");
+  EXPECT_EQ(segment_a.identifier, 0);
+  EXPECT_EQ(segment_a.literals.size(), 2);
+  EXPECT_EQ(segment_a.literals.at(0)->value, "b");
+  EXPECT_EQ(segment_a.literals.at(0)->identifier, 2);
+  EXPECT_EQ(segment_a.literals.at(1)->value, "c");
+  EXPECT_EQ(segment_a.literals.at(1)->identifier, 3);
+}


### PR DESCRIPTION
Every existing test in `uritemplate_router_test.cc` only checks `match()` and `describes()` behavior, so nothing verifies that `add()` actually builds the trie correctly. A bug that scrambles node types or child linkage but happens to still match the test paths by coincidence would go undetected today.

This adds two tests that walk `root()` directly:

- One builds a router with literal, variable, expansion, and optional-expansion routes and asserts each resulting node's `type`, `value`, `identifier`, and child structure.
- The other builds nested literal routes and asserts that sibling literals are stored sorted and that a multi-segment literal chain nests correctly, with identifiers only on the routes actually registered.

Verified with a full local build and the `sourcemeta_core_uritemplate_unit` target: 885/885 tests pass (883 existing + 2 new), no new compiler or clang-tidy warnings, `clang_format` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

