### PR TITLE
Scale the YAML alias expansion limit with the input size

### DIFF
--- a/src/core/yaml/lexer.h
+++ b/src/core/yaml/lexer.h
@@ -81,6 +81,11 @@ public:
     return this->bom_length_;
   }
 
+  // The length of the document being tokenised, excluding any byte order mark
+  [[nodiscard]] auto input_size() const noexcept -> std::size_t {
+    return this->input_.size();
+  }
+
   auto next() -> std::optional<Token> {
     if (this->roundtrip_) {
       this->inline_comment_buffer_.reset();

--- a/src/core/yaml/lexer.h
+++ b/src/core/yaml/lexer.h
@@ -81,11 +81,6 @@ public:
     return this->bom_length_;
   }
 
-  // The length of the document being tokenised, excluding any byte order mark
-  [[nodiscard]] auto input_size() const noexcept -> std::size_t {
-    return this->input_.size();
-  }
-
   auto next() -> std::optional<Token> {
     if (this->roundtrip_) {
       this->inline_comment_buffer_.reset();

--- a/src/core/yaml/parser.h
+++ b/src/core/yaml/parser.h
@@ -239,27 +239,28 @@ public:
 private:
   // Cap how many nodes alias expansion may materialise, so that a document
   // cannot expand into a far larger one on attacker-controlled input. The
-  // allowance grows with how much of the document has been read so far, as an
-  // expansion that outgrows the text calling for it by orders of magnitude is
-  // the shape of the attack, whereas a long document that reuses anchors in
-  // earnest grows in step with its own size. Measuring what has been read
-  // rather than what was handed over keeps text that the parser never reaches,
-  // such as the documents that follow this one in a stream, from paying for an
-  // expansion it takes no part in. The floor keeps short documents workable and
-  // the ceiling keeps long ones from claiming an unbounded allowance
+  // allowance grows with the text that stands ahead of the alias drawing on
+  // it, as an expansion that outgrows the text calling for it by orders of
+  // magnitude is the shape of the attack, whereas a long document that reuses
+  // anchors in earnest grows in step with its own size. Measuring the text
+  // ahead rather than the whole of what was handed over keeps everything the
+  // parser has not reached, from a comment sitting behind the alias to the
+  // documents that follow this one in a stream, from paying for an expansion it
+  // takes no part in. The floor keeps short documents workable and the ceiling
+  // keeps long ones from claiming an unbounded allowance
   static constexpr std::size_t MAXIMUM_EXPANDED_NODES{10000000};
   static constexpr std::size_t MINIMUM_EXPANDED_NODES{10000};
   static constexpr std::size_t EXPANDED_NODES_PER_INPUT_BYTE{100};
 
-  [[nodiscard]] auto expansion_budget() const -> std::size_t {
-    const auto consumed{this->lexer_->position()};
-    if (consumed > MAXIMUM_EXPANDED_NODES / EXPANDED_NODES_PER_INPUT_BYTE)
+  [[nodiscard]] static auto expansion_budget(const std::size_t input_read)
+      -> std::size_t {
+    if (input_read > MAXIMUM_EXPANDED_NODES / EXPANDED_NODES_PER_INPUT_BYTE)
         [[unlikely]] {
       return MAXIMUM_EXPANDED_NODES;
     }
 
     return std::max(MINIMUM_EXPANDED_NODES,
-                    consumed * EXPANDED_NODES_PER_INPUT_BYTE);
+                    input_read * EXPANDED_NODES_PER_INPUT_BYTE);
   }
 
   // Cap the recursion depth of the value parser so that a deeply nested
@@ -751,6 +752,9 @@ private:
                                            property, key_line, key_column);
         break;
       case TokenType::Alias: {
+        // Reading the token that follows the alias skips over any comment
+        // between them, so how far the document had been read is settled here
+        const auto input_read{this->position()};
         auto next{this->next_token()};
         if (next.has_value() && next->type == TokenType::BlockMappingValue) {
           const std::string alias_name{current_token.value};
@@ -774,7 +778,7 @@ private:
                                  "Cannot anchor an alias node"};
           }
           result = this->resolve_alias(current_token, context, index, property,
-                                       key_line, key_column);
+                                       input_read, key_line, key_column);
           if (this->roundtrip_ != nullptr) {
             this->roundtrip_->aliases[this->pointer_stack_] =
                 std::string{current_token.value};
@@ -1634,6 +1638,7 @@ private:
 
   auto resolve_alias(const Token &token, const JSON::ParseContext context,
                      const std::size_t index, const std::string &property,
+                     const std::size_t input_read,
                      const std::uint64_t key_line = 0,
                      const std::uint64_t key_column = 0) -> JSON {
     const std::string anchor_name{token.value};
@@ -1686,7 +1691,7 @@ private:
     }
 
     this->expanded_nodes_ += anchored.node_count;
-    if (this->expanded_nodes_ > this->expansion_budget()) [[unlikely]] {
+    if (this->expanded_nodes_ > expansion_budget(input_read)) [[unlikely]] {
       throw YAMLParseError{token.line, token.column,
                            "Maximum YAML alias expansion exceeded"};
     }

--- a/src/core/yaml/parser.h
+++ b/src/core/yaml/parser.h
@@ -9,6 +9,7 @@
 #include <sourcemeta/core/yaml_error.h>
 #include <sourcemeta/core/yaml_roundtrip.h>
 
+#include <algorithm>     // std::max
 #include <cassert>       // assert
 #include <cstdint>       // std::uint64_t, std::int64_t
 #include <optional>      // std::optional
@@ -42,7 +43,8 @@ class Parser {
 public:
   Parser(Lexer *lexer, const JSON::ParseCallback *callback,
          YAMLRoundTrip *roundtrip = nullptr)
-      : lexer_{lexer}, callback_{callback}, roundtrip_{roundtrip} {}
+      : lexer_{lexer}, callback_{callback}, roundtrip_{roundtrip},
+        maximum_expanded_nodes_{expansion_budget(lexer->input_size())} {}
 
   auto parse() -> JSON {
     std::optional<Token> token;
@@ -236,7 +238,27 @@ public:
   }
 
 private:
+  // Cap how many nodes alias expansion may materialise, so that a document
+  // cannot expand into a far larger one on attacker-controlled input. The
+  // allowance grows with the length of the document, as an expansion that
+  // outgrows the text describing it by orders of magnitude is the shape of the
+  // attack, whereas a long document that reuses anchors in earnest grows in
+  // step with its own size. The floor keeps short documents workable and the
+  // ceiling keeps long ones from claiming an unbounded allowance
   static constexpr std::size_t MAXIMUM_EXPANDED_NODES{10000000};
+  static constexpr std::size_t MINIMUM_EXPANDED_NODES{10000};
+  static constexpr std::size_t EXPANDED_NODES_PER_INPUT_BYTE{100};
+
+  [[nodiscard]] static auto expansion_budget(const std::size_t input_size)
+      -> std::size_t {
+    if (input_size > MAXIMUM_EXPANDED_NODES / EXPANDED_NODES_PER_INPUT_BYTE)
+        [[unlikely]] {
+      return MAXIMUM_EXPANDED_NODES;
+    }
+
+    return std::max(MINIMUM_EXPANDED_NODES,
+                    input_size * EXPANDED_NODES_PER_INPUT_BYTE);
+  }
 
   // Cap the recursion depth of the value parser so that a deeply nested
   // document cannot overflow the stack on attacker-controlled input. The bound
@@ -1662,7 +1684,7 @@ private:
     }
 
     this->expanded_nodes_ += anchored.node_count;
-    if (this->expanded_nodes_ > MAXIMUM_EXPANDED_NODES) [[unlikely]] {
+    if (this->expanded_nodes_ > this->maximum_expanded_nodes_) [[unlikely]] {
       throw YAMLParseError{token.line, token.column,
                            "Maximum YAML alias expansion exceeded"};
     }
@@ -2254,6 +2276,7 @@ private:
   bool recording_anchor_{false};
   bool indent_width_detected_{false};
   std::size_t expanded_nodes_{0};
+  std::size_t maximum_expanded_nodes_;
   std::vector<CallbackRecord> current_anchor_callbacks_;
   std::deque<Token> pending_tokens_;
   std::optional<std::size_t> pending_token_position_;

--- a/src/core/yaml/parser.h
+++ b/src/core/yaml/parser.h
@@ -43,8 +43,7 @@ class Parser {
 public:
   Parser(Lexer *lexer, const JSON::ParseCallback *callback,
          YAMLRoundTrip *roundtrip = nullptr)
-      : lexer_{lexer}, callback_{callback}, roundtrip_{roundtrip},
-        maximum_expanded_nodes_{expansion_budget(lexer->input_size())} {}
+      : lexer_{lexer}, callback_{callback}, roundtrip_{roundtrip} {}
 
   auto parse() -> JSON {
     std::optional<Token> token;
@@ -240,24 +239,27 @@ public:
 private:
   // Cap how many nodes alias expansion may materialise, so that a document
   // cannot expand into a far larger one on attacker-controlled input. The
-  // allowance grows with the length of the document, as an expansion that
-  // outgrows the text describing it by orders of magnitude is the shape of the
-  // attack, whereas a long document that reuses anchors in earnest grows in
-  // step with its own size. The floor keeps short documents workable and the
-  // ceiling keeps long ones from claiming an unbounded allowance
+  // allowance grows with how much of the document has been read so far, as an
+  // expansion that outgrows the text calling for it by orders of magnitude is
+  // the shape of the attack, whereas a long document that reuses anchors in
+  // earnest grows in step with its own size. Measuring what has been read
+  // rather than what was handed over keeps text that the parser never reaches,
+  // such as the documents that follow this one in a stream, from paying for an
+  // expansion it takes no part in. The floor keeps short documents workable and
+  // the ceiling keeps long ones from claiming an unbounded allowance
   static constexpr std::size_t MAXIMUM_EXPANDED_NODES{10000000};
   static constexpr std::size_t MINIMUM_EXPANDED_NODES{10000};
   static constexpr std::size_t EXPANDED_NODES_PER_INPUT_BYTE{100};
 
-  [[nodiscard]] static auto expansion_budget(const std::size_t input_size)
-      -> std::size_t {
-    if (input_size > MAXIMUM_EXPANDED_NODES / EXPANDED_NODES_PER_INPUT_BYTE)
+  [[nodiscard]] auto expansion_budget() const -> std::size_t {
+    const auto consumed{this->lexer_->position()};
+    if (consumed > MAXIMUM_EXPANDED_NODES / EXPANDED_NODES_PER_INPUT_BYTE)
         [[unlikely]] {
       return MAXIMUM_EXPANDED_NODES;
     }
 
     return std::max(MINIMUM_EXPANDED_NODES,
-                    input_size * EXPANDED_NODES_PER_INPUT_BYTE);
+                    consumed * EXPANDED_NODES_PER_INPUT_BYTE);
   }
 
   // Cap the recursion depth of the value parser so that a deeply nested
@@ -1684,7 +1686,7 @@ private:
     }
 
     this->expanded_nodes_ += anchored.node_count;
-    if (this->expanded_nodes_ > this->maximum_expanded_nodes_) [[unlikely]] {
+    if (this->expanded_nodes_ > this->expansion_budget()) [[unlikely]] {
       throw YAMLParseError{token.line, token.column,
                            "Maximum YAML alias expansion exceeded"};
     }
@@ -2276,7 +2278,6 @@ private:
   bool recording_anchor_{false};
   bool indent_width_detected_{false};
   std::size_t expanded_nodes_{0};
-  std::size_t maximum_expanded_nodes_;
   std::vector<CallbackRecord> current_anchor_callbacks_;
   std::deque<Token> pending_tokens_;
   std::optional<std::size_t> pending_token_position_;

--- a/test/yaml/yaml_parse_test.cc
+++ b/test/yaml/yaml_parse_test.cc
@@ -840,6 +840,28 @@ TEST(alias_expansion_allowance_scales_with_the_input) {
   EXPECT_EQ(result.at("e").at(9).at(9).at(9).at(9), expected_leaf);
 }
 
+// The allowance an alias draws on is fixed by the text ahead of it, so a
+// comment sitting behind it buys nothing even though reading the token that
+// follows the alias skips over that comment first
+TEST(alias_expansion_allowance_ignores_a_comment_behind_the_alias) {
+  const std::string input{"a: &a [ x, x, x, x, x, x, x, x, x, x ]\n"
+                          "b: &b [ *a, *a, *a, *a, *a, *a, *a, *a, *a, *a ]\n"
+                          "c: &c [ *b, *b, *b, *b, *b, *b, *b, *b, *b, *b ]\n"
+                          "d: &d [ *c, *c, *c, *c, *c, *c, *c, *c, *c, *c ]\n"
+                          "e: *d #" +
+                          std::string(2000, 'x') + "\n"};
+
+  try {
+    sourcemeta::core::parse_yaml(input);
+    FAIL();
+  } catch (const sourcemeta::core::YAMLParseError &error) {
+    EXPECT_EQ(error.line(), 5);
+    EXPECT_EQ(error.column(), 4);
+  } catch (...) {
+    FAIL();
+  }
+}
+
 // Text the parser has not reached cannot pay for an expansion it takes no part
 // in, so trailing content leaves the allowance where it stood. This is what
 // keeps a short document from buying room out of the documents that follow it

--- a/test/yaml/yaml_parse_test.cc
+++ b/test/yaml/yaml_parse_test.cc
@@ -804,7 +804,61 @@ TEST(exponential_alias_expansion_is_bounded) {
     FAIL();
   } catch (const sourcemeta::core::YAMLParseError &error) {
     EXPECT_EQ(error.line(), 5);
-    EXPECT_EQ(error.column(), 17);
+    EXPECT_EQ(error.column(), 9);
+  } catch (...) {
+    FAIL();
+  }
+}
+
+// The allowance is a ratio to the text that has been read rather than a fixed
+// count, so the very same aliases are turned away in a short document and
+// expanded in full in a long one
+TEST(alias_expansion_allowance_scales_with_the_input) {
+  const std::string aliases{"a: &a [ x, x, x, x, x, x, x, x, x, x ]\n"
+                            "b: &b [ *a, *a, *a, *a, *a, *a, *a, *a, *a, *a ]\n"
+                            "c: &c [ *b, *b, *b, *b, *b, *b, *b, *b, *b, *b ]\n"
+                            "d: &d [ *c, *c, *c, *c, *c, *c, *c, *c, *c, *c ]\n"
+                            "e: [ *d, *d, *d, *d, *d, *d, *d, *d, *d, *d ]\n"};
+
+  try {
+    sourcemeta::core::parse_yaml(aliases);
+    FAIL();
+  } catch (const sourcemeta::core::YAMLParseError &error) {
+    EXPECT_EQ(error.line(), 5);
+    EXPECT_EQ(error.column(), 6);
+  } catch (...) {
+    FAIL();
+  }
+
+  const auto result{sourcemeta::core::parse_yaml(
+      "filler: " + std::string(2000, 'x') + "\n" + aliases)};
+
+  const sourcemeta::core::JSON expected_leaf = sourcemeta::core::parse_json(
+      R"JSON([ "x", "x", "x", "x", "x", "x", "x", "x", "x", "x" ])JSON");
+
+  EXPECT_EQ(result.at("e").size(), 10);
+  EXPECT_EQ(result.at("e").at(9).at(9).at(9).at(9), expected_leaf);
+}
+
+// Text the parser has not reached cannot pay for an expansion it takes no part
+// in, so trailing content leaves the allowance where it stood. This is what
+// keeps a short document from buying room out of the documents that follow it
+// in a stream
+TEST(alias_expansion_allowance_ignores_text_after_the_expansion) {
+  const std::string input{"a: &a [ x, x, x, x, x, x, x, x, x, x ]\n"
+                          "b: &b [ *a, *a, *a, *a, *a, *a, *a, *a, *a, *a ]\n"
+                          "c: &c [ *b, *b, *b, *b, *b, *b, *b, *b, *b, *b ]\n"
+                          "d: &d [ *c, *c, *c, *c, *c, *c, *c, *c, *c, *c ]\n"
+                          "e: [ *d, *d, *d, *d, *d, *d, *d, *d, *d, *d ]\n"
+                          "filler: " +
+                          std::string(2000, 'x') + "\n"};
+
+  try {
+    sourcemeta::core::parse_yaml(input);
+    FAIL();
+  } catch (const sourcemeta::core::YAMLParseError &error) {
+    EXPECT_EQ(error.line(), 5);
+    EXPECT_EQ(error.column(), 6);
   } catch (...) {
     FAIL();
   }

--- a/test/yaml/yaml_parse_test.cc
+++ b/test/yaml/yaml_parse_test.cc
@@ -803,11 +803,38 @@ TEST(exponential_alias_expansion_is_bounded) {
     sourcemeta::core::parse_yaml(input);
     FAIL();
   } catch (const sourcemeta::core::YAMLParseError &error) {
-    EXPECT_EQ(error.line(), 7);
-    EXPECT_EQ(error.column(), 37);
+    EXPECT_EQ(error.line(), 5);
+    EXPECT_EQ(error.column(), 17);
   } catch (...) {
     FAIL();
   }
+}
+
+// Reusing an anchor so that the expanded document outgrows the text describing
+// it is ordinary YAML, and stays well within the expansion allowance
+TEST(repeated_alias_expansion_beyond_the_input_length_is_accepted) {
+  const std::string input{"a: &a [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]\n"
+                          "b: [ *a, *a, *a, *a, *a, *a, *a, *a, *a, *a ]\n"};
+
+  const auto result{sourcemeta::core::parse_yaml(input)};
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "a": [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+    "b": [
+      [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+      [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+      [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+      [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+      [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+      [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+      [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+      [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+      [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ],
+      [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+    ]
+  })JSON");
+
+  EXPECT_EQ(result, expected);
 }
 
 // A !!float tag whose value is outside the 64-bit integer range must not


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

