### PR TITLE
Reuse sibling module primitives and collapse repetition in the OpenAPI module

### DIFF
--- a/src/core/http/include/sourcemeta/core/http_status.h
+++ b/src/core/http/include/sourcemeta/core/http_status.h
@@ -390,6 +390,28 @@ inline constexpr HTTPStatus HTTP_STATUS_NETWORK_AUTHENTICATION_REQUIRED{
     .wire = "511 Network Authentication Required"};
 
 /// @ingroup http
+///
+/// Check whether a string is a three digit HTTP status code, which RFC 9110
+/// Section 15 gives as three digits whose first is `1` through `5`. This asks
+/// about the form alone, as a code may be well formed without the registry
+/// naming it. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::http_is_status_code("299"));
+/// assert(!sourcemeta::core::http_is_status_code("99"));
+/// assert(!sourcemeta::core::http_is_status_code("2XX"));
+/// ```
+constexpr auto http_is_status_code(const std::string_view value) noexcept
+    -> bool {
+  return value.size() == 3 && value.front() >= '1' && value.front() <= '5' &&
+         value[1] >= '0' && value[1] <= '9' && value[2] >= '0' &&
+         value[2] <= '9';
+}
+
+/// @ingroup http
 /// Resolve a numeric status code into its registered status, with unknown
 /// codes resolving to an empty reason phrase. For example:
 ///

--- a/src/core/openapi/CMakeLists.txt
+++ b/src/core/openapi/CMakeLists.txt
@@ -20,3 +20,5 @@ target_link_libraries(sourcemeta_core_openapi PRIVATE sourcemeta::core::text)
 target_link_libraries(sourcemeta_core_openapi PRIVATE sourcemeta::core::http)
 target_link_libraries(sourcemeta_core_openapi PRIVATE
   sourcemeta::core::unicode)
+target_link_libraries(sourcemeta_core_openapi PRIVATE
+  sourcemeta::core::uritemplate)

--- a/src/core/openapi/content.h
+++ b/src/core/openapi/content.h
@@ -22,7 +22,6 @@ constexpr auto OPENAPI_HASH_EXPLODE{JSON::Object::hash("explode"sv)};
 constexpr auto OPENAPI_HASH_ALLOW_RESERVED{
     JSON::Object::hash("allowReserved"sv)};
 constexpr auto OPENAPI_HASH_REQUIRED{JSON::Object::hash("required"sv)};
-constexpr auto OPENAPI_HASH_DEPRECATED{JSON::Object::hash("deprecated"sv)};
 constexpr auto OPENAPI_HASH_ITEM_SCHEMA{JSON::Object::hash("itemSchema"sv)};
 constexpr auto OPENAPI_HASH_ITEM_ENCODING{JSON::Object::hash("itemEncoding"sv)};
 constexpr auto OPENAPI_HASH_PREFIX_ENCODING{
@@ -66,6 +65,24 @@ constexpr std::array<JSON::StringView, 6> OPENAPI_HEADER_CONTENT_FIELDS_3_2{
 inline auto openapi_check_header_or_reference(const JSON &value,
                                               const Pointer &base,
                                               OpenAPIWalk &walk) -> void;
+
+// The Header Objects an Object may map names to, which the Response Object
+// and the Encoding Object each declare the same way
+inline auto openapi_check_headers(const JSON &value, const Pointer &base,
+                                  const char *message, OpenAPIWalk &walk)
+    -> void {
+  const auto *headers{value.try_at("headers", OPENAPI_HASH_HEADERS)};
+  if (headers == nullptr) {
+    return;
+  }
+
+  const auto location{openapi_child(base, "headers"sv)};
+  openapi_expect_object(*headers, location, message);
+  for (const auto &entry : headers->as_object()) {
+    openapi_check_header_or_reference(
+        entry.second, openapi_child(location, entry.first), walk);
+  }
+}
 
 // OpenAPI Specification 3.1.1, Section 4.8.15: "A single encoding definition
 // applied to a single schema property"
@@ -133,23 +150,12 @@ inline auto openapi_check_encoding(const JSON &value, const Pointer &base,
 
   // The specification says media type definitions "SHOULD be in compliance
   // with RFC6838", which is not a requirement, so only the type is checked
-  const auto *content_type{
-      value.try_at("contentType", OPENAPI_HASH_CONTENT_TYPE)};
-  if (content_type != nullptr) {
-    openapi_expect_string(*content_type, base, "contentType"sv,
-                          "The Encoding Object content type must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "contentType"sv, OPENAPI_HASH_CONTENT_TYPE,
+      "The Encoding Object content type must be a string");
 
-  const auto *headers{value.try_at("headers", OPENAPI_HASH_HEADERS)};
-  if (headers != nullptr) {
-    const auto location{openapi_child(base, "headers"sv)};
-    openapi_expect_object(*headers, location,
-                          "The Encoding Object headers must be an object");
-    for (const auto &entry : headers->as_object()) {
-      openapi_check_header_or_reference(
-          entry.second, openapi_child(location, entry.first), walk);
-    }
-  }
+  openapi_check_headers(value, base,
+                        "The Encoding Object headers must be an object", walk);
 
   const auto *style{value.try_at("style", OPENAPI_HASH_STYLE)};
   if (style != nullptr) {
@@ -221,12 +227,8 @@ inline auto openapi_check_media_type(const JSON &value, const Pointer &base,
 inline auto openapi_check_media_type_or_reference(const JSON &value,
                                                   const Pointer &base,
                                                   OpenAPIWalk &walk) -> void {
-  if (openapi_is_reference(value)) {
-    openapi_check_reference(value, base, OpenAPIObjectKind::MediaType, walk);
-    return;
-  }
-
-  openapi_check_media_type(value, base, walk);
+  openapi_check_or_reference<OpenAPIObjectKind::MediaType,
+                             openapi_check_media_type>(value, base, walk);
 }
 
 // The map that the Request Body, Response, Parameter and Header Objects all
@@ -283,12 +285,9 @@ inline auto openapi_check_header(const JSON &value, const Pointer &base,
         "The Header Object does not define this field");
   }
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(*description, base, "description"sv,
-                          "The Header Object description must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "description"sv, OPENAPI_HASH_DESCRIPTION,
+      "The Header Object description must be a string");
 
   const auto *required{value.try_at("required", OPENAPI_HASH_REQUIRED)};
   if (required != nullptr) {
@@ -345,12 +344,8 @@ inline auto openapi_check_header(const JSON &value, const Pointer &base,
 inline auto openapi_check_header_or_reference(const JSON &value,
                                               const Pointer &base,
                                               OpenAPIWalk &walk) -> void {
-  if (openapi_is_reference(value)) {
-    openapi_check_reference(value, base, OpenAPIObjectKind::Header, walk);
-    return;
-  }
-
-  openapi_check_header(value, base, walk);
+  openapi_check_or_reference<OpenAPIObjectKind::Header, openapi_check_header>(
+      value, base, walk);
 }
 
 } // namespace sourcemeta::core

--- a/src/core/openapi/document.h
+++ b/src/core/openapi/document.h
@@ -314,13 +314,11 @@ inline auto openapi_check_document(const JSON &document, OpenAPIWalk &walk)
     }
 
     // Section 4.8.1: "openapi | string | REQUIRED"
-    const auto *version{document.try_at("openapi", OPENAPI_HASH_OPENAPI)};
-    if (version == nullptr) {
-      throw OpenAPIError{EMPTY_POINTER,
-                         "The OpenAPI Description must declare its version"};
-    }
+    const auto &version{openapi_require(
+        document, "openapi"sv, OPENAPI_HASH_OPENAPI, EMPTY_POINTER,
+        "The OpenAPI Description must declare its version")};
 
-    if (!version->is_string()) {
+    if (!version.is_string()) {
       throw OpenAPIError{Pointer{"openapi"},
                          "The OpenAPI version must be a string"};
     }

--- a/src/core/openapi/example.h
+++ b/src/core/openapi/example.h
@@ -40,18 +40,12 @@ inline auto openapi_check_example(const JSON &value, const Pointer &base,
       value, OPENAPI_EXAMPLE_FIELDS_3_1, OPENAPI_EXAMPLE_FIELDS_3_2, base,
       "The Example Object does not define this field", walk);
 
-  const auto *summary{value.try_at("summary", OPENAPI_HASH_SUMMARY)};
-  if (summary != nullptr) {
-    openapi_expect_string(*summary, base, "summary"sv,
-                          "The Example Object summary must be a string");
-  }
+  openapi_check_optional_string(value, base, "summary"sv, OPENAPI_HASH_SUMMARY,
+                                "The Example Object summary must be a string");
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(*description, base, "description"sv,
-                          "The Example Object description must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "description"sv, OPENAPI_HASH_DESCRIPTION,
+      "The Example Object description must be a string");
 
   // OpenAPI Specification 3.2.1, Section 4.19: "dataValue | Any | An example
   // of the data structure [...] If this field is present, `value` MUST be
@@ -111,12 +105,8 @@ inline auto openapi_check_example(const JSON &value, const Pointer &base,
 inline auto openapi_check_example_or_reference(const JSON &value,
                                                const Pointer &base,
                                                OpenAPIWalk &walk) -> void {
-  if (openapi_is_reference(value)) {
-    openapi_check_reference(value, base, OpenAPIObjectKind::Example, walk);
-    return;
-  }
-
-  openapi_check_example(value, base, walk);
+  openapi_check_or_reference<OpenAPIObjectKind::Example, openapi_check_example>(
+      value, base, walk);
 }
 
 // The Parameter, Media Type and Header Objects all carry this pair, and all

--- a/src/core/openapi/external_documentation.h
+++ b/src/core/openapi/external_documentation.h
@@ -34,24 +34,18 @@ inline auto openapi_check_external_documentation(const JSON &value,
   // URI for the target documentation. This MUST be in the form of a URI".
   // Unlike the Server Object, this one does state a requirement on its form,
   // and it names no template variables, so it is checked
-  const auto *url{value.try_at("url", OPENAPI_HASH_URL)};
-  if (url == nullptr) {
-    throw OpenAPIError{base,
-                       "The External Documentation Object must declare a URI"};
-  }
+  const auto &url{
+      openapi_require(value, "url"sv, OPENAPI_HASH_URL, base,
+                      "The External Documentation Object must declare a URI")};
 
   openapi_expect_uri_reference(
-      *url, base, "url"sv,
+      url, base, "url"sv,
       "The External Documentation Object URI must be a string",
       "The External Documentation Object URI must be a URI reference");
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(
-        *description, base, "description"sv,
-        "The External Documentation Object description must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "description"sv, OPENAPI_HASH_DESCRIPTION,
+      "The External Documentation Object description must be a string");
 }
 
 // OpenAPI Specification 3.1.1, Section 4.8.1: "externalDocs | External

--- a/src/core/openapi/frame.cc
+++ b/src/core/openapi/frame.cc
@@ -1,5 +1,6 @@
 #include <sourcemeta/core/openapi.h>
 
+#include <sourcemeta/core/text.h>
 #include <sourcemeta/core/uri.h>
 
 #include "document.h"
@@ -26,10 +27,7 @@ using namespace std::string_view_literals;
 // same map rather than a key the reader has to rebuild
 auto document_of(const sourcemeta::core::JSON::String &uri)
     -> sourcemeta::core::JSON::String {
-  const auto fragment{uri.find('#')};
-  return fragment == sourcemeta::core::JSON::String::npos
-             ? uri
-             : uri.substr(0, fragment);
+  return sourcemeta::core::JSON::String{sourcemeta::core::take_until(uri, '#')};
 }
 
 auto parent_of(const std::map<sourcemeta::core::JSON::String,
@@ -152,28 +150,25 @@ auto check_operation_id_links(
   }
 }
 
-auto optional_string(
-    const std::optional<sourcemeta::core::JSON::StringView> &value)
-    -> sourcemeta::core::JSON {
-  return value.has_value() ? sourcemeta::core::JSON{value.value()}
-                           : sourcemeta::core::JSON{nullptr};
-}
-
 auto info_json(const sourcemeta::core::OpenAPIInfo &info)
     -> sourcemeta::core::JSON {
   auto result{sourcemeta::core::JSON::make_object()};
   result.assign_assume_new("title", sourcemeta::core::JSON{info.title});
   result.assign_assume_new("version", sourcemeta::core::JSON{info.version});
-  result.assign_assume_new("summary", optional_string(info.summary));
-  result.assign_assume_new("description", optional_string(info.description));
+  result.assign_assume_new("summary", sourcemeta::core::to_json(info.summary));
+  result.assign_assume_new("description",
+                           sourcemeta::core::to_json(info.description));
   result.assign_assume_new("termsOfService",
-                           optional_string(info.terms_of_service));
+                           sourcemeta::core::to_json(info.terms_of_service));
 
   if (info.contact.has_value()) {
     auto contact{sourcemeta::core::JSON::make_object()};
-    contact.assign_assume_new("name", optional_string(info.contact->name));
-    contact.assign_assume_new("url", optional_string(info.contact->url));
-    contact.assign_assume_new("email", optional_string(info.contact->email));
+    contact.assign_assume_new("name",
+                              sourcemeta::core::to_json(info.contact->name));
+    contact.assign_assume_new("url",
+                              sourcemeta::core::to_json(info.contact->url));
+    contact.assign_assume_new("email",
+                              sourcemeta::core::to_json(info.contact->email));
     result.assign_assume_new("contact", std::move(contact));
   } else {
     result.assign_assume_new("contact", sourcemeta::core::JSON{nullptr});
@@ -183,9 +178,10 @@ auto info_json(const sourcemeta::core::OpenAPIInfo &info)
     auto license{sourcemeta::core::JSON::make_object()};
     license.assign_assume_new("name",
                               sourcemeta::core::JSON{info.license->name});
-    license.assign_assume_new("identifier",
-                              optional_string(info.license->identifier));
-    license.assign_assume_new("url", optional_string(info.license->url));
+    license.assign_assume_new(
+        "identifier", sourcemeta::core::to_json(info.license->identifier));
+    license.assign_assume_new("url",
+                              sourcemeta::core::to_json(info.license->url));
     result.assign_assume_new("license", std::move(license));
   } else {
     result.assign_assume_new("license", sourcemeta::core::JSON{nullptr});
@@ -466,7 +462,7 @@ auto project(const sourcemeta::core::OpenAPIWalk &walk)
     // only what the Paths Object exposes has any templating to correspond to
     const auto templated{kind == sourcemeta::core::OpenAPIOperationKind::Path};
     const auto templates{
-        templated ? sourcemeta::core::openapi_path_templates(path)
+        templated ? sourcemeta::core::openapi_brace_expressions(path)
                   : std::vector<sourcemeta::core::JSON::StringView>{}};
     if (templated) {
       check_path_parameters(walk, templates, entry->second.parameters);
@@ -582,7 +578,7 @@ OpenAPIFrame::OpenAPIFrame(const JSON &document, const SchemaWalker &walker,
                            const std::uint64_t max_locations)
     : internal_{std::make_unique<Internal>()} {
   auto walk{analyse(document, canonical_base(default_base))};
-  this->internal_->version = openapi_version(document).value();
+  this->internal_->version = walk.version;
   this->internal_->info = walk.info;
   // What the caller passed in is where the entry document was retrieved from,
   // and from 3.2 onwards the document may give itself a URI of its own, which
@@ -756,33 +752,16 @@ auto OpenAPIFrame::to_json() const -> JSON {
     entry.assign_assume_new("origin", JSON{operation.origin});
     entry.assign_assume_new("endpoint", JSON{operation.endpoint});
 
-    auto tags{JSON::make_array()};
-    for (const auto &tag : operation.tags) {
-      tags.push_back(tag.has_value() ? JSON{tag.value()} : JSON{nullptr});
-    }
+    entry.assign_assume_new("tags", sourcemeta::core::to_json(operation.tags));
 
-    entry.assign_assume_new("tags", std::move(tags));
+    entry.assign_assume_new("servers",
+                            sourcemeta::core::to_json(operation.servers));
 
-    auto servers{JSON::make_array()};
-    for (const auto &server : operation.servers) {
-      servers.push_back(JSON{server});
-    }
+    entry.assign_assume_new("security",
+                            sourcemeta::core::to_json(operation.security));
 
-    entry.assign_assume_new("servers", std::move(servers));
-
-    auto security{JSON::make_array()};
-    for (const auto &requirement : operation.security) {
-      security.push_back(JSON{requirement});
-    }
-
-    entry.assign_assume_new("security", std::move(security));
-
-    auto parameters{JSON::make_array()};
-    for (const auto &parameter : operation.parameters) {
-      parameters.push_back(JSON{parameter});
-    }
-
-    entry.assign_assume_new("parameters", std::move(parameters));
+    entry.assign_assume_new("parameters",
+                            sourcemeta::core::to_json(operation.parameters));
     operations.push_back(std::move(entry));
   }
 

--- a/src/core/openapi/helpers.h
+++ b/src/core/openapi/helpers.h
@@ -24,6 +24,7 @@ using namespace std::string_view_literals;
 // OpenAPI Specification 3.1.1, Section 4.9: "The field name MUST begin with
 // `x-`, for example, `x-internal-id`"
 constexpr auto OPENAPI_EXTENSION_PREFIX{"x-"sv};
+constexpr auto OPENAPI_HASH_DEPRECATED{JSON::Object::hash("deprecated"sv)};
 
 constexpr auto OPENAPI_HASH_DESCRIPTION{JSON::Object::hash("description"sv)};
 constexpr auto OPENAPI_HASH_SUMMARY{JSON::Object::hash("summary"sv)};
@@ -594,6 +595,34 @@ inline auto openapi_check_array_of_strings(const JSON &value,
   }
 }
 
+// The expressions a template declares between curly braces. OpenAPI
+// Specification 3.1.1, Section 3.5: "Path templating refers to the usage of
+// template expressions, delimited by curly braces (`{}`), to mark a section of
+// a URL path as replaceable using path parameters", and Section 4.8.5 names
+// server variables the same way. Nothing there says what an unbalanced brace
+// means, so a run that never closes is no expression
+inline auto openapi_brace_expressions(const JSON::StringView value)
+    -> std::vector<JSON::StringView> {
+  std::vector<JSON::StringView> result;
+  std::size_t cursor{0};
+  while (cursor < value.size()) {
+    const auto open{value.find('{', cursor)};
+    if (open == JSON::StringView::npos) {
+      break;
+    }
+
+    const auto close{value.find('}', open)};
+    if (close == JSON::StringView::npos) {
+      break;
+    }
+
+    result.push_back(value.substr(open + 1, close - open - 1));
+    cursor = close + 1;
+  }
+
+  return result;
+}
+
 inline auto openapi_expect_string(const JSON &value, const Pointer &base,
                                   const JSON::StringView field,
                                   const char *message) -> JSON::StringView {
@@ -602,6 +631,34 @@ inline auto openapi_expect_string(const JSON &value, const Pointer &base,
   }
 
   return value.to_string();
+}
+
+// A field an Object may leave out, which is checked only where it is written.
+// The overwhelming majority of what this specification asks of a field is that
+// it holds a string, so that shape is worth reading as one line
+inline auto openapi_check_optional_string(const JSON &value,
+                                          const Pointer &base,
+                                          const JSON::StringView field,
+                                          const JSON::Object::hash_type hash,
+                                          const char *message) -> void {
+  const auto *member{value.try_at(field, hash)};
+  if (member != nullptr) {
+    openapi_expect_string(*member, base, field, message);
+  }
+}
+
+// A field an Object must declare, handed back already found, so that what
+// follows reads what is there rather than what might be
+inline auto openapi_require(const JSON &value, const JSON::StringView field,
+                            const JSON::Object::hash_type hash,
+                            const Pointer &base, const char *message)
+    -> const JSON & {
+  const auto *member{value.try_at(field, hash)};
+  if (member == nullptr) {
+    throw OpenAPIError{base, message};
+  }
+
+  return *member;
 }
 
 // OpenAPI Specification 3.1.1, Section 4.6: "Unless specified otherwise, all

--- a/src/core/openapi/info.h
+++ b/src/core/openapi/info.h
@@ -94,13 +94,11 @@ inline auto openapi_parse_license(const JSON &value, const Pointer &base,
 
   // OpenAPI Specification 3.1.1, Section 4.8.4: "name | string | REQUIRED. The
   // license name used for the API"
-  const auto *name{value.try_at("name", OPENAPI_HASH_NAME)};
-  if (name == nullptr) {
-    throw OpenAPIError{base, "The License Object must declare a name"};
-  }
+  const auto &name{openapi_require(value, "name"sv, OPENAPI_HASH_NAME, base,
+                                   "The License Object must declare a name")};
 
   result.name = openapi_expect_string(
-      *name, base, "name"sv, "The License Object name must be a string");
+      name, base, "name"sv, "The License Object name must be a string");
 
   // The specification states no requirement on the syntax of this field, only
   // that it is "An SPDX license expression for the API", so it is recorded as
@@ -135,44 +133,39 @@ inline auto openapi_parse_info(const JSON &document, OpenAPIWalk &walk)
     -> OpenAPIInfo {
   // OpenAPI Specification 3.1.1, Section 4.8.1: "info | Info Object |
   // REQUIRED. Provides metadata about the API"
-  const auto *value{document.try_at("info", OPENAPI_HASH_INFO)};
-  if (value == nullptr) {
-    throw OpenAPIError{EMPTY_POINTER,
-                       "The OpenAPI Description must provide an Info Object"};
-  }
+  const auto &value{
+      openapi_require(document, "info"sv, OPENAPI_HASH_INFO, EMPTY_POINTER,
+                      "The OpenAPI Description must provide an Info Object")};
 
   const Pointer base{"info"};
   openapi_record(walk, base, OpenAPIObjectKind::Info);
-  if (!value->is_object()) {
+  if (!value.is_object()) {
     throw OpenAPIError{base, "The Info Object must be an object"};
   }
 
-  openapi_reject_unknown_fields(*value, OPENAPI_INFO_FIELDS, base,
+  openapi_reject_unknown_fields(value, OPENAPI_INFO_FIELDS, base,
                                 "The Info Object does not define this field");
 
   OpenAPIInfo result;
 
   // OpenAPI Specification 3.1.1, Section 4.8.2: "title | string | REQUIRED.
   // The title of the API"
-  const auto *title{value->try_at("title", OPENAPI_HASH_TITLE)};
-  if (title == nullptr) {
-    throw OpenAPIError{base, "The Info Object must declare a title"};
-  }
+  const auto &title{openapi_require(value, "title"sv, OPENAPI_HASH_TITLE, base,
+                                    "The Info Object must declare a title")};
 
   result.title = openapi_expect_string(
-      *title, base, "title"sv, "The Info Object title must be a string");
+      title, base, "title"sv, "The Info Object title must be a string");
 
   // OpenAPI Specification 3.1.1, Section 4.8.2: "version | string | REQUIRED.
   // The version of the OpenAPI Document"
-  const auto *version{value->try_at("version", OPENAPI_HASH_VERSION)};
-  if (version == nullptr) {
-    throw OpenAPIError{base, "The Info Object must declare a version"};
-  }
+  const auto &version{
+      openapi_require(value, "version"sv, OPENAPI_HASH_VERSION, base,
+                      "The Info Object must declare a version")};
 
   result.version = openapi_expect_string(
-      *version, base, "version"sv, "The Info Object version must be a string");
+      version, base, "version"sv, "The Info Object version must be a string");
 
-  const auto *summary{value->try_at("summary", OPENAPI_HASH_SUMMARY)};
+  const auto *summary{value.try_at("summary", OPENAPI_HASH_SUMMARY)};
   if (summary != nullptr) {
     result.summary =
         openapi_expect_string(*summary, base, "summary"sv,
@@ -182,7 +175,7 @@ inline auto openapi_parse_info(const JSON &document, OpenAPIWalk &walk)
   // The specification permits CommonMark here but does not require it, so
   // there is nothing to check beyond the type
   const auto *description{
-      value->try_at("description", OPENAPI_HASH_DESCRIPTION)};
+      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
   if (description != nullptr) {
     result.description =
         openapi_expect_string(*description, base, "description"sv,
@@ -192,7 +185,7 @@ inline auto openapi_parse_info(const JSON &document, OpenAPIWalk &walk)
   // OpenAPI Specification 3.1.1, Section 4.8.2: "A URI for the Terms of
   // Service for the API. This MUST be in the form of a URI"
   const auto *terms{
-      value->try_at("termsOfService", OPENAPI_HASH_TERMS_OF_SERVICE)};
+      value.try_at("termsOfService", OPENAPI_HASH_TERMS_OF_SERVICE)};
   if (terms != nullptr) {
     result.terms_of_service = openapi_expect_uri_reference(
         *terms, base, "termsOfService"sv,
@@ -200,13 +193,13 @@ inline auto openapi_parse_info(const JSON &document, OpenAPIWalk &walk)
         "The Info Object terms of service must be a URI reference");
   }
 
-  const auto *contact{value->try_at("contact", OPENAPI_HASH_CONTACT)};
+  const auto *contact{value.try_at("contact", OPENAPI_HASH_CONTACT)};
   if (contact != nullptr) {
     result.contact =
         openapi_parse_contact(*contact, openapi_child(base, "contact"sv), walk);
   }
 
-  const auto *license{value->try_at("license", OPENAPI_HASH_LICENSE)};
+  const auto *license{value.try_at("license", OPENAPI_HASH_LICENSE)};
   if (license != nullptr) {
     result.license =
         openapi_parse_license(*license, openapi_child(base, "license"sv), walk);

--- a/src/core/openapi/link.h
+++ b/src/core/openapi/link.h
@@ -72,12 +72,9 @@ inline auto openapi_check_link(const JSON &value, const Pointer &base,
                           "The Link Object parameters must be an object");
   }
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(*description, base, "description"sv,
-                          "The Link Object description must be a string");
-  }
+  openapi_check_optional_string(value, base, "description"sv,
+                                OPENAPI_HASH_DESCRIPTION,
+                                "The Link Object description must be a string");
 
   const auto *server{value.try_at("server", OPENAPI_HASH_SERVER)};
   if (server != nullptr) {
@@ -104,12 +101,8 @@ inline auto openapi_check_link(const JSON &value, const Pointer &base,
 inline auto openapi_check_link_or_reference(const JSON &value,
                                             const Pointer &base,
                                             OpenAPIWalk &walk) -> void {
-  if (openapi_is_reference(value)) {
-    openapi_check_reference(value, base, OpenAPIObjectKind::Link, walk);
-    return;
-  }
-
-  openapi_check_link(value, base, walk);
+  openapi_check_or_reference<OpenAPIObjectKind::Link, openapi_check_link>(
+      value, base, walk);
 }
 
 } // namespace sourcemeta::core

--- a/src/core/openapi/parameter.h
+++ b/src/core/openapi/parameter.h
@@ -99,21 +99,18 @@ inline auto openapi_check_parameter(const JSON &value, const Pointer &base,
 
   // OpenAPI Specification 3.1.1, Section 4.8.12: "name | string | REQUIRED.
   // The name of the parameter"
-  const auto *name{value.try_at("name", OPENAPI_HASH_NAME)};
-  if (name == nullptr) {
-    throw OpenAPIError{base, "The Parameter Object must declare a name"};
-  }
+  const auto &name{openapi_require(value, "name"sv, OPENAPI_HASH_NAME, base,
+                                   "The Parameter Object must declare a name")};
 
   const auto parameter_name{openapi_expect_string(
-      *name, base, "name"sv, "The Parameter Object name must be a string")};
+      name, base, "name"sv, "The Parameter Object name must be a string")};
 
   // OpenAPI Specification 3.1.1, Section 4.8.12: "in | string | REQUIRED. The
   // location of the parameter. Possible values are `"query"`, `"header"`,
   // `"path"` or `"cookie"`"
-  const auto *location_field{value.try_at("in", OPENAPI_HASH_IN)};
-  if (location_field == nullptr) {
-    throw OpenAPIError{base, "The Parameter Object must declare a location"};
-  }
+  const auto &location_field{
+      openapi_require(value, "in"sv, OPENAPI_HASH_IN, base,
+                      "The Parameter Object must declare a location")};
 
   // OpenAPI Specification 3.2.1, Section 4.12 adds a fifth location,
   // `querystring`, "a parameter that treats the entire URL query string as a
@@ -122,13 +119,13 @@ inline auto openapi_check_parameter(const JSON &value, const Pointer &base,
   const auto parameter_location{
       walk.version == OpenAPIVersion::OPENAPI_3_2
           ? openapi_expect_enumeration(
-                *location_field, base, "in"sv,
+                location_field, base, "in"sv,
                 {"query"sv, "header"sv, "path"sv, "cookie"sv, "querystring"sv},
                 "The Parameter Object location must be a string",
                 "The Parameter Object location is not one this specification "
                 "defines")
           : openapi_expect_enumeration(
-                *location_field, base, "in"sv,
+                location_field, base, "in"sv,
                 {"query"sv, "header"sv, "path"sv, "cookie"sv},
                 "The Parameter Object location must be a string",
                 "The Parameter Object location is not one this specification "
@@ -182,12 +179,9 @@ inline auto openapi_check_parameter(const JSON &value, const Pointer &base,
         "The Parameter Object does not define this field");
   }
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(*description, base, "description"sv,
-                          "The Parameter Object description must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "description"sv, OPENAPI_HASH_DESCRIPTION,
+      "The Parameter Object description must be a string");
 
   const auto *deprecated{value.try_at("deprecated", OPENAPI_HASH_DEPRECATED)};
   if (deprecated != nullptr) {

--- a/src/core/openapi/path_item.h
+++ b/src/core/openapi/path_item.h
@@ -94,12 +94,8 @@ inline auto openapi_check_callbacks(const JSON &value, const Pointer &base,
 inline auto openapi_check_callbacks_or_reference(const JSON &value,
                                                  const Pointer &base,
                                                  OpenAPIWalk &walk) -> void {
-  if (openapi_is_reference(value)) {
-    openapi_check_reference(value, base, OpenAPIObjectKind::Callbacks, walk);
-    return;
-  }
-
-  openapi_check_callbacks(value, base, walk);
+  openapi_check_or_reference<OpenAPIObjectKind::Callbacks,
+                             openapi_check_callbacks>(value, base, walk);
 }
 
 // OpenAPI Specification 3.1.1, Section 4.8.10: "Describes a single API
@@ -126,18 +122,13 @@ inline auto openapi_check_operation(const JSON &value, const Pointer &base,
     }
   }
 
-  const auto *summary{value.try_at("summary", OPENAPI_HASH_SUMMARY)};
-  if (summary != nullptr) {
-    openapi_expect_string(*summary, base, "summary"sv,
-                          "The Operation Object summary must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "summary"sv, OPENAPI_HASH_SUMMARY,
+      "The Operation Object summary must be a string");
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(*description, base, "description"sv,
-                          "The Operation Object description must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "description"sv, OPENAPI_HASH_DESCRIPTION,
+      "The Operation Object description must be a string");
 
   const auto *external_documentation{
       value.try_at("externalDocs", OPENAPI_HASH_EXTERNAL_DOCS)};
@@ -251,18 +242,13 @@ inline auto openapi_check_path_item(const JSON &value, const Pointer &base,
                              OpenAPIObjectKind::PathItem, walk);
   }
 
-  const auto *summary{value.try_at("summary", OPENAPI_HASH_SUMMARY)};
-  if (summary != nullptr) {
-    openapi_expect_string(*summary, base, "summary"sv,
-                          "The Path Item Object summary must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "summary"sv, OPENAPI_HASH_SUMMARY,
+      "The Path Item Object summary must be a string");
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(*description, base, "description"sv,
-                          "The Path Item Object description must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "description"sv, OPENAPI_HASH_DESCRIPTION,
+      "The Path Item Object description must be a string");
 
   OpenAPIPathItemRecord record;
 

--- a/src/core/openapi/paths.h
+++ b/src/core/openapi/paths.h
@@ -7,11 +7,11 @@
 #include "path_item.h"
 
 #include <sourcemeta/core/text.h>
+#include <sourcemeta/core/uri.h>
 
 #include <cstddef>     // std::size_t
 #include <set>         // std::set
 #include <string_view> // std::string_view
-#include <vector>      // std::vector
 
 namespace sourcemeta::core {
 
@@ -45,48 +45,6 @@ inline auto openapi_path_shape(const JSON::StringView path) -> JSON::String {
 
   result.append(path.substr(cursor));
   return result;
-}
-
-// The template expressions a path declares. OpenAPI Specification 3.1.1,
-// Section 3.5: "Path templating refers to the usage of template expressions,
-// delimited by curly braces (`{}`), to mark a section of a URL path as
-// replaceable using path parameters". Nothing there says what an unbalanced
-// brace means, so a run that never closes is no expression
-inline auto openapi_path_templates(const JSON::StringView path)
-    -> std::vector<JSON::StringView> {
-  std::vector<JSON::StringView> result;
-  std::size_t cursor{0};
-  while (cursor < path.size()) {
-    const auto open{path.find('{', cursor)};
-    if (open == JSON::StringView::npos) {
-      break;
-    }
-
-    const auto close{path.find('}', open)};
-    if (close == JSON::StringView::npos) {
-      break;
-    }
-
-    result.push_back(path.substr(open + 1, close - open - 1));
-    cursor = close + 1;
-  }
-
-  return result;
-}
-
-// The `pchar` a path literal is made of, which OpenAPI Specification 3.2.1,
-// Section 4.8.2 takes from RFC 3986: "unreserved / pct-encoded / sub-delims /
-// `:` / `@`", with `pct-encoded` handled where a run of them is read. The URI
-// parser in this repository classifies the same production for its own use and
-// admits a percent sign as one of these characters, leaving the triplet to the
-// scan around it, so the two sets are deliberately not the same one
-inline auto openapi_is_path_character(const char character) -> bool {
-  return is_alphanum(character) || character == '-' || character == '.' ||
-         character == '_' || character == '~' || character == '!' ||
-         character == '$' || character == '&' || character == '\'' ||
-         character == '(' || character == ')' || character == '*' ||
-         character == '+' || character == ',' || character == ';' ||
-         character == '=' || character == ':' || character == '@';
 }
 
 // OpenAPI Specification 3.2.1, Section 4.8.2 states the grammar 3.1 left
@@ -129,14 +87,15 @@ inline auto openapi_is_path_template(const JSON::StringView path) -> bool {
       segment_is_empty = false;
       cursor = close + 1;
     } else if (path[cursor] == '%') {
-      if (cursor + 2 >= path.size() || !is_hex_digit(path[cursor + 1]) ||
-          !is_hex_digit(path[cursor + 2])) {
+      if (!is_percent_triplet(path, cursor)) {
         return false;
       }
 
       segment_is_empty = false;
       cursor += 3;
-    } else if (openapi_is_path_character(path[cursor])) {
+      // A percent sign is a path character too, and the branch above is what
+      // holds it to introducing a triplet, so nothing reaches here with one
+    } else if (URI::is_pchar(path[cursor])) {
       segment_is_empty = false;
       cursor += 1;
     } else {
@@ -188,7 +147,7 @@ inline auto openapi_check_paths(const JSON &document, OpenAPIWalk &walk)
       }
 
       std::set<JSON::StringView> expressions;
-      for (const auto &expression : openapi_path_templates(entry.first)) {
+      for (const auto &expression : openapi_brace_expressions(entry.first)) {
         if (!expressions.insert(expression).second) {
           throw OpenAPIError{
               location,

--- a/src/core/openapi/reference.h
+++ b/src/core/openapi/reference.h
@@ -5,14 +5,23 @@
 
 #include "helpers.h"
 
+#include <cassert>     // assert
 #include <string_view> // std::string_view
 
 namespace sourcemeta::core {
 
 constexpr auto OPENAPI_HASH_REF{JSON::Object::hash("$ref"sv)};
 
+// A Reference Object stands in for most of the Objects the Components Object
+// holds, and the meta-schema tells the two apart by whether `$ref` is present
+inline auto openapi_is_reference(const JSON &value) -> bool {
+  return value.is_object() && value.try_at("$ref", OPENAPI_HASH_REF) != nullptr;
+}
+
 // OpenAPI Specification 3.1.1, Section 4.8.23: "A simple object to allow
-// referencing other components in the OpenAPI Description"
+// referencing other components in the OpenAPI Description". Only a value the
+// predicate above accepts may be read as one, which is what makes the
+// identifier below something rather than nothing
 inline auto openapi_check_reference(const JSON &value, const Pointer &base,
                                     const OpenAPIObjectKind expected,
                                     OpenAPIWalk &walk) -> void {
@@ -20,24 +29,20 @@ inline auto openapi_check_reference(const JSON &value, const Pointer &base,
   // OpenAPI Specification 3.1.1, Section 4.8.23: "$ref | string | REQUIRED.
   // The reference identifier. This MUST be in the form of a URI"
   const auto *target{value.try_at("$ref", OPENAPI_HASH_REF)};
+  assert(target != nullptr);
   const auto reference{openapi_expect_uri_reference(
       *target, base, "$ref"sv,
       "The Reference Object identifier must be a "
       "string",
       "The Reference Object identifier must be a URI reference")};
 
-  const auto *summary{value.try_at("summary", OPENAPI_HASH_SUMMARY)};
-  if (summary != nullptr) {
-    openapi_expect_string(*summary, base, "summary"sv,
-                          "The Reference Object summary must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "summary"sv, OPENAPI_HASH_SUMMARY,
+      "The Reference Object summary must be a string");
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(*description, base, "description"sv,
-                          "The Reference Object description must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "description"sv, OPENAPI_HASH_DESCRIPTION,
+      "The Reference Object description must be a string");
 
   // OpenAPI Specification 3.1.1, Section 4.8.23: "This object cannot be
   // extended with additional properties, and any properties added SHALL be
@@ -50,10 +55,19 @@ inline auto openapi_check_reference(const JSON &value, const Pointer &base,
                            walk);
 }
 
-// A Reference Object stands in for most of the Objects the Components Object
-// holds, and the meta-schema tells the two apart by whether `$ref` is present
-inline auto openapi_is_reference(const JSON &value) -> bool {
-  return value.is_object() && value.try_at("$ref", OPENAPI_HASH_REF) != nullptr;
+// Most of the Objects this specification defines may stand in for themselves
+// or be written as a Reference Object, and which one a value is comes down to
+// the predicate above. The kind is what the reference is held to, and the
+// check is what the Object itself goes through
+template <OpenAPIObjectKind Kind, auto Check>
+inline auto openapi_check_or_reference(const JSON &value, const Pointer &base,
+                                       OpenAPIWalk &walk) -> void {
+  if (openapi_is_reference(value)) {
+    openapi_check_reference(value, base, Kind, walk);
+    return;
+  }
+
+  Check(value, base, walk);
 }
 
 } // namespace sourcemeta::core

--- a/src/core/openapi/request_body.h
+++ b/src/core/openapi/request_body.h
@@ -26,13 +26,9 @@ inline auto openapi_check_request_body(const JSON &value, const Pointer &base,
       value, OPENAPI_REQUEST_BODY_FIELDS, base,
       "The Request Body Object does not define this field");
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(
-        *description, base, "description"sv,
-        "The Request Body Object description must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "description"sv, OPENAPI_HASH_DESCRIPTION,
+      "The Request Body Object description must be a string");
 
   const auto *required{value.try_at("required", OPENAPI_HASH_REQUIRED)};
   if (required != nullptr) {
@@ -43,12 +39,11 @@ inline auto openapi_check_request_body(const JSON &value, const Pointer &base,
 
   // OpenAPI Specification 3.1.1, Section 4.8.13: "content | Map[string, Media
   // Type Object] | REQUIRED. The content of the request body"
-  const auto *content{value.try_at("content", OPENAPI_HASH_CONTENT)};
-  if (content == nullptr) {
-    throw OpenAPIError{base, "The Request Body Object must declare a content"};
-  }
+  const auto &content{
+      openapi_require(value, "content"sv, OPENAPI_HASH_CONTENT, base,
+                      "The Request Body Object must declare a content")};
 
-  openapi_check_content(*content, openapi_child(base, "content"sv),
+  openapi_check_content(content, openapi_child(base, "content"sv),
                         "The Request Body Object content must be an object",
                         walk);
 }
@@ -56,12 +51,8 @@ inline auto openapi_check_request_body(const JSON &value, const Pointer &base,
 inline auto openapi_check_request_body_or_reference(const JSON &value,
                                                     const Pointer &base,
                                                     OpenAPIWalk &walk) -> void {
-  if (openapi_is_reference(value)) {
-    openapi_check_reference(value, base, OpenAPIObjectKind::RequestBody, walk);
-    return;
-  }
-
-  openapi_check_request_body(value, base, walk);
+  openapi_check_or_reference<OpenAPIObjectKind::RequestBody,
+                             openapi_check_request_body>(value, base, walk);
 }
 
 } // namespace sourcemeta::core

--- a/src/core/openapi/response.h
+++ b/src/core/openapi/response.h
@@ -8,6 +8,8 @@
 #include "link.h"
 #include "reference.h"
 
+#include <sourcemeta/core/http.h>
+
 #include <array>       // std::array
 #include <string_view> // std::string_view
 
@@ -51,22 +53,11 @@ inline auto openapi_check_response(const JSON &value, const Pointer &base,
   }
 
   // OpenAPI Specification 3.2.1, Section 4.17: "summary | string"
-  const auto *summary{value.try_at("summary", OPENAPI_HASH_SUMMARY)};
-  if (summary != nullptr) {
-    openapi_expect_string(*summary, base, "summary"sv,
-                          "The Response Object summary must be a string");
-  }
+  openapi_check_optional_string(value, base, "summary"sv, OPENAPI_HASH_SUMMARY,
+                                "The Response Object summary must be a string");
 
-  const auto *headers{value.try_at("headers", OPENAPI_HASH_HEADERS)};
-  if (headers != nullptr) {
-    const auto location{openapi_child(base, "headers"sv)};
-    openapi_expect_object(*headers, location,
-                          "The Response Object headers must be an object");
-    for (const auto &entry : headers->as_object()) {
-      openapi_check_header_or_reference(
-          entry.second, openapi_child(location, entry.first), walk);
-    }
-  }
+  openapi_check_headers(value, base,
+                        "The Response Object headers must be an object", walk);
 
   const auto *content{value.try_at("content", OPENAPI_HASH_CONTENT)};
   if (content != nullptr) {
@@ -90,12 +81,8 @@ inline auto openapi_check_response(const JSON &value, const Pointer &base,
 inline auto openapi_check_response_or_reference(const JSON &value,
                                                 const Pointer &base,
                                                 OpenAPIWalk &walk) -> void {
-  if (openapi_is_reference(value)) {
-    openapi_check_reference(value, base, OpenAPIObjectKind::Response, walk);
-    return;
-  }
-
-  openapi_check_response(value, base, walk);
+  openapi_check_or_reference<OpenAPIObjectKind::Response,
+                             openapi_check_response>(value, base, walk);
 }
 
 // OpenAPI Specification 3.1.1, Section 4.8.16 keys this map by HTTP status
@@ -103,15 +90,13 @@ inline auto openapi_check_response_or_reference(const JSON &value,
 // `100` through `599`, or a leading digit followed by `XX` for a whole range
 inline auto openapi_is_status_code(const JSON::StringView code) noexcept
     -> bool {
-  if (code.size() != 3 || code.front() < '1' || code.front() > '5') {
-    return false;
-  }
-
-  if (code[1] == 'X' && code[2] == 'X') {
+  // The range form is this specification's own, HTTP knowing nothing of it
+  if (code.size() == 3 && code.front() >= '1' && code.front() <= '5' &&
+      code[1] == 'X' && code[2] == 'X') {
     return true;
   }
 
-  return code[1] >= '0' && code[1] <= '9' && code[2] >= '0' && code[2] <= '9';
+  return http_is_status_code(code);
 }
 
 // OpenAPI Specification 3.1.1, Section 4.8.16: "A container for the expected

--- a/src/core/openapi/security.h
+++ b/src/core/openapi/security.h
@@ -39,8 +39,6 @@ constexpr auto OPENAPI_HASH_DEVICE_URL{
     JSON::Object::hash("deviceAuthorizationUrl"sv)};
 constexpr auto OPENAPI_HASH_OAUTH2_METADATA_URL{
     JSON::Object::hash("oauth2MetadataUrl"sv)};
-constexpr auto OPENAPI_HASH_SCHEME_DEPRECATED{
-    JSON::Object::hash("deprecated"sv)};
 
 constexpr std::array<JSON::StringView, 4>
     OPENAPI_SECURITY_SCHEME_APIKEY_FIELDS_3_1{
@@ -194,13 +192,12 @@ inline auto openapi_check_oauth_flow(const JSON &value, const Pointer &base,
 
   // OpenAPI Specification 3.1.1, Section 4.8.29: "scopes | Map[string, string]
   // | REQUIRED. The available scopes for the OAuth2 security scheme"
-  const auto *scopes{value.try_at("scopes", OPENAPI_HASH_SCOPES)};
-  if (scopes == nullptr) {
-    throw OpenAPIError{base, "The OAuth Flow Object must declare its scopes"};
-  }
+  const auto &scopes{
+      openapi_require(value, "scopes"sv, OPENAPI_HASH_SCOPES, base,
+                      "The OAuth Flow Object must declare its scopes")};
 
   openapi_check_map_of_strings(
-      *scopes, openapi_child(base, "scopes"sv),
+      scopes, openapi_child(base, "scopes"sv),
       "The OAuth Flow Object scopes must be an object",
       "The OAuth Flow Object scopes must hold strings");
 }
@@ -267,34 +264,27 @@ inline auto openapi_check_security_scheme(const JSON &value,
 
   // OpenAPI Specification 3.1.1, Section 4.8.27: "type | string | Any |
   // REQUIRED. The type of the security scheme"
-  const auto *type{value.try_at("type", OPENAPI_HASH_TYPE)};
-  if (type == nullptr) {
-    throw OpenAPIError{base,
-                       "The Security Scheme Object must declare its type"};
-  }
+  const auto &type{
+      openapi_require(value, "type"sv, OPENAPI_HASH_TYPE, base,
+                      "The Security Scheme Object must declare its type")};
 
   const auto scheme_type{openapi_expect_enumeration(
-      *type, base, "type"sv,
+      type, base, "type"sv,
       {"apiKey"sv, "http"sv, "mutualTLS"sv, "oauth2"sv, "openIdConnect"sv},
       "The Security Scheme Object type must be a string",
       "The Security Scheme Object type is not one this specification "
       "defines")};
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(
-        *description, base, "description"sv,
-        "The Security Scheme Object description must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "description"sv, OPENAPI_HASH_DESCRIPTION,
+      "The Security Scheme Object description must be a string");
 
   // OpenAPI Specification 3.2.1, Section 4.27: "deprecated | boolean | Any".
   // Its "Applies To" column names every type, so it is read here rather than
   // under one of them, and each type's field table admits it in turn. Only
   // 3.2 defines the field, so under 3.1 the table below is what has something
   // to say about it rather than its type
-  const auto *deprecated{
-      value.try_at("deprecated", OPENAPI_HASH_SCHEME_DEPRECATED)};
+  const auto *deprecated{value.try_at("deprecated", OPENAPI_HASH_DEPRECATED)};
   if (deprecated != nullptr && walk.version == OpenAPIVersion::OPENAPI_3_2) {
     openapi_expect_boolean(
         *deprecated, base, "deprecated"sv,
@@ -307,23 +297,19 @@ inline auto openapi_check_security_scheme(const JSON &value,
         OPENAPI_SECURITY_SCHEME_APIKEY_FIELDS_3_2, base,
         "The Security Scheme Object does not define this field", walk);
 
-    const auto *name{value.try_at("name", OPENAPI_HASH_NAME)};
-    if (name == nullptr) {
-      throw OpenAPIError{
-          base, "An apiKey Security Scheme Object must declare a name"};
-    }
+    const auto &name{openapi_require(
+        value, "name"sv, OPENAPI_HASH_NAME, base,
+        "An apiKey Security Scheme Object must declare a name")};
 
-    openapi_expect_string(*name, base, "name"sv,
+    openapi_expect_string(name, base, "name"sv,
                           "The Security Scheme Object name must be a string");
 
-    const auto *location{value.try_at("in", OPENAPI_HASH_IN)};
-    if (location == nullptr) {
-      throw OpenAPIError{
-          base, "An apiKey Security Scheme Object must declare a location"};
-    }
+    const auto &location{openapi_require(
+        value, "in"sv, OPENAPI_HASH_IN, base,
+        "An apiKey Security Scheme Object must declare a location")};
 
     openapi_expect_enumeration(
-        *location, base, "in"sv, {"query"sv, "header"sv, "cookie"sv},
+        location, base, "in"sv, {"query"sv, "header"sv, "cookie"sv},
         "The Security Scheme Object location must be a string",
         "The Security Scheme Object location is not one an apiKey admits");
 
@@ -356,13 +342,9 @@ inline auto openapi_check_security_scheme(const JSON &value,
     openapi_expect_string(*scheme, base, "scheme"sv,
                           "The Security Scheme Object scheme must be a string");
 
-    const auto *bearer{
-        value.try_at("bearerFormat", OPENAPI_HASH_BEARER_FORMAT)};
-    if (bearer != nullptr) {
-      openapi_expect_string(
-          *bearer, base, "bearerFormat"sv,
-          "The Security Scheme Object bearer format must be a string");
-    }
+    openapi_check_optional_string(
+        value, base, "bearerFormat"sv, OPENAPI_HASH_BEARER_FORMAT,
+        "The Security Scheme Object bearer format must be a string");
 
     return;
   }
@@ -383,13 +365,11 @@ inline auto openapi_check_security_scheme(const JSON &value,
           "The Security Scheme Object metadata URI must be a URI reference");
     }
 
-    const auto *flows{value.try_at("flows", OPENAPI_HASH_FLOWS)};
-    if (flows == nullptr) {
-      throw OpenAPIError{
-          base, "An oauth2 Security Scheme Object must declare its flows"};
-    }
+    const auto &flows{openapi_require(
+        value, "flows"sv, OPENAPI_HASH_FLOWS, base,
+        "An oauth2 Security Scheme Object must declare its flows")};
 
-    openapi_check_oauth_flows(*flows, openapi_child(base, "flows"sv), walk);
+    openapi_check_oauth_flows(flows, openapi_child(base, "flows"sv), walk);
     return;
   }
 
@@ -399,15 +379,13 @@ inline auto openapi_check_security_scheme(const JSON &value,
         OPENAPI_SECURITY_SCHEME_OIDC_FIELDS_3_2, base,
         "The Security Scheme Object does not define this field", walk);
 
-    const auto *url{
-        value.try_at("openIdConnectUrl", OPENAPI_HASH_OPENID_CONNECT_URL)};
-    if (url == nullptr) {
-      throw OpenAPIError{base, "An openIdConnect Security Scheme Object must "
-                               "declare its discovery URI"};
-    }
+    const auto &url{openapi_require(
+        value, "openIdConnectUrl"sv, OPENAPI_HASH_OPENID_CONNECT_URL, base,
+        "An openIdConnect Security Scheme Object must "
+        "declare its discovery URI")};
 
     openapi_expect_uri_reference(
-        *url, base, "openIdConnectUrl"sv,
+        url, base, "openIdConnectUrl"sv,
         "The Security Scheme Object discovery URI must be a string",
         "The Security Scheme Object discovery URI must be a URI reference");
     return;
@@ -424,13 +402,8 @@ inline auto openapi_check_security_scheme_or_reference(const JSON &value,
                                                        const Pointer &base,
                                                        OpenAPIWalk &walk)
     -> void {
-  if (openapi_is_reference(value)) {
-    openapi_check_reference(value, base, OpenAPIObjectKind::SecurityScheme,
-                            walk);
-    return;
-  }
-
-  openapi_check_security_scheme(value, base, walk);
+  openapi_check_or_reference<OpenAPIObjectKind::SecurityScheme,
+                             openapi_check_security_scheme>(value, base, walk);
 }
 
 // A Security Requirement Object name that no component declares. 3.1 has

--- a/src/core/openapi/server.h
+++ b/src/core/openapi/server.h
@@ -7,6 +7,7 @@
 
 #include <sourcemeta/core/text.h>
 #include <sourcemeta/core/unicode.h>
+#include <sourcemeta/core/uritemplate.h>
 
 #include <algorithm>   // std::ranges::any_of
 #include <array>       // std::array
@@ -78,23 +79,17 @@ inline auto openapi_check_server_variable(const JSON &value,
 
   // OpenAPI Specification 3.1.1, Section 4.8.6: "default | string | REQUIRED.
   // The default value to use for substitution"
-  const auto *fallback{value.try_at("default", OPENAPI_HASH_SERVER_DEFAULT)};
-  if (fallback == nullptr) {
-    throw OpenAPIError{base,
-                       "The Server Variable Object must declare a default"};
-  }
+  const auto &fallback{
+      openapi_require(value, "default"sv, OPENAPI_HASH_SERVER_DEFAULT, base,
+                      "The Server Variable Object must declare a default")};
 
   const auto default_value{openapi_expect_string(
-      *fallback, base, "default"sv,
+      fallback, base, "default"sv,
       "The Server Variable Object default must be a string")};
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(
-        *description, base, "description"sv,
-        "The Server Variable Object description must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "description"sv, OPENAPI_HASH_DESCRIPTION,
+      "The Server Variable Object description must be a string");
 
   // OpenAPI Specification 3.1.1, Section 4.8.6: "If the `enum` is defined, the
   // value MUST exist in the enum's values". The published meta-schema does not
@@ -109,28 +104,6 @@ inline auto openapi_check_server_variable(const JSON &value,
         openapi_child(base, "default"sv),
         "The Server Variable Object default must exist in its enumeration"};
   }
-}
-
-// The `literals` of a server URL template, which OpenAPI Specification 3.2.1,
-// Section 4.6 takes from RFC 6570 "incorporating the corrections specified in
-// Errata 6937":
-//
-//     literals = 1*( %x21 / %x23-24 / %x26-3B / %x3D / %x3F-5B
-//                / %x5D / %x5F / %x61-7A / %x7E / ucschar / iprivate
-//                / pct-encoded)
-//
-// The two productions it names beyond that range are the ones RFC 3987
-// Section 2.2 defines, and a `pct-encoded` triplet is read where a run of them
-// is
-inline auto openapi_is_server_url_literal(const char32_t point) -> bool {
-  if (point < 0x80) {
-    return point == 0x21 || (point >= 0x23 && point <= 0x24) ||
-           (point >= 0x26 && point <= 0x3B) || point == 0x3D ||
-           (point >= 0x3F && point <= 0x5B) || point == 0x5D || point == 0x5F ||
-           (point >= 0x61 && point <= 0x7A) || point == 0x7E;
-  }
-
-  return is_ucschar(point) || is_iprivate(point);
 }
 
 // OpenAPI Specification 3.2.1, Section 4.6 states the grammar 3.1 left
@@ -161,8 +134,7 @@ inline auto openapi_is_server_url_template(const JSON::StringView address)
 
       cursor = close + 1;
     } else if (address[cursor] == '%') {
-      if (cursor + 2 >= address.size() || !is_hex_digit(address[cursor + 1]) ||
-          !is_hex_digit(address[cursor + 2])) {
+      if (!is_percent_triplet(address, cursor)) {
         return false;
       }
 
@@ -170,7 +142,7 @@ inline auto openapi_is_server_url_template(const JSON::StringView address)
     } else {
       const auto character{utf8_decode(address, cursor)};
       if (!character.has_value() ||
-          !openapi_is_server_url_literal(character.value().first)) {
+          !URITemplate::is_literal(character.value().first)) {
         return false;
       }
 
@@ -179,30 +151,6 @@ inline auto openapi_is_server_url_template(const JSON::StringView address)
   }
 
   return true;
-}
-
-// The variables a server URL template names, which are unambiguous once the
-// grammar above has held
-inline auto openapi_server_url_variables(const JSON::StringView address)
-    -> std::vector<JSON::StringView> {
-  std::vector<JSON::StringView> result;
-  std::size_t cursor{0};
-  while (cursor < address.size()) {
-    const auto open{address.find('{', cursor)};
-    if (open == JSON::StringView::npos) {
-      break;
-    }
-
-    const auto close{address.find('}', open)};
-    if (close == JSON::StringView::npos) {
-      break;
-    }
-
-    result.push_back(address.substr(open + 1, close - open - 1));
-    cursor = close + 1;
-  }
-
-  return result;
 }
 
 // OpenAPI Specification 3.1.1, Section 4.8.5: "An object representing a Server"
@@ -221,13 +169,11 @@ inline auto openapi_check_server(const JSON &value, const Pointer &base,
   // URL to the target host. This URL supports Server Variables and MAY be
   // relative". Beyond its type there is little to check, as it is a template
   // rather than a URL once a variable is named in braces
-  const auto *url{value.try_at("url", OPENAPI_HASH_URL)};
-  if (url == nullptr) {
-    throw OpenAPIError{base, "The Server Object must declare a URL"};
-  }
+  const auto &url{openapi_require(value, "url"sv, OPENAPI_HASH_URL, base,
+                                  "The Server Object must declare a URL")};
 
   const auto address{openapi_expect_string(
-      *url, base, "url"sv, "The Server Object URL must be a string")};
+      url, base, "url"sv, "The Server Object URL must be a string")};
 
   // OpenAPI Specification 3.1.2, Section 4.8.5 adds to that row: "Query and
   // fragment MUST NOT be part of this URL". A query begins at the first `?`
@@ -254,7 +200,7 @@ inline auto openapi_check_server(const JSON &value, const Pointer &base,
     }
 
     std::set<JSON::StringView> names;
-    for (const auto &variable : openapi_server_url_variables(address)) {
+    for (const auto &variable : openapi_brace_expressions(address)) {
       if (!names.insert(variable).second) {
         throw OpenAPIError{openapi_child(base, "url"sv),
                            "A server URL template must not repeat a variable"};
@@ -262,19 +208,13 @@ inline auto openapi_check_server(const JSON &value, const Pointer &base,
     }
   }
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(*description, base, "description"sv,
-                          "The Server Object description must be a string");
-  }
+  openapi_check_optional_string(
+      value, base, "description"sv, OPENAPI_HASH_DESCRIPTION,
+      "The Server Object description must be a string");
 
   // OpenAPI Specification 3.2.1, Section 4.5: "name | string"
-  const auto *name{value.try_at("name", OPENAPI_HASH_NAME)};
-  if (name != nullptr) {
-    openapi_expect_string(*name, base, "name"sv,
-                          "The Server Object name must be a string");
-  }
+  openapi_check_optional_string(value, base, "name"sv, OPENAPI_HASH_NAME,
+                                "The Server Object name must be a string");
 
   // OpenAPI Specification 3.1.1, Section 4.8.5: "variables | Map[string,
   // Server Variable Object] | A map between a variable name and its value"

--- a/src/core/openapi/tag.h
+++ b/src/core/openapi/tag.h
@@ -41,39 +41,28 @@ inline auto openapi_check_tag(const JSON &value, const Pointer &base,
 
   // OpenAPI Specification 3.1.1, Section 4.8.22: "name | string | REQUIRED.
   // The name of the tag"
-  const auto *name{value.try_at("name", OPENAPI_HASH_NAME)};
-  if (name == nullptr) {
-    throw OpenAPIError{base, "The Tag Object must declare a name"};
-  }
+  const auto &name{openapi_require(value, "name"sv, OPENAPI_HASH_NAME, base,
+                                   "The Tag Object must declare a name")};
 
   const auto result{openapi_expect_string(
-      *name, base, "name"sv, "The Tag Object name must be a string")};
+      name, base, "name"sv, "The Tag Object name must be a string")};
 
   // A parent names a tag that "MUST exist in the API description", which
   // spans every document rather than the entry one alone, so what a Tag
   // Object is called is written down wherever it sits
   walk.tag_names.emplace(result);
 
-  const auto *description{
-      value.try_at("description", OPENAPI_HASH_DESCRIPTION)};
-  if (description != nullptr) {
-    openapi_expect_string(*description, base, "description"sv,
-                          "The Tag Object description must be a string");
-  }
+  openapi_check_optional_string(value, base, "description"sv,
+                                OPENAPI_HASH_DESCRIPTION,
+                                "The Tag Object description must be a string");
 
   // OpenAPI Specification 3.2.1, Section 4.22: "summary | string" and
   // "kind | string"
-  const auto *summary{value.try_at("summary", OPENAPI_HASH_SUMMARY)};
-  if (summary != nullptr) {
-    openapi_expect_string(*summary, base, "summary"sv,
-                          "The Tag Object summary must be a string");
-  }
+  openapi_check_optional_string(value, base, "summary"sv, OPENAPI_HASH_SUMMARY,
+                                "The Tag Object summary must be a string");
 
-  const auto *kind{value.try_at("kind", OPENAPI_HASH_KIND)};
-  if (kind != nullptr) {
-    openapi_expect_string(*kind, base, "kind"sv,
-                          "The Tag Object kind must be a string");
-  }
+  openapi_check_optional_string(value, base, "kind"sv, OPENAPI_HASH_KIND,
+                                "The Tag Object kind must be a string");
 
   // Section 4.22: "parent | string | The `name` of a tag that this tag is
   // nested under. The named tag MUST exist in the API description, and

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -1207,6 +1207,21 @@ public:
   /// ```
   [[nodiscard]] static auto is_gen_delim(char character) noexcept -> bool;
 
+  /// Check if the given character is a URI path character per RFC 3986
+  /// (`unreserved / pct-encoded / sub-delims / ":" / "@"`). A percent sign
+  /// answers true, as it is what a percent-encoded triplet begins with, and
+  /// whether one follows is for the scan around this to say. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  ///
+  /// assert(sourcemeta::core::URI::is_pchar('a'));
+  /// assert(sourcemeta::core::URI::is_pchar('@'));
+  /// assert(!sourcemeta::core::URI::is_pchar('/'));
+  /// ```
+  [[nodiscard]] static auto is_pchar(char character) noexcept -> bool;
+
   /// Check if the given string is a valid absolute URI (has a scheme) per
   /// RFC 3986 without constructing a full URI object. For example:
   ///

--- a/src/core/uri/parse.cc
+++ b/src/core/uri/parse.cc
@@ -659,6 +659,10 @@ auto URI::is_gen_delim(const char character) noexcept -> bool {
   return uri_is_gen_delim(character);
 }
 
+auto URI::is_pchar(const char character) noexcept -> bool {
+  return uri_is_pchar(character);
+}
+
 auto URI::is_uri(const std::string_view input) noexcept -> bool {
   try {
     std::optional<std::string> scheme;

--- a/src/core/uritemplate/CMakeLists.txt
+++ b/src/core/uritemplate/CMakeLists.txt
@@ -9,3 +9,5 @@ endif()
 target_link_libraries(sourcemeta_core_uritemplate PUBLIC sourcemeta::core::io)
 target_link_libraries(sourcemeta_core_uritemplate PRIVATE sourcemeta::core::regex)
 target_link_libraries(sourcemeta_core_uritemplate PRIVATE sourcemeta::core::text)
+target_link_libraries(sourcemeta_core_uritemplate PRIVATE
+  sourcemeta::core::unicode)

--- a/src/core/uritemplate/helpers.h
+++ b/src/core/uritemplate/helpers.h
@@ -2,6 +2,7 @@
 #define SOURCEMETA_CORE_URITEMPLATE_HELPERS_H_
 
 #include <sourcemeta/core/text.h>
+#include <sourcemeta/core/unicode.h>
 #include <sourcemeta/core/uritemplate.h>
 
 #include <algorithm>   // std::min
@@ -158,14 +159,21 @@ inline auto append_name(std::string &result, const std::string_view name,
   }
 }
 
-// RFC 6570 Section 2.1: a literal character outside the pct-encoded form. The
-// apostrophe is also accepted because the specification's own normative
-// examples rely on it as a literal
-inline auto is_literal_char(const char character) noexcept -> bool {
-  const auto byte = static_cast<unsigned char>(character);
-  if (byte >= 0x80) {
-    return true;
+// RFC 6570 Section 2.1, incorporating the corrections of Errata 6937:
+//
+//     literals = 1*( %x21 / %x23-24 / %x26-3B / %x3D / %x3F-5B / %x5D / %x5F
+//                / %x61-7A / %x7E / ucschar / iprivate / pct-encoded)
+//
+// The apostrophe falls in the second of those ranges, which is why the
+// specification's own normative examples may rely on it. The two productions
+// beyond the ASCII range are the ones RFC 3987 Section 2.2 defines, so a code
+// point outside them is no literal however it was encoded
+inline auto is_literal_codepoint(const char32_t point) noexcept -> bool {
+  if (point >= 0x80) {
+    return is_ucschar(point) || is_iprivate(point);
   }
+
+  const auto byte = static_cast<unsigned char>(point);
 
   switch (byte) {
     case 0x21:
@@ -353,9 +361,7 @@ auto parse_expression(const std::string_view input)
 
       // See https://www.rfc-editor.org/rfc/rfc6570#section-2.1
       if (character == '%') {
-        if (position + 2 >= input.size() ||
-            !is_hex_digit(input[position + 1]) ||
-            !is_hex_digit(input[position + 2])) {
+        if (!is_percent_triplet(input, position)) {
           throw URITemplateParseError(position + 1);
         }
 
@@ -363,11 +369,15 @@ auto parse_expression(const std::string_view input)
         continue;
       }
 
-      if (!is_literal_char(character)) {
+      // The production is defined over characters rather than over bytes, so
+      // what stands here is read as one before it is held to it
+      const auto codepoint{sourcemeta::core::utf8_decode(input, position)};
+      if (!codepoint.has_value() ||
+          !is_literal_codepoint(codepoint.value().first)) {
         throw URITemplateParseError(position + 1);
       }
 
-      position++;
+      position += codepoint.value().second;
     }
 
     if constexpr (CheckOnly) {

--- a/src/core/uritemplate/include/sourcemeta/core/uritemplate.h
+++ b/src/core/uritemplate/include/sourcemeta/core/uritemplate.h
@@ -89,6 +89,22 @@ public:
   [[nodiscard]] static auto is_uritemplate(std::string_view input) noexcept
       -> bool;
 
+  /// Check whether a code point may stand literally in a template, which
+  /// RFC 6570 Section 2.1 writes as `literals`, incorporating the corrections
+  /// of Errata 6937. A percent sign is not one of these, as a percent-encoded
+  /// triplet is a production of its own. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uritemplate.h>
+  ///
+  /// #include <cassert>
+  ///
+  /// assert(sourcemeta::core::URITemplate::is_literal(U'a'));
+  /// assert(!sourcemeta::core::URITemplate::is_literal(U'%'));
+  /// assert(!sourcemeta::core::URITemplate::is_literal(U'{'));
+  /// ```
+  [[nodiscard]] static auto is_literal(char32_t codepoint) noexcept -> bool;
+
   /// Get the number of tokens in the template
   [[nodiscard]] auto size() const noexcept -> std::uint64_t;
 

--- a/src/core/uritemplate/uritemplate.cc
+++ b/src/core/uritemplate/uritemplate.cc
@@ -55,6 +55,10 @@ URITemplate::URITemplate(const std::string_view source) {
   }
 }
 
+auto URITemplate::is_literal(const char32_t codepoint) noexcept -> bool {
+  return is_literal_codepoint(codepoint);
+}
+
 auto URITemplate::is_uritemplate(const std::string_view input) noexcept
     -> bool {
   try {

--- a/src/lang/text/include/sourcemeta/core/text.h
+++ b/src/lang/text/include/sourcemeta/core/text.h
@@ -800,8 +800,9 @@ inline auto is_hex_digit(const char character) noexcept -> bool {
 /// ```
 inline auto is_percent_triplet(const std::string_view input,
                                const std::size_t position) noexcept -> bool {
-  return position + 2 < input.size() && input[position] == '%' &&
-         is_hex_digit(input[position + 1]) && is_hex_digit(input[position + 2]);
+  return input.size() >= 3 && position < input.size() - 2 &&
+         input[position] == '%' && is_hex_digit(input[position + 1]) &&
+         is_hex_digit(input[position + 2]);
 }
 
 /// @ingroup text

--- a/src/lang/text/include/sourcemeta/core/text.h
+++ b/src/lang/text/include/sourcemeta/core/text.h
@@ -787,6 +787,25 @@ inline auto is_hex_digit(const char character) noexcept -> bool {
 
 /// @ingroup text
 ///
+/// Check whether a percent-encoded triplet begins at the given position, which
+/// RFC 3986 Section 2.1 writes as `pct-encoded = "%" HEXDIG HEXDIG`. A
+/// position at or past the end of the input begins nothing. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/text.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::is_percent_triplet("a%20b", 1));
+/// assert(!sourcemeta::core::is_percent_triplet("a%2", 1));
+/// ```
+inline auto is_percent_triplet(const std::string_view input,
+                               const std::size_t position) noexcept -> bool {
+  return position + 2 < input.size() && input[position] == '%' &&
+         is_hex_digit(input[position + 1]) && is_hex_digit(input[position + 2]);
+}
+
+/// @ingroup text
+///
 /// Decode a hexadecimal string into its raw bytes, returning no value when
 /// the input contains a character outside the hexadecimal alphabet, or has an
 /// odd length unless `allow_odd_length` is set, in which case a leading zero

--- a/test/http/CMakeLists.txt
+++ b/test/http/CMakeLists.txt
@@ -8,6 +8,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME http
           http_serialize_cache_control_test.cc
           http_accept_includes_all_test.cc http_content_type_matches_test.cc
           http_method_test.cc http_status_from_code_test.cc
+          http_is_status_code_test.cc
           http_is_status_line_test.cc http_accumulate_header_line_test.cc
           http_parse_headers_test.cc http_serialize_headers_test.cc
           http_header_find_test.cc http_error_test.cc

--- a/test/http/http_is_status_code_test.cc
+++ b/test/http/http_is_status_code_test.cc
@@ -1,7 +1,7 @@
 #include <sourcemeta/core/http.h>
 #include <sourcemeta/core/test.h>
 
-TEST(the_lowest_and_highest_registered_classes) {
+TEST(the_lowest_and_highest_codes_the_form_admits) {
   EXPECT_TRUE(sourcemeta::core::http_is_status_code("100"));
   EXPECT_TRUE(sourcemeta::core::http_is_status_code("599"));
 }

--- a/test/http/http_is_status_code_test.cc
+++ b/test/http/http_is_status_code_test.cc
@@ -1,0 +1,53 @@
+#include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
+
+TEST(the_lowest_and_highest_registered_classes) {
+  EXPECT_TRUE(sourcemeta::core::http_is_status_code("100"));
+  EXPECT_TRUE(sourcemeta::core::http_is_status_code("599"));
+}
+
+TEST(a_code_the_registry_does_not_name) {
+  EXPECT_TRUE(sourcemeta::core::http_is_status_code("299"));
+  EXPECT_TRUE(sourcemeta::core::http_status_from_code(299).phrase.empty());
+}
+
+TEST(one_of_each_class) {
+  EXPECT_TRUE(sourcemeta::core::http_is_status_code("100"));
+  EXPECT_TRUE(sourcemeta::core::http_is_status_code("200"));
+  EXPECT_TRUE(sourcemeta::core::http_is_status_code("301"));
+  EXPECT_TRUE(sourcemeta::core::http_is_status_code("404"));
+  EXPECT_TRUE(sourcemeta::core::http_is_status_code("500"));
+}
+
+TEST(the_class_below_the_first) {
+  EXPECT_FALSE(sourcemeta::core::http_is_status_code("099"));
+}
+
+TEST(the_class_above_the_last) {
+  EXPECT_FALSE(sourcemeta::core::http_is_status_code("600"));
+  EXPECT_FALSE(sourcemeta::core::http_is_status_code("999"));
+}
+
+TEST(too_few_digits) {
+  EXPECT_FALSE(sourcemeta::core::http_is_status_code("20"));
+}
+
+TEST(too_many_digits) {
+  EXPECT_FALSE(sourcemeta::core::http_is_status_code("2000"));
+}
+
+TEST(empty_input) { EXPECT_FALSE(sourcemeta::core::http_is_status_code("")); }
+
+TEST(a_range_is_not_a_code) {
+  EXPECT_FALSE(sourcemeta::core::http_is_status_code("2XX"));
+}
+
+TEST(letters_where_digits_belong) {
+  EXPECT_FALSE(sourcemeta::core::http_is_status_code("2a0"));
+  EXPECT_FALSE(sourcemeta::core::http_is_status_code("20a"));
+}
+
+TEST(a_sign_is_not_a_digit) {
+  EXPECT_FALSE(sourcemeta::core::http_is_status_code("+20"));
+  EXPECT_FALSE(sourcemeta::core::http_is_status_code("2 0"));
+}

--- a/test/text/CMakeLists.txt
+++ b/test/text/CMakeLists.txt
@@ -14,6 +14,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME text
           text_split_test.cc text_join_to_test.cc
           text_hex_to_bytes_test.cc text_bytes_to_hex_test.cc
           text_is_hex_digit_test.cc text_hex_digit_value_test.cc
+          text_is_percent_triplet_test.cc
           text_strip_left_test.cc text_strip_right_test.cc
           text_pad_left_test.cc text_squeeze_test.cc
           text_digits_test.cc)

--- a/test/text/text_is_percent_triplet_test.cc
+++ b/test/text/text_is_percent_triplet_test.cc
@@ -1,6 +1,9 @@
 #include <sourcemeta/core/test.h>
 #include <sourcemeta/core/text.h>
 
+#include <cstddef> // std::size_t
+#include <limits>  // std::numeric_limits
+
 TEST(at_the_start) {
   EXPECT_TRUE(sourcemeta::core::is_percent_triplet("%20", 0));
 }
@@ -50,3 +53,8 @@ TEST(position_past_the_end) {
 }
 
 TEST(empty_input) { EXPECT_FALSE(sourcemeta::core::is_percent_triplet("", 0)); }
+
+TEST(the_largest_position_the_type_can_hold) {
+  EXPECT_FALSE(sourcemeta::core::is_percent_triplet(
+      "%20", std::numeric_limits<std::size_t>::max()));
+}

--- a/test/text/text_is_percent_triplet_test.cc
+++ b/test/text/text_is_percent_triplet_test.cc
@@ -1,0 +1,52 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/text.h>
+
+TEST(at_the_start) {
+  EXPECT_TRUE(sourcemeta::core::is_percent_triplet("%20", 0));
+}
+
+TEST(within_a_string) {
+  EXPECT_TRUE(sourcemeta::core::is_percent_triplet("a%20b", 1));
+}
+
+TEST(uppercase_digits) {
+  EXPECT_TRUE(sourcemeta::core::is_percent_triplet("%2F", 0));
+}
+
+TEST(lowercase_digits) {
+  EXPECT_TRUE(sourcemeta::core::is_percent_triplet("%2f", 0));
+}
+
+TEST(letter_digits) {
+  EXPECT_TRUE(sourcemeta::core::is_percent_triplet("%ab", 0));
+}
+
+TEST(not_a_percent_sign) {
+  EXPECT_FALSE(sourcemeta::core::is_percent_triplet("a20", 0));
+}
+
+TEST(one_digit_short) {
+  EXPECT_FALSE(sourcemeta::core::is_percent_triplet("%2", 0));
+}
+
+TEST(nothing_after_the_percent_sign) {
+  EXPECT_FALSE(sourcemeta::core::is_percent_triplet("%", 0));
+}
+
+TEST(first_digit_is_not_hexadecimal) {
+  EXPECT_FALSE(sourcemeta::core::is_percent_triplet("%g0", 0));
+}
+
+TEST(second_digit_is_not_hexadecimal) {
+  EXPECT_FALSE(sourcemeta::core::is_percent_triplet("%0g", 0));
+}
+
+TEST(truncated_at_the_end_of_the_input) {
+  EXPECT_FALSE(sourcemeta::core::is_percent_triplet("a%2", 1));
+}
+
+TEST(position_past_the_end) {
+  EXPECT_FALSE(sourcemeta::core::is_percent_triplet("%20", 3));
+}
+
+TEST(empty_input) { EXPECT_FALSE(sourcemeta::core::is_percent_triplet("", 0)); }

--- a/test/uri/CMakeLists.txt
+++ b/test/uri/CMakeLists.txt
@@ -14,6 +14,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME uri
     uri_is_scheme_test.cc
     uri_is_absolute_path_reference_test.cc
     uri_is_gen_delim_test.cc
+    uri_is_pchar_test.cc
     uri_query_test.cc
     uri_is_absolute_test.cc
     uri_is_relative_test.cc

--- a/test/uri/uri_is_pchar_test.cc
+++ b/test/uri/uri_is_pchar_test.cc
@@ -1,0 +1,59 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uri.h>
+
+TEST(unreserved_letters) {
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('a'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('Z'));
+}
+
+TEST(unreserved_digits) {
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('0'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('9'));
+}
+
+TEST(unreserved_marks) {
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('-'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('.'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('_'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('~'));
+}
+
+TEST(all_sub_delimiters) {
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('!'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('$'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('&'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('\''));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('('));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar(')'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('*'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('+'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar(','));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar(';'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('='));
+}
+
+TEST(the_two_extra_characters) {
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar(':'));
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('@'));
+}
+
+TEST(a_percent_sign_begins_a_triplet) {
+  EXPECT_TRUE(sourcemeta::core::URI::is_pchar('%'));
+}
+
+TEST(generic_delimiters_that_are_not_path_characters) {
+  EXPECT_FALSE(sourcemeta::core::URI::is_pchar('/'));
+  EXPECT_FALSE(sourcemeta::core::URI::is_pchar('?'));
+  EXPECT_FALSE(sourcemeta::core::URI::is_pchar('#'));
+  EXPECT_FALSE(sourcemeta::core::URI::is_pchar('['));
+  EXPECT_FALSE(sourcemeta::core::URI::is_pchar(']'));
+}
+
+TEST(a_space_is_not_a_path_character) {
+  EXPECT_FALSE(sourcemeta::core::URI::is_pchar(' '));
+}
+
+TEST(a_brace_is_not_a_path_character) {
+  EXPECT_FALSE(sourcemeta::core::URI::is_pchar('{'));
+  EXPECT_FALSE(sourcemeta::core::URI::is_pchar('}'));
+}

--- a/test/uritemplate/CMakeLists.txt
+++ b/test/uritemplate/CMakeLists.txt
@@ -2,6 +2,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME uritemplate
   SOURCES
     uritemplate_helpers.h
     uritemplate_test.cc
+    uritemplate_is_literal_test.cc
     uritemplate_parse_test.cc
     uritemplate_parse_error_test.cc
     uritemplate_expand_uri_test.cc

--- a/test/uritemplate/uritemplate_is_literal_test.cc
+++ b/test/uritemplate/uritemplate_is_literal_test.cc
@@ -46,12 +46,12 @@ TEST(control_characters_are_not_literals) {
 }
 
 TEST(a_character_the_other_productions_admit) {
-  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'é'));
-  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'中'));
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'\U000000E9'));
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'\U00004E2D'));
 }
 
 TEST(a_private_use_character) {
-  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U''));
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'\U0000E000'));
 }
 
 TEST(the_boundaries_of_the_first_of_those_productions) {

--- a/test/uritemplate/uritemplate_is_literal_test.cc
+++ b/test/uritemplate/uritemplate_is_literal_test.cc
@@ -1,0 +1,65 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uritemplate.h>
+
+TEST(letters_and_digits) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'a'));
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'Z'));
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'0'));
+}
+
+TEST(the_named_single_characters) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'!'));
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'='));
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U']'));
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'_'));
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'~'));
+}
+
+TEST(the_apostrophe_the_errata_restores) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'\''));
+}
+
+TEST(the_expression_delimiters_are_not_literals) {
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'{'));
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'}'));
+}
+
+TEST(a_percent_sign_begins_a_production_of_its_own) {
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'%'));
+}
+
+TEST(characters_the_grammar_leaves_out) {
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U' '));
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'"'));
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'<'));
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'>'));
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'\\'));
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'^'));
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'`'));
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'|'));
+}
+
+TEST(control_characters_are_not_literals) {
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'\0'));
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'\n'));
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'\x7F'));
+}
+
+TEST(a_character_the_other_productions_admit) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'é'));
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'中'));
+}
+
+TEST(a_private_use_character) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U''));
+}
+
+TEST(the_boundaries_of_the_first_of_those_productions) {
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'\x9F'));
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_literal(U'\xA0'));
+}
+
+TEST(characters_beyond_those_two_productions) {
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'\xFFFF'));
+  EXPECT_FALSE(sourcemeta::core::URITemplate::is_literal(U'\xFFF0'));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

